### PR TITLE
Improve quitting on error

### DIFF
--- a/src/arm_dynarec.c
+++ b/src/arm_dynarec.c
@@ -24,6 +24,7 @@ int blockend;
 /* FPA10 floating-point coprocessor emulation (see fpa.c). */
 #define FPA
 
+#include <errno.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
@@ -585,7 +586,7 @@ set_memory_executable(void *ptr, size_t len)
 
 	if (mprotect(start, len, PROT_READ | PROT_WRITE | PROT_EXEC) != 0) {
 		perror("mprotect");
-		exit(1);
+		fatal("mprotect failed making code cache executable: %s", strerror(errno));
 	}
 }
 #elif defined _WIN32

--- a/src/cmos.c
+++ b/src/cmos.c
@@ -701,7 +701,7 @@ cmosi2cchange(int scl, int sda)
 			if (slave == NULL) {
 				fprintf(stderr, "I2C-SerDes Bug: no slave in I2C-read\n");
 				rpclog("I2C-SerDes Bug: no slave in I2C-read\n");
-				exit(5324);
+				fatal("I2C-SerDes: no active slave in I2C read");
 			}
 			if (sda) {
 				/* Last was not acknowledged, so read nothing */
@@ -798,7 +798,7 @@ cmosi2cchange(int scl, int sda)
 				if (slave == NULL) {
 					fprintf(stderr, "I2C-SerDes Emulator Bug: no slave in write\n");
 					rpclog("I2C-SerDes Emulator Bug: no slave in write\n");
-					exit(3245);
+					fatal("I2C-SerDes: no active slave in I2C write");
 				}
 				result = slave->devops->write(slave->dev, serdes->inbuf);
 				serdes->slave_was_accessed = 1;

--- a/src/cp15.c
+++ b/src/cp15.c
@@ -362,7 +362,7 @@ cp15_write(uint32_t opcode, uint32_t val)
 		default:
 			fprintf(stderr, "cp15_write(): unknown CPU model %d\n",
 				cp15.cpu_model);
-			exit(EXIT_FAILURE);
+			fatal("cp15_write(): unknown CPU model %d", cp15.cpu_model);
 		}
 		break;
 

--- a/src/gui/emulator_host.cpp
+++ b/src/gui/emulator_host.cpp
@@ -73,6 +73,18 @@ Config *pconfig_copy = nullptr;
 static GuiBridge *g_gui_bridge = nullptr;
 static EmulatorHost *g_emulator_host = nullptr;
 
+/* Set as soon as any fatal() is raised, on whatever thread. The raising thread
+   then spins forever inside fatal(), so it can never again service commands or
+   signal a condition variable. GUI-thread waits and joins check this flag so
+   they can never deadlock on that spinning thread; the process is terminated
+   cleanly by ShowFatal() (or OnClose) reaching std::_Exit. */
+static std::atomic<bool> g_fatal_occurred{false};
+
+bool EmulatorFatalOccurred()
+{
+	return g_fatal_occurred.load();
+}
+
 static pthread_t sound_thread;
 static pthread_cond_t sound_cond = PTHREAD_COND_INITIALIZER;
 static pthread_mutex_t sound_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -346,6 +358,16 @@ extern "C" void fatal(const char *format, ...)
 	rpclog("FATAL: %s\n", buf);
 	fprintf(stderr, "RPCEmu fatal error: %s\n", buf);
 
+	/* Record the fatal before anything else so any GUI-thread wait/join can
+	   observe it and stop blocking on this (about to spin) thread. A cv.wait
+	   only re-evaluates its predicate when notified, so also wake every request
+	   condition variable — otherwise a GUI thread already parked in one of them
+	   would sleep forever, since this thread is about to stop signalling. */
+	g_fatal_occurred.store(true);
+	if (g_emulator_host != nullptr) {
+		g_emulator_host->WakeAllWaiters();
+	}
+
 	if (g_gui_bridge == nullptr) {
 		exit(EXIT_FAILURE);
 	}
