### PR TITLE
CI: keep the boot test's ROM and machine out of the build artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -548,6 +548,14 @@ jobs:
           set -eu
           export RPCEMU_DATADIR="$RUNNER_TEMP/rpcemu-data"
           export RPCEMU_NO_GUI_MESSAGES=1
+          # The bundle is the one layout where the read-only payload is not
+          # beside the executable: it lives in Contents/Resources, while the
+          # binary sits in Contents/MacOS. The emulator finds its resources by
+          # looking for a directory holding configs/, and the data directory
+          # created below has one, so it would otherwise settle on that and find
+          # no poduleroms/ - leaving HostFS unavailable and !Boot unable to run.
+          # Name the resource directory outright so the split is explicit.
+          export RPCEMU_RESOURCE_DIR="$PWD/releases/macos/RPCEmu.app/Contents/Resources"
           mkdir -p "$RPCEMU_DATADIR" ci-rom
           cp -r default configs "$RPCEMU_DATADIR/"
           if ! ls ci-rom/ROM* >/dev/null 2>&1; then
@@ -562,6 +570,9 @@ jobs:
       - name: Headless boot and VNC screenshot
         timeout-minutes: 3
         run: |
+          # See the fetch step: the bundle keeps its read-only payload in
+          # Contents/Resources, so that has to be named rather than found.
+          export RPCEMU_RESOURCE_DIR="$PWD/releases/macos/RPCEmu.app/Contents/Resources"
           python3 tests/vnc_smoke.py \
             --binary releases/macos/RPCEmu.app/Contents/MacOS/rpcemu \
             --datadir "$RUNNER_TEMP/rpcemu-data" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,31 +65,38 @@ jobs:
       # WinHTTP on Windows, NSURLSession on macOS).
       #
       # Cached so RISC OS Open are not asked for the same file on every push.
-      # Packaging has already happened by this point, so neither the ROM nor the
-      # machine the fetch creates ends up in the released archive.
+      # The ROM and the machine the test creates go in a data directory under
+      # RUNNER_TEMP, not in the staged release. The emulator resolves its
+      # writable data separately from its read-only resources, so RPCEMU_DATADIR
+      # moves every write out of the tree that is about to be uploaded while it
+      # still finds its resources beside the binary. The staged release is left
+      # exactly as it was built.
       - name: Cache the RISC OS ROM
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ci-rom
           key: rpcemu-rom-stable-v1
       - name: Fetch a ROM for the boot test
         run: |
           set -eu
-          data="releases/linux/amd64"
-          mkdir -p ci-rom
+          export RPCEMU_DATADIR="$RUNNER_TEMP/rpcemu-data"
+          export RPCEMU_NO_GUI_MESSAGES=1
+          mkdir -p "$RPCEMU_DATADIR" ci-rom
+          cp -r default configs "$RPCEMU_DATADIR/"
           if ! ls ci-rom/ROM* >/dev/null 2>&1; then
-            RPCEMU_DATADIR="$data" RPCEMU_NO_GUI_MESSAGES=1 \
-              "$data/rpcemu-recompiler" --fetch-riscos --no-disc --accept-licence
-            cp "$data"/roms/ROM* ci-rom/
+            releases/linux/amd64/rpcemu-recompiler --fetch-riscos --no-disc --accept-licence
+            cp "$RPCEMU_DATADIR"/roms/ROM* ci-rom/
           fi
-          cp ci-rom/ROM* "$data/roms/"
-          ls -la "$data/roms/"
+          mkdir -p "$RPCEMU_DATADIR/roms"
+          cp ci-rom/ROM* "$RPCEMU_DATADIR/roms/"
+          ls -la "$RPCEMU_DATADIR/roms/"
 
       - name: Headless boot and VNC screenshot
         timeout-minutes: 3
         run: |
           python3 tests/vnc_smoke.py \
             --binary releases/linux/amd64/rpcemu-recompiler \
+            --datadir "$RUNNER_TEMP/rpcemu-data" \
             --save vnc-smoke-linux-amd64.png
 
       - name: Upload the boot screenshot
@@ -153,31 +160,38 @@ jobs:
       # WinHTTP on Windows, NSURLSession on macOS).
       #
       # Cached so RISC OS Open are not asked for the same file on every push.
