### PR TITLE
GUI: stop a machine's bridge name turning to rubbish when its settings are saved

### DIFF
--- a/src/gui/machine_edit_dialog.cpp
+++ b/src/gui/machine_edit_dialog.cpp
@@ -1388,10 +1388,19 @@ void MachineEditDialog::ApplySavedSettingsToGlobalConfig(const wxString &rom_dir
                                                          int vram_internal, int refresh,
                                                          NetworkType network_type)
 {
+	/* GetValue() returns a temporary, and the buffer utf8_str() gives back
+	   points into that string rather than owning a copy of it. Taking the
+	   buffer straight from the temporary leaves it dangling at the end of the
+	   statement, so the strings are held in named locals that outlive the use
+	   below. The other two are already named, which is why only these two came
+	   out as rubbish. */
+	const wxString bridge_value = bridge_edit_->GetValue();
+	const wxString ip_value = tunnel_edit_->GetValue();
+
 	const wxScopedCharBuffer name_utf8 = new_name_.utf8_str();
 	const wxScopedCharBuffer rom_utf8 = rom_dir.utf8_str();
-	const wxScopedCharBuffer bridge_utf8 = bridge_edit_->GetValue().utf8_str();
-	const wxScopedCharBuffer ip_utf8 = tunnel_edit_->GetValue().utf8_str();
+	const wxScopedCharBuffer bridge_utf8 = bridge_value.utf8_str();
+	const wxScopedCharBuffer ip_utf8 = ip_value.utf8_str();
 	config_apply_machine_edit(&config, name_utf8.data(), rom_utf8.data(),
 	                          static_cast<unsigned>(mem_size),
 	                          static_cast<unsigned>(vram_internal), refresh, network_type,


### PR DESCRIPTION
Saving a machine's settings could write a corrupted bridge name into the running configuration — a run of random bytes where `rpcemu` should have been — taking any Ethernet Bridging setup with it.

The two network fields took their UTF-8 buffers straight from the text controls:

```cpp
const wxScopedCharBuffer bridge_utf8 = bridge_edit_->GetValue().utf8_str();
```

`GetValue()` returns a temporary `wxString`, and the buffer `utf8_str()` hands back points into that string rather than owning a copy. The temporary dies at the end of the statement, leaving the buffer pointing at freed memory. The two lines above it look identical but are not — those take their strings from named references that outlive the call, which is why only the bridge name and the tunnelling address were affected.

Because it was freed memory it read back as whatever had since been written there, so it usually looked fine and only sometimes came out visibly wrong. Holding the two strings in named locals gives the buffers something that lives long enough.

## How it turned up

A machine asked to be restarted after its settings were saved with nothing changed. The restart offer was correct — the configuration really had changed — but only because this had just corrupted it.

Confirmed by logging the value on both sides of the conversion: the control held `rpcemu`, the buffer handed on held `_~??X`.

## Testing

Built clean, 15/15 unit tests. The original case no longer reproduces: saving a machine's settings with nothing changed leaves the configuration alone and asks for no restart.