@@ -405,9 +427,27 @@ void EmulatorHost::Stop()
 
 void EmulatorHost::Join()
 {
+	if (g_fatal_occurred.load()) {
+		/* The emulator thread is spinning forever inside fatal() and will
+		   never return; joining it would deadlock. The process is terminated
+		   via ShowFatal()/OnClose reaching std::_Exit instead. */
+		return;
+	}
 	if (emu_thread_.joinable()) {
 		emu_thread_.join();
 	}
+}
+
+void EmulatorHost::WakeAllWaiters()
+{
+	/* Notify without holding the per-request mutexes: the predicates already
+	   test g_fatal_occurred (set before this is called), so a waiter that wakes
+	   spuriously here still sees the fatal and returns. */
+	trace_cv_.notify_all();
+	snapshot_cv_.notify_all();
+	state_cv_.notify_all();
+	memory_cv_.notify_all();
+	disasm_cv_.notify_all();
 }
 
 void EmulatorHost::PostCommand(EmuCommand command)
@@ -1063,7 +1103,7 @@ std::vector<DebugTraceEvent> EmulatorHost::DrainTraceEvents(uint32_t max, uint32
 	cmd.debug_count = max;
 	PostCommand(cmd);
 
-	trace_cv_.wait(lock, [this]() { return trace_ready_; });
+	trace_cv_.wait(lock, [this]() { return trace_ready_ || g_fatal_occurred.load(); });
 
 	if (dropped_out != nullptr) {
 		*dropped_out = trace_dropped_;
@@ -1078,7 +1118,7 @@ MachineSnapshot EmulatorHost::TakeSnapshot()
 
 	PostCommand(MakeCommand(EmuCommandType::TakeSnapshot));
 
-	snapshot_cv_.wait(lock, [this]() { return snapshot_ready_; });
+	snapshot_cv_.wait(lock, [this]() { return snapshot_ready_ || g_fatal_occurred.load(); });
 	return snapshot_result_;
 }
 
@@ -1091,7 +1131,7 @@ bool EmulatorHost::SaveState(const std::string &path)
 	command.string_path = path;
 	PostCommand(command);
 
-	state_cv_.wait(lock, [this]() { return state_ready_; });
+	state_cv_.wait(lock, [this]() { return state_ready_ || g_fatal_occurred.load(); });
 	return state_ok_;
 }
 
@@ -1104,7 +1144,7 @@ bool EmulatorHost::LoadState(const std::string &path, std::string *error_out)
 	command.string_path = path;
 	PostCommand(command);
 
-	state_cv_.wait(lock, [this]() { return state_ready_; });
+	state_cv_.wait(lock, [this]() { return state_ready_ || g_fatal_occurred.load(); });
 	if (error_out != nullptr) {
 		*error_out = state_error_;
 	}
