### PR TITLE
GUI: offer to restart a machine when its settings need it

### DIFF
--- a/src/gui/emulator_host.cpp
+++ b/src/gui/emulator_host.cpp
@@ -728,6 +728,37 @@ void EmulatorHost::HandleCommand(const EmuCommand &command)
 		rpclog("RPCEmu: Machine switch complete\n");
 		break;
 	}
+	case EmuCommandType::Restart: {
+		rpclog("RPCEmu: Restarting machine\n");
+
+		/* The guest writes its CMOS out as it changes it (see the checksum
+		   handling in cmos.c), so this is only here to catch a change that had
+		   not reached the checksum byte yet. */
+		savecmos();
+
+		/* Re-read the machine's own configuration file, so a setting changed
+		   in the machine editor since it started is picked up. */
+		config_load(&config);
+
+		hostfs_init();
+		cmos_init();
+
+		/* Unconditionally, unlike SwitchMachine: the machine editor has already
+		   written the new ROM directory into the live config by this point, so
+		   comparing the old value against the new one would never differ and
+		   the ROM would never be reloaded - which is the whole reason a reset
+		   was not enough. */
+		loadroms();
+
+		resetrpc();
+
+		if (gui_bridge_ != nullptr) {
+			gui_bridge_->PostMachineSwitched(config.name);
+		}
+
+		rpclog("RPCEmu: Restart complete\n");
+		break;
+	}
 	case EmuCommandType::CpuIdle:
 		config.cpu_idle ^= 1;
 		config_save(&config);
@@ -1039,6 +1070,13 @@ void EmulatorHost::SwitchMachine(const std::string &config_path)
 	EmuCommand cmd;
 	cmd.type = EmuCommandType::SwitchMachine;
 	cmd.string_path = config_path;
+	PostCommand(cmd);
+}
+
+void EmulatorHost::Restart()
+{
+	EmuCommand cmd;
+	cmd.type = EmuCommandType::Restart;
 	PostCommand(cmd);
 }
 

--- a/src/gui/emulator_host.h
+++ b/src/gui/emulator_host.h
@@ -69,6 +69,7 @@ enum class EmuCommandType {
 	HostClipboardChanged,
 	ReloadIdeImages,
 	SwitchMachine,
+	Restart,
 	NatRuleAdd,
 	NatRuleEdit,
 	NatRuleRemove,
@@ -161,6 +162,7 @@ public:
 	void FollowHostDisplay();
 	void SetClipboardEnabled();
 	void SwitchMachine(const std::string &config_path);
+	void Restart();
 	void NatRuleAdd(const PortForwardRule &rule);
 	void NatRuleEdit(const PortForwardRule &old_rule, const PortForwardRule &new_rule);
 	void NatRuleRemove(const PortForwardRule &rule);

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -90,6 +90,101 @@ bool HostResetQuestion(wxWindow *parent)
 	           parent) == wxOK;
 }
 