-      # Packaging has already happened by this point, so neither the ROM nor the
-      # machine the fetch creates ends up in the released archive.
+      # The ROM and the machine the test creates go in a data directory under
+      # RUNNER_TEMP, not in the staged release. The emulator resolves its
+      # writable data separately from its read-only resources, so RPCEMU_DATADIR
+      # moves every write out of the tree that is about to be uploaded while it
+      # still finds its resources beside the binary. The staged release is left
+      # exactly as it was built.
       - name: Cache the RISC OS ROM
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ci-rom
           key: rpcemu-rom-stable-v1
       - name: Fetch a ROM for the boot test
         run: |
           set -eu
-          data="releases/linux/arm64"
-          mkdir -p ci-rom
+          export RPCEMU_DATADIR="$RUNNER_TEMP/rpcemu-data"
+          export RPCEMU_NO_GUI_MESSAGES=1
+          mkdir -p "$RPCEMU_DATADIR" ci-rom
+          cp -r default configs "$RPCEMU_DATADIR/"
           if ! ls ci-rom/ROM* >/dev/null 2>&1; then
-            RPCEMU_DATADIR="$data" RPCEMU_NO_GUI_MESSAGES=1 \
-              "$data/rpcemu-interpreter" --fetch-riscos --no-disc --accept-licence
-            cp "$data"/roms/ROM* ci-rom/
+            releases/linux/arm64/rpcemu-interpreter --fetch-riscos --no-disc --accept-licence
+            cp "$RPCEMU_DATADIR"/roms/ROM* ci-rom/
           fi
-          cp ci-rom/ROM* "$data/roms/"
-          ls -la "$data/roms/"
+          mkdir -p "$RPCEMU_DATADIR/roms"
+          cp ci-rom/ROM* "$RPCEMU_DATADIR/roms/"
+          ls -la "$RPCEMU_DATADIR/roms/"
 
       - name: Headless boot and VNC screenshot
         timeout-minutes: 3
         run: |
           python3 tests/vnc_smoke.py \
             --binary releases/linux/arm64/rpcemu-interpreter \
+            --datadir "$RUNNER_TEMP/rpcemu-data" \
             --save vnc-smoke-linux-arm64.png
 
       - name: Upload the boot screenshot
@@ -283,23 +297,34 @@ jobs:
       # WinHTTP on Windows, NSURLSession on macOS).
       #
       # Cached so RISC OS Open are not asked for the same file on every push.
-      # Packaging has already happened by this point, so neither the ROM nor the
-      # machine the fetch creates ends up in the released archive.
+      # The ROM and the machine the test creates go in a data directory under
+      # RUNNER_TEMP, not in the staged release. The emulator resolves its
+      # writable data separately from its read-only resources, so RPCEMU_DATADIR
+      # moves every write out of the tree that is about to be uploaded while it
+      # still finds its resources beside the binary. The staged release is left
+      # exactly as it was built.
       - name: Cache the RISC OS ROM
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ci-rom
           key: rpcemu-rom-stable-v1
       - name: Fetch a ROM for the boot test
         run: |
           set -eu
-          data="releases/windows/amd64"
-          mkdir -p ci-rom
+          # The one platform where the two cannot be the same string. This shell
+          # needs the MSYS2 form of the path, while the executable is a native
+          # Windows program and needs the Windows form, so RUNNER_TEMP (which
+          # arrives as D:\a\_temp) goes through cygpath both ways.
+          data="$(cygpath -u "$RUNNER_TEMP")/rpcemu-data"
+          export RPCEMU_DATADIR="$(cygpath -w "$data")"
+          export RPCEMU_NO_GUI_MESSAGES=1
+          mkdir -p "$data" ci-rom
+          cp -r default configs "$data/"
           if ! ls ci-rom/ROM* >/dev/null 2>&1; then
-            RPCEMU_DATADIR="$data" RPCEMU_NO_GUI_MESSAGES=1 \
-              "$data/rpcemu-recompiler.exe" --fetch-riscos --no-disc --accept-licence
+            releases/windows/amd64/rpcemu-recompiler.exe --fetch-riscos --no-disc --accept-licence
             cp "$data"/roms/ROM* ci-rom/
           fi
+          mkdir -p "$data/roms"
           cp ci-rom/ROM* "$data/roms/"
           ls -la "$data/roms/"
 