@@ -1132,7 +1172,7 @@ size_t EmulatorHost::ReadMemory(uint32_t address, uint32_t length, uint8_t *buff
 	cmd.debug_count = length;
 	PostCommand(cmd);
 
-	memory_cv_.wait(lock, [this]() { return memory_ready_; });
+	memory_cv_.wait(lock, [this]() { return memory_ready_ || g_fatal_occurred.load(); });
 
 	const size_t to_copy = std::min(static_cast<size_t>(length), memory_result_.size());
 	if (to_copy > 0) {
@@ -1152,7 +1192,7 @@ std::string EmulatorHost::DisassembleAt(uint32_t address, int count)
 	cmd.arg1 = count;
 	PostCommand(cmd);
 
-	disasm_cv_.wait(lock, [this]() { return disasm_ready_; });
+	disasm_cv_.wait(lock, [this]() { return disasm_ready_ || g_fatal_occurred.load(); });
 	return disasm_result_;
 }
 

--- a/src/gui/emulator_host.h
+++ b/src/gui/emulator_host.h
@@ -109,6 +109,11 @@ struct EmuCommand {
 	DebugTraceConfig debug_trace_config{};
 };
 
+/* True once any fatal() has been raised (on any thread). The raising thread
+   then spins forever inside fatal(), so GUI-thread teardown must not try to
+   join it or wait on a condition variable it can no longer signal. */
+bool EmulatorFatalOccurred();
+
 class EmulatorHost {
 public:
 	explicit EmulatorHost(GuiBridge *gui_bridge);
@@ -117,6 +122,11 @@ public:
 	void Start();
 	void Stop();
 	void Join();
+
+	/* Notify every request condition variable so any GUI-thread wait wakes and
+	   re-evaluates its predicate. Called from fatal() when the emulator thread
+	   is about to spin forever and can no longer signal completion itself. */
+	void WakeAllWaiters();
 
 	bool IsRunning() const { return emu_thread_.joinable(); }
 

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -1321,6 +1321,16 @@ void MainFrame::OnClose(wxCloseEvent &event)
 		return;
 	}
 
+	// If a fatal error has been raised, the emulator thread is spinning forever
+	// inside fatal() and can never be joined or asked to save state. ShowFatal()
+	// normally terminates the process directly, but guard here too: run no
+	// teardown (destructors would try to join the spinning thread and hang) and
+	// exit immediately.
+	if (EmulatorFatalOccurred()) {
+		fflush(nullptr);
+		std::_Exit(EXIT_FAILURE);
+	}
+
 	// Store the machine state on exit so the next launch can Resume it (the
 	// machine selector offers it). This must run while the emulator thread is
 	// still alive, before ShutdownEmulator() stops it.

--- a/src/hostfs.c
+++ b/src/hostfs.c
@@ -253,7 +253,7 @@ hostfs_ensure_buffer_size(size_t buffer_size_needed)
     if (!buffer) {
       fprintf(stderr, "HostFS could not increase buffer size to %lu bytes\n",
               (unsigned long) buffer_size_needed);
-      exit(EXIT_FAILURE);
+      fatal("HostFS: out of memory growing buffer to %lu bytes", (unsigned long) buffer_size_needed);
     }
     buffer_size = buffer_size_needed;
   }
@@ -971,7 +971,7 @@ hostfs_open(ARMul_State *state)
     /* No more space in the open_file[] array.
        This should never occur, because RISC OS is constraining the max
        number of open files */
-    abort();
+    fatal("HostFS: no free slot in open_file[] (RISC OS open-file limit exceeded)");
   }
 
 
@@ -1001,7 +1001,7 @@ hostfs_open(ARMul_State *state)
     case ENOMEM: /* Out of memory */
       fprintf(stderr, "HostFS out of memory in hostfs_open(): \'%s\'\n",
               strerror(errno));
-      exit(EXIT_FAILURE);
+      fatal("HostFS: out of memory in hostfs_open(): %s", strerror(errno));
       break;
 
     case ENOENT: /* File not found */
@@ -1470,7 +1470,7 @@ hostfs_file_1_write_cat_info(ARMul_State *state)
     break;
 
   default:
-    abort();
+    fatal("HostFS: unexpected object type in hostfs_read_file()");
   }
 }
 
@@ -1560,7 +1560,7 @@ hostfs_file_6_delete(ARMul_State *state)
     break;
 
   default:
-    abort();
+    fatal("HostFS: unexpected object type in hostfs_write_file()");
   }
 }
 
