### PR TITLE
fix: replace typedef int bool with stdbool.h for GCC 15 / C23 compatibility

### DIFF
--- a/src/hostfs.c
+++ b/src/hostfs.c
@@ -51,10 +51,7 @@
 # define mkdir(name, mode) _mkdir(name)
 #endif
 
-typedef int bool;
-
-#define true  ((bool) 1)
-#define false ((bool) 0)
+#include <stdbool.h>
 
 /** Registration states of HostFS module with backend code */
 typedef enum {


### PR DESCRIPTION
## Summary

Fixes #3 — GCC 15 defaults to `-std=gnu23` (C23 mode) where `bool` is a keyword and cannot be redefined via `typedef`.

## Changes

- `src/hostfs.c`: Replace `typedef int bool` + manual `#define true/false` with the standard `#include <stdbool.h>`

## Verification

```bash
gcc -std=gnu2x -fsyntax-only -c src/hostfs.c -I src/
# No errors — compiles clean
```

Before the fix, the same command produces:
```
error: two or more data types in declaration specifiers
```

## Notes

- `<stdbool.h>` has been part of the C standard since C99 — no compatibility risk with older compilers.
- No other files in the repo have `typedef.*bool` patterns (verified via grep).