@@ -308,6 +333,7 @@ jobs:
         run: |
           python3 tests/vnc_smoke.py \
             --binary releases/windows/amd64/rpcemu-recompiler.exe \
+            --datadir "$(cygpath -u "$RUNNER_TEMP")/rpcemu-data" \
             --save vnc-smoke-windows-amd64.png
 
       - name: Upload the boot screenshot
@@ -506,31 +532,39 @@ jobs:
       # WinHTTP on Windows, NSURLSession on macOS).
       #
       # Cached so RISC OS Open are not asked for the same file on every push.
-      # Packaging has already happened by this point, so neither the ROM nor the
-      # machine the fetch creates ends up in the released archive.
+      # The ROM and the machine the test creates go in a data directory under
+      # RUNNER_TEMP, not in the staged release. The emulator resolves its
+      # writable data separately from its read-only resources, so RPCEMU_DATADIR
+      # moves every write out of the tree that is about to be uploaded while it
+      # still finds its resources beside the binary. The staged release is left
+      # exactly as it was built.
       - name: Cache the RISC OS ROM
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ci-rom
           key: rpcemu-rom-stable-v1
       - name: Fetch a ROM for the boot test
         run: |
           set -eu
-          data="releases/macos/RPCEmu.app/Contents/Resources"
-          mkdir -p ci-rom
+          export RPCEMU_DATADIR="$RUNNER_TEMP/rpcemu-data"
+          export RPCEMU_NO_GUI_MESSAGES=1
+          mkdir -p "$RPCEMU_DATADIR" ci-rom
+          cp -r default configs "$RPCEMU_DATADIR/"
           if ! ls ci-rom/ROM* >/dev/null 2>&1; then
-            RPCEMU_DATADIR="$data" RPCEMU_NO_GUI_MESSAGES=1 \
-              "$data/../MacOS/rpcemu" --fetch-riscos --no-disc --accept-licence
-            cp "$data"/roms/ROM* ci-rom/
+            releases/macos/RPCEmu.app/Contents/MacOS/rpcemu \
+              --fetch-riscos --no-disc --accept-licence
+            cp "$RPCEMU_DATADIR"/roms/ROM* ci-rom/
           fi
-          cp ci-rom/ROM* "$data/roms/"
-          ls -la "$data/roms/"
+          mkdir -p "$RPCEMU_DATADIR/roms"
+          cp ci-rom/ROM* "$RPCEMU_DATADIR/roms/"
+          ls -la "$RPCEMU_DATADIR/roms/"
 
       - name: Headless boot and VNC screenshot
         timeout-minutes: 3
         run: |
           python3 tests/vnc_smoke.py \
             --binary releases/macos/RPCEmu.app/Contents/MacOS/rpcemu \
+            --datadir "$RUNNER_TEMP/rpcemu-data" \
             --save vnc-smoke-macos-universal.png
 
       - name: Upload the boot screenshot


### PR DESCRIPTION
A Windows build artifact was shipping a `vncsmoke` machine and a RISC OS ROM.

Packaging runs before the smoke tests, but that only protects the archives. The upload step runs at the end of the job and takes the staged directory too, so anything written there after packaging still reaches the artifact. The boot test used that directory as its data directory, so the fetched ROM and the test's machine landed in it.

Published releases were never affected — they are built from the archives alone.

## The change

Point `RPCEMU_DATADIR` at a directory under `RUNNER_TEMP`. The emulator resolves writable data separately from read-only resources, so every write goes there while resources are still found beside the binary. The directory is seeded with `default/` and `configs/`; the emulator creates the rest.

The second commit handles macOS, where the payload lives in `Contents/Resources` rather than beside the binary. The emulator locates it by searching for a directory holding `configs/`, and the new data directory has one, so the search settled there and found no `poduleroms/` — HostFS never came up and `!Boot` never ran. `RPCEMU_RESOURCE_DIR` now names the payload directly.

Windows converts `RUNNER_TEMP` with `cygpath`, as it arrives as `D:\a\_temp`.

`actions/cache` goes v4 to v6 while it is being touched: Node 24 and ESM, no input changes.

## Testing

Green on all four platforms on a fork.

The macOS problem above was a real failure on the first CI run, reproduced locally and fixed in the second commit. Also verified locally that the boot reaches the desktop from the new data directory, and that the staged tree is unchanged afterwards.