+bool SameString(const char *a, const char *b)
+{
+	if (a == nullptr || b == nullptr) {
+		return a == b;
+	}
+	return strcmp(a, b) == 0;
+}
+
+/* Release the strings config_deep_copy() duplicated into a scratch Config. */
+void FreeConfigCopy(Config *cfg)
+{
+	free(cfg->username);
+	free(cfg->ipaddress);
+	free(cfg->macaddress);
+	free(cfg->bridgename);
+	free(cfg->network_capture);
+	cfg->username = nullptr;
+	cfg->ipaddress = nullptr;
+	cfg->macaddress = nullptr;
+	cfg->bridgename = nullptr;
+	cfg->network_capture = nullptr;
+}
+
+/*
+ * Did the machine editor change something the running machine cannot pick up?
+ *
+ * The dialog's Options tab holds the settings that are either already live or
+ * read when the machine next starts, so nothing there needs a restart. The
+ * System, Network, IDE Drives and Podules tabs are the other way round: they
+ * describe the hardware, which is built when the machine starts and by the
+ * reset the editor does not perform. The ROM is the furthest out of reach,
+ * being read only by loadroms() at start-up.
+ *
+ * Written as "everything except the Options fields" rather than as a list of
+ * the fields that matter, so a setting added to one of the hardware tabs later
+ * is treated as needing a restart without anyone having to remember to add it
+ * here. Being asked to restart unnecessarily is a smaller problem than a
+ * change that silently does not apply.
+ */
+bool MachineNeedsRestart(const Config *before, const Config *after)
+{
+	Config a;
+	Config b;
+
+	memset(&a, 0, sizeof(a));
+	memset(&b, 0, sizeof(b));
+	config_deep_copy(&a, before);
+	config_deep_copy(&b, after);
+
+	/* Flatten every Options-tab setting so it cannot register as a change. */
+	a.show_fullscreen_message = b.show_fullscreen_message = 0;
+	a.integer_scaling = b.integer_scaling = 0;
+	a.fit_to_window = b.fit_to_window = 0;
+	a.follow_host_display = b.follow_host_display = 0;
+	a.soundenabled = b.soundenabled = 0;
+	a.cdromenabled = b.cdromenabled = 0;
+	a.mousetwobutton = b.mousetwobutton = 0;
+	a.cpu_idle = b.cpu_idle = 0;
+	a.suspend_on_exit = b.suspend_on_exit = 0;
+	a.vnc_enabled = b.vnc_enabled = 0;
+	a.clipboard_enabled = b.clipboard_enabled = 0;
+	/* A rename is not something to restart for, and offering to would be
+	   worse than useless: the data directory is deliberately left under the
+	   old name while the machine is running, so a restart would load the
+	   configuration under the new one and point HostFS at a directory that
+	   does not exist. The rename has already said so in its own message. */
+	memset(a.name, 0, sizeof(a.name));
+	memset(b.name, 0, sizeof(b.name));
+
+	/* Compared by value: the memcmp below only sees the pointers, which always
+	   differ between two copies. */
+	bool changed = !SameString(a.username, b.username) ||
+	               !SameString(a.ipaddress, b.ipaddress) ||
+	               !SameString(a.macaddress, b.macaddress) ||
+	               !SameString(a.bridgename, b.bridgename) ||
+	               !SameString(a.network_capture, b.network_capture);
+
+	if (!changed) {
+		/* Take the pointers out of the picture for the structure comparison,
+		   keeping hold of them so they can still be freed. */
+		Config a_cmp = a;
+		Config b_cmp = b;
+		a_cmp.username = b_cmp.username = nullptr;
+		a_cmp.ipaddress = b_cmp.ipaddress = nullptr;
+		a_cmp.macaddress = b_cmp.macaddress = nullptr;
+		a_cmp.bridgename = b_cmp.bridgename = nullptr;
+		a_cmp.network_capture = b_cmp.network_capture = nullptr;
+		changed = memcmp(&a_cmp, &b_cmp, sizeof(Config)) != 0;
+	}
+
+	FreeConfigCopy(&a);
+	FreeConfigCopy(&b);
+	return changed;
+}
+
 } // namespace
 
 wxBEGIN_EVENT_TABLE(MainFrame, wxFrame)
@@ -275,6 +370,18 @@ void MainFrame::OnReset(wxCommandEvent &)
 	if (emulator_) {
 		emulator_->Reset();
 	}
+}
+
+/* Restart the running machine, picking up its configuration file and ROMs as
+   they are now. Does nothing if no machine is running, where there is nothing
+   to restart and the settings that would be applied are read at startup
+   anyway. */
+void MainFrame::RestartMachine()
+{
+	if (emulator_ == nullptr || !emulator_->IsRunning()) {
+		return;
+	}
+	emulator_->Restart();
 }
 
 void MainFrame::OnSaveState(wxCommandEvent &)
@@ -1180,10 +1287,17 @@ void MainFrame::EditMachineConfiguration()
 	const wxString old_config_path = ConfigPathsAbsoluteConfigPath(wxString::FromUTF8(config_get_path()));
 	const wxString old_name = wxString::FromUTF8(config_copy_.name);
 