@@ -1909,7 +1909,7 @@ hostfs_cache_dir(const char *directory_name)
   }
   if ((!cache_entries) || (!cache_names)) {
     fprintf(stderr, "hostfs_cache_dir(): Out of memory\n");
-    exit(1);
+    fatal("hostfs_cache_dir(): out of memory");
   }
 
   /* Read each of the directory entries one at a time.
@@ -1950,7 +1950,7 @@ hostfs_cache_dir(const char *directory_name)
       cache_names = realloc(cache_names, cache_names_capacity);
       if (!cache_names) {
         fprintf(stderr, "hostfs_cache_dir(): Out of memory\n");
-        exit(1);
+        fatal("hostfs_cache_dir(): out of memory");
       }
     }
 
@@ -1968,7 +1968,7 @@ hostfs_cache_dir(const char *directory_name)
       cache_entries = realloc(cache_entries, cache_entries_capacity * sizeof(cache_directory_entry));
       if (!cache_entries) {
         fprintf(stderr, "hostfs_cache_dir(): Out of memory\n");
-        exit(1);
+        fatal("hostfs_cache_dir(): out of memory");
       }
     }
   }

--- a/src/i8042.c
+++ b/src/i8042.c
@@ -173,7 +173,7 @@ i8042_data_write(uint8_t val)
 		mouse_data_write(val);
 		break;
 	default:
-		exit(1);
+		fatal("i8042: unknown controller command 0x%02x", val);
 	}
 	i8042.command = 0;
 }
@@ -215,7 +215,7 @@ i8042_command_write(uint8_t val)
 		i8042.command = val;
 		break;
 	default:
-		exit(1);
+		fatal("i8042: unknown controller command 0x%02x", val);
 	}
 }
 

--- a/src/ide.c
+++ b/src/ide.c
@@ -1330,7 +1330,7 @@ static void atapicommand(void)
                         for (c=0;c<12;c++)
                             rpclog("%02X ",idebufferb[c]);
                         rpclog("\n");
-                        exit(-1);
+                        fatal("IDE: bad read TOC format (unhandled ATAPI request)");
                 }
                 len=atapi->readtoc(idebufferb,idebufferb[6],msf);
   /*      rpclog("ATAPI buffer len %i\n",len);
@@ -1355,7 +1355,7 @@ static void atapicommand(void)
                 rpclog("Packet data :\n");
                 for (c=0;c<12;c++)
                     rpclog("%02X\n",idebufferb[c]);
-                exit(-1);
+                fatal("IDE: unhandled READ CD flags (see log)");
                 
         case GPCMD_READ_CD:
                 if (!atapi->ready()) { atapi_notready(); return; }
@@ -1363,12 +1363,12 @@ static void atapicommand(void)
                 if (idebufferb[9]!=0x10)
                 {
                         rpclog("Bad flags bits %02X\n",idebufferb[9]);
-                        exit(-1);
+                        fatal("IDE: unhandled READ CD sector count (see log)");
                 }
 /*                if (idebufferb[6] || idebufferb[7] || (idebufferb[8]!=1))
                 {
                         rpclog("More than 1 sector!\n");
-                        exit(-1);
+                        fatal("IDE: unhandled READ HEADER in MSF mode");
                 }*/
                 ide.cdlen=(idebufferb[6]<<16)|(idebufferb[7]<<8)|idebufferb[8];
                 ide.cdpos=(idebufferb[2]<<24)|(idebufferb[3]<<16)|(idebufferb[4]<<8)|idebufferb[5];
@@ -1391,7 +1391,7 @@ static void atapicommand(void)
                 if (msf)
                 {
                         rpclog("Read Header MSF!\n");
-                        exit(-1);
+                        fatal("IDE: unhandled MODE SENSE page (not 3F, see log)");
                 }
                 for (c=0;c<4;c++) idebufferb[c+4]=idebufferb[c+2];
                 idebufferb[0]=1; /*2048 bytes user data*/
@@ -1413,7 +1413,7 @@ static void atapicommand(void)
                         rpclog("Packet data :\n");
                         for (c=0;c<12;c++)
                             rpclog("%02X\n",idebufferb[c]);
-                        exit(-1);
+                        fatal("IDE: unhandled READ SUBCHANNEL request (see log)");
                 }
                 len=(idebufferb[8]|(idebufferb[7]<<8));
 //                rpclog("Mode sense! %i\n",len);
@@ -1486,7 +1486,7 @@ static void atapicommand(void)
                         for (c=0;c<12;c++)
                             rpclog("%02X\n",idebufferb[c]);
                         arm_dump();
-                        exit(-1);
+                        fatal("IDE: unhandled ATAPI command (see log)");
                 }
                 pos=0;
                 idebufferb[pos++]=0;
@@ -1510,7 +1510,7 @@ static void atapicommand(void)
                         rpclog("Packet data :\n");
                         for (c=0;c<12;c++)
                             rpclog("%02X\n",idebufferb[c]);
-                        exit(-1);
+                        fatal("IDE: bad START/STOP UNIT command (see log)");
                 }
                 if (!idebufferb[4])        atapi->stop();
                 else if (idebufferb[4]==2) atapi->eject();


### PR DESCRIPTION
When encountering an error the code will often quit with exit(-1), however this just delegates to glibc to wait for everything to complete. I found frequently it would hang, and this is because other threads etc are running and never getting this exit condition. This replaces with call to fatal which will correctly handle this and shut everything down cleanly to avoid hangs.