### PR TITLE
CI: update the GitHub actions, and stop building superseded commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   linux-amd64:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install dependencies
         run: bash setup-build-env.sh
@@ -78,7 +78,7 @@ jobs:
     # does not exist, so arm64 uses the interpreter (--interpreter).
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install dependencies
         run: bash setup-build-env.sh
@@ -143,7 +143,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up MSYS2 / MinGW-w64
         uses: msys2/setup-msys2@v2
@@ -244,7 +244,7 @@ jobs:
     # in /opt/homebrew can't provide them) and Rosetta 2 to run the JIT test.
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rosetta 2
         run: softwareupdate --install-rosetta --agree-to-license
@@ -298,7 +298,7 @@ jobs:
     # Linux arm64 build. On Apple Silicon the x86_64 slice also runs via Rosetta.
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install dependencies
         run: |
@@ -332,16 +332,16 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Download x86_64 slice
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: macos-slice-x86_64
           path: build-mac-x86_64/appstage
 
       - name: Download arm64 slice
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: macos-slice-arm64
           path: build-mac-arm64/appstage
@@ -440,12 +440,12 @@ jobs:
       contents: write
     steps:
       - name: Download all build artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: upload
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,19 @@ on:
 permissions:
   contents: read
 
+# Push again while a run is still going and the first one is now building a
+# commit nobody is waiting on, so stop it and let the new one have the runners.
+# Each ref gets its own group, so a push to main never cancels a pull request.
+#
+# Tags are the exception. A tag run is the one that publishes a release, and it
+# uploads the assets one at a time, so cancelling it half way leaves a release
+# carrying some of its files - worse than the runner time it saves. Nothing
+# supersedes a tag anyway, each one being its own ref, so there is nothing to
+# gain by cancelling it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   linux-amd64:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Two independent changes to `.github/workflows/build.yml`, in separate commits so either can be dropped on its own.

## 1. Update the actions to their current versions

No dependabot on the repository, so these had drifted a few majors behind.

| action | before | after |
| --- | --- | --- |
| `actions/checkout` | v4 | v7 |
| `actions/download-artifact` | v7 | v8 |
| `softprops/action-gh-release` | v2 | v3 |

`actions/upload-artifact` and `msys2/setup-msys2` were already current.

The checkout and gh-release bumps are mostly the move to a Node 24 runtime. Checkout v7's one breaking change is that it will not check out a fork's head for `pull_request_target` or `workflow_run`; this workflow uses neither.

`download-artifact` v8 is the one with a behaviour change worth noting: a digest mismatch on download is now an error rather than a warning, which is what you want for something about to be published. `digest-mismatch: warn` puts that back if it ever fires.

## 2. Cancel a run that has already been superseded

Pushing twice in quick succession left both runs going, the first building a commit nobody is waiting on while holding six runners, two of them macOS. This has happened on `main` — two commits three minutes apart, against a six-to-seven minute run.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
```

The group is per ref, so only the same branch or pull request is affected; a push to `main` leaves a pull request's run alone.

Tags are deliberately excluded. The tag run publishes the release, uploading assets one at a time, so cancelling it part way could leave a release holding only some of its files — and nothing supersedes a tag anyway, each being its own ref.

## Testing

Run on real runners on a fork.

**Full release path, via a throwaway tag** — the part a pull request never reaches, since the release job is gated on `refs/tags/v*` and a tag also switches the Linux jobs to `--deb`. All seven jobs passed and the release published the expected seven assets (two `.deb`, three `.tar.gz`, one `.dmg`, one `.zip`).

That covers `download-artifact` v8 in the release job, where it downloads every artifact in one step: no digest mismatch fired across the ten artifacts, and the release contents were unchanged. Tag and release were deleted afterwards.

**Pull request build** — six build jobs green, `release` correctly skipped.

**Cancellation** — two commits pushed ~30s apart on one PR. The first run went `in_progress` → `cancelled`, all six build jobs killed mid-flight, while the second ran to completion. Probe commits removed afterwards.

Nothing exercised the `digest-mismatch` error path itself, since no mismatch occurred; that default is taken from the v8 release notes.