+	/* The dialog writes straight into the live configuration, so a copy has to
+	   be taken now to have anything to compare against afterwards. */
+	Config old_config;
+	memset(&old_config, 0, sizeof(old_config));
+	config_deep_copy(&old_config, &config);
+
 	MachineEditDialog dlg(this, old_config_path,
 	                      emulator_ == nullptr || !emulator_->IsRunning(),
 	                      emulator_ != nullptr && emulator_->IsRunning());
 	if (dlg.ShowModal() != wxID_OK) {
+		FreeConfigCopy(&old_config);
 		return;
 	}
 
@@ -1211,11 +1325,31 @@ void MainFrame::EditMachineConfiguration()
 	SyncSettingsMenuChecks();
 	SyncCdromMenuChecks();
 	UpdateMachineStatus();
-	wxMessageBox(
-	    "Machine configuration saved.\n\nRestart the emulator for changes to take full effect.",
+
+	/* Ask only when the machine's hardware description changed and there is a
+	   machine running to apply it to. Changing something on the Options tab -
+	   the two-button mouse, the sound - needs nothing, and a dialog offering to
+	   throw the machine away over it would be noise. */
+	const bool needs_restart = MachineNeedsRestart(&old_config, &config);
+	FreeConfigCopy(&old_config);
+
+	if (!needs_restart || emulator_ == nullptr || !emulator_->IsRunning()) {
+		return;
+	}
+
+	wxMessageDialog restart_dlg(
+	    this,
+	    "The machine's configuration has changed, which only takes effect "
+	    "when it restarts.\n\n"
+	    "Restarting will lose any unsaved data in the running machine.",
 	    "Machine Configuration",
-	    wxOK | wxICON_INFORMATION,
-	    this);
+	    /* Continue is the default: a stray Return should not throw away
+	       whatever is running. */
+	    wxYES_NO | wxNO_DEFAULT | wxICON_QUESTION);
+	restart_dlg.SetYesNoLabels("Restart", "Continue Without Restarting");
+	if (restart_dlg.ShowModal() == wxID_YES) {
+		RestartMachine();
+	}
 }
 
 void MainFrame::OnVideoTimer(wxTimerEvent &)

--- a/src/gui/main_frame.h
+++ b/src/gui/main_frame.h
@@ -263,6 +263,7 @@ private:
 
 	wxString BlankDiscResourcePath(const wxString &filename) const;
 	wxString ConfigPathForMachine(const wxString &machine_name) const;
+	void RestartMachine();
 
 	Config config_copy_{};
 	Model model_copy_ = Model_RPCARM710;


### PR DESCRIPTION
Change a machine's ROM, pick Reset, and you still get the old ROM.

Reset is not the wrong answer to that — it resets the emulated hardware, the same as the button on a real machine, and the ROM chips do not change when you press it. `loadroms()` runs once at start-up and no reset repeats it, so nothing short of quitting picked up a new ROM. The editor already knew: it ended by saying "Restart the emulator for changes to take full effect", and offered only OK.

## The change

A machine can now be restarted — reload its configuration, reload its ROMs, reset the hardware, in the order start-up does. The reload is unconditional, unlike the one in `SwitchMachine`, which compares the old ROM directory against the new one. By the time the editor has finished, the new directory is already in the live configuration, so that comparison never differs and the ROM is never re-read. That is how this went unnoticed.

The offer lives in the machine editor rather than the File menu: a restart is what you want after changing a setting, not something to reach for on its own, and Reset keeps its meaning.

It only appears when it is worth making. The Options tab holds settings that are already live or read when the machine next starts; System, Network, IDE Drives and Podules describe hardware built at start-up and by a reset the editor does not perform. Toggling the two-button mouse now saves silently.

The test is written as "anything except the Options fields" rather than as a list of the fields that matter, so a setting added to a hardware tab later needs a restart without anyone having to remember this code exists. An unnecessary prompt is a smaller problem than a change that quietly does not apply.

Renames are excluded deliberately: the data directory keeps its old name while the machine runs, so a restart would load the configuration under the new name and point HostFS at a directory that is not there. The rename already says as much in its own message.

"Continue Without Restarting" is the default button, so a stray Return does not throw away a running machine.

## Testing

Built clean, 15/15 unit tests, and the headless VNC boot test reaches the desktop. The restart itself was tested in the GUI.
