### PR TITLE
GUI: give the hard disc download a button of its own

### DIFF
--- a/src/gui/machine_edit_dialog.cpp
+++ b/src/gui/machine_edit_dialog.cpp
@@ -175,11 +175,11 @@ wxWindow *MachineEditDialog::BuildSystemPage(wxWindow *parent)
 	rom_combo_ = new wxComboBox(page, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, nullptr, wxCB_READONLY);
 	get_rom_button_ = new wxButton(page, wxID_ANY, "Get RISC OS...");
 	get_rom_button_->SetToolTip("Download a RISC OS ROM from RISC OS Open");
-	get_disc_check_ = new wxCheckBox(page, wxID_ANY,
-	    "Also download a ready-to-use hard disc (about 13 MB)");
-	get_disc_check_->SetToolTip(
-	    "HardDisc4 from RISC OS Open: applications, utilities, !System and a "
-	    "configured !Boot, set up for the ROM you choose.\n\n"
+	get_disc_button_ = new wxButton(page, wxID_ANY, "Get hard disc...");
+	get_disc_button_->SetToolTip(
+	    "Download HardDisc4 from RISC OS Open: applications, utilities, "
+	    "!System and a configured !Boot, set up for the ROM this machine "
+	    "uses (about 13 MB).\n\n"
 	    "Only offered while this machine's hard disc is empty. An existing "
 	    "disc is never overwritten.");
 	get_disc_note_ = new wxStaticText(page, wxID_ANY, wxEmptyString);
@@ -250,13 +250,14 @@ wxWindow *MachineEditDialog::BuildSystemPage(wxWindow *parent)
 		form->Add(rom_row, 1, wxEXPAND);
 	}
 
-	/* What the download brings with it, directly under the button it applies
-	   to, so the two read as one thing. */
-	form->Add(new wxStaticText(page, wxID_ANY, ""), 0);
+	/* The disc is its own download, under the ROM it will boot. A button
+	   rather than something to tick: it happens when it is pressed, which is
+	   what the rest of this row does, and nothing here is applied by OK. */
+	form->Add(new wxStaticText(page, wxID_ANY, "Hard disc:"), 0, wxALIGN_CENTER_VERTICAL);
 	{
 		auto *disc_col = new wxBoxSizer(wxVERTICAL);
 
-		disc_col->Add(get_disc_check_, 0);
+		disc_col->Add(get_disc_button_, 0);
 		disc_col->Add(get_disc_note_, 0, wxTOP, 2);
 		form->Add(disc_col, 1, wxEXPAND);
 	}
@@ -504,6 +505,7 @@ void MachineEditDialog::BuildUi()
 	network_combo_->Bind(wxEVT_COMBOBOX, &MachineEditDialog::OnNetworkChanged, this);
 	rom_combo_->Bind(wxEVT_COMBOBOX, &MachineEditDialog::OnRomOrModelChanged, this);
 	get_rom_button_->Bind(wxEVT_BUTTON, &MachineEditDialog::OnGetRiscos, this);
+	get_disc_button_->Bind(wxEVT_BUTTON, &MachineEditDialog::OnGetHardDisc, this);
 	model_combo_->Bind(wxEVT_COMBOBOX, &MachineEditDialog::OnRomOrModelChanged, this);
 	/* 512MB RAM is Kinetic-only: if any other model is selected, snap a 512MB
 	   choice back to 256MB immediately so it can't be left selected. */
@@ -599,15 +601,14 @@ void MachineEditDialog::SetRomSelection(const wxString &rom_dir)
  */
 void MachineEditDialog::UpdateDiscDownloadAvailability()
 {
-	if (get_disc_check_ == nullptr) {
+	if (get_disc_button_ == nullptr) {
 		return;
 	}
 
 	const bool empty = RiscosFetchMachineDiscIsEmpty(CurrentMachineNameForHd());
 
-	get_disc_check_->Enable(empty);
+	get_disc_button_->Enable(empty);
 	if (!empty) {
-		get_disc_check_->SetValue(false);
 		get_disc_note_->SetLabel("This machine already has files on its hard "
 		                         "disc, which are never overwritten.");
 	} else {
@@ -621,20 +622,16 @@ void MachineEditDialog::UpdateDiscDownloadAvailability()
  *
  * Only the ROM: this machine already exists and has a hard disc of its own,
  * and replacing that is never something to do as a side effect of choosing a
- * ROM. Somebody wanting the ready-made disc as well wants a new machine, which
- * is what the same download offers everywhere else.
+ * ROM. The disc has its own button beneath, for when that is what is wanted.
  */
 void MachineEditDialog::OnGetRiscos(wxCommandEvent &)
 {
 	RiscosSetupDialog dialog(this, false);
 	RiscosFetchOutcome outcome;
-	wxString summary;
 
 	/* The licensing terms are asked for by the dialogue itself, once the
 	   version has been chosen. */
-	dialog.SetTargetMachine(CurrentMachineNameForHd(),
-	                        get_disc_check_->IsEnabled() &&
-	                        get_disc_check_->GetValue());
+	dialog.SetTargetMachine(CurrentMachineNameForHd(), false);
 	if (dialog.ShowModal() != wxID_OK) {
 		return;
 	}
@@ -646,19 +643,63 @@ void MachineEditDialog::OnGetRiscos(wxCommandEvent &)
 	wxCommandEvent dummy;
 	OnRomOrModelChanged(dummy);
 
-	/* The disc has just landed, so the option for it no longer applies. */
 	UpdateDiscDownloadAvailability();
 	UpdateHdStatus();
 
-	summary = wxString::Format("RISC OS %s has been downloaded and selected "
-	                           "for this machine.", outcome.version);
-	if (outcome.disc_files > 0) {
-		summary += wxString::Format("\n\nIts hard disc now holds %d files, "
-		                            "ready to boot to the desktop.",
-		                            outcome.disc_files);
+	wxMessageBox(wxString::Format("RISC OS %s has been downloaded and "
+	                              "selected for this machine.",
+	                              outcome.version),
+	             "RISC OS is ready", wxOK | wxICON_INFORMATION, this);
+}
+
+/**
+ * Download the ready-made hard disc for this machine.
+ *
+ * Separate from the ROM because the two are wanted separately: a machine that
+ * has its ROM and nothing to boot should not have to fetch the ROM again to
+ * get a disc. The disc is set up for the ROM the machine is configured with,
+ * which is read from that ROM's name rather than downloaded.
+ */
+void MachineEditDialog::OnGetHardDisc(wxCommandEvent &)
+{
+	const wxString machine_name = CurrentMachineNameForHd();
+	RiscosFetchRequest request;
+	RiscosFetchOutcome outcome;
+
+	if (!RiscosFetchConfirmLicence(this)) {
+		return;
 	}
 
-	wxMessageBox(summary, "RISC OS is ready", wxOK | wxICON_INFORMATION, this);
+	request.include_rom = false;
+	request.include_disc = true;
+	request.create_machine = false;
+	request.machine_name = machine_name;
+
+	{
+		RiscosFetchProgressReporter reporter(this);
+
+		outcome = RiscosFetchPerform(request, reporter);
+	}
+
+	if (outcome.cancelled) {
+		return;
+	}
+
+	if (!outcome.ok) {
+		wxMessageBox(outcome.message + "\n\nNothing has been changed.",
+		             "Could not fetch the hard disc", wxOK | wxICON_ERROR,
+		             this);
+		return;
+	}
+
+	/* It is no longer empty, so the button no longer applies. */
+	UpdateDiscDownloadAvailability();
+	UpdateHdStatus();
+
+	wxMessageBox(wxString::Format("The hard disc now holds %d files, ready "
+	                              "to boot to the desktop.",
+	                              outcome.disc_files),
+	             "Hard disc is ready", wxOK | wxICON_INFORMATION, this);
 }
 
 /**

--- a/src/gui/machine_edit_dialog.h
+++ b/src/gui/machine_edit_dialog.h
@@ -110,6 +110,7 @@ private:
 	void OnNetworkChanged(wxCommandEvent &event);
 	void OnRomOrModelChanged(wxCommandEvent &event);
 	void OnGetRiscos(wxCommandEvent &event);
+	void OnGetHardDisc(wxCommandEvent &event);
 	void UpdateDiscDownloadAvailability();
 	void OnNameChanged(wxCommandEvent &event);
 	wxString SelectedRomDir() const;
@@ -128,7 +129,7 @@ private:
 	wxTextCtrl *name_edit_ = nullptr;
 	wxComboBox *rom_combo_ = nullptr;
 	wxButton *get_rom_button_ = nullptr;
-	wxCheckBox *get_disc_check_ = nullptr;
+	wxButton *get_disc_button_ = nullptr;
 	wxStaticText *get_disc_note_ = nullptr;
 
 	/* The System page, kept so a note that grows can have its page laid out

--- a/src/gui/riscos_fetch.cpp
+++ b/src/gui/riscos_fetch.cpp
@@ -1012,7 +1012,8 @@ bool RiscosFetchMachineDiscIsEmpty(const wxString &machine_name)
 
 long long RiscosFetchApproximateSize(const RiscosFetchRequest &request)
 {
-	return kRomApproxBytes + (request.include_disc ? kDiscApproxBytes : 0);
+	return (request.include_rom ? kRomApproxBytes : 0) +
+	       (request.include_disc ? kDiscApproxBytes : 0);
 }
 
 RiscosFetchOutcome RiscosFetchPerform(const RiscosFetchRequest &request,
@@ -1027,6 +1028,11 @@ RiscosFetchOutcome RiscosFetchPerform(const RiscosFetchRequest &request,
 	wxString rom_url, rom_name, machine_name, config_path, staged_hostfs;
 	wxString version, datestamp;
 
+	if (!request.include_rom && !request.include_disc) {
+		outcome.message = "Nothing was asked for.";
+		return outcome;
+	}
+
 	if (!ConfigPathsEnsureDataLayout()) {
 		outcome.message = "The RPCEmu data directory could not be created.";
 		return outcome;
@@ -1040,21 +1046,27 @@ RiscosFetchOutcome RiscosFetchPerform(const RiscosFetchRequest &request,
 	}
 
 	/* --- Work out what to fetch --- */
-	rom_url = ResolveRomUrl(request.release, reporter, make_loop);
-	if (rom_url.empty()) {
-		outcome.cancelled = true;
-		RemoveTree(temp_dir);
-		return outcome;
-	}
+	if (request.include_rom) {
+		rom_url = ResolveRomUrl(request.release, reporter, make_loop);
+		if (rom_url.empty()) {
+			outcome.cancelled = true;
+			RemoveTree(temp_dir);
+			return outcome;
+		}
 
-	version = VersionFromUrl(rom_url);
-	if (version.empty()) {
-		version = (request.release == RiscosRelease::Nightly) ? "5.31" : "5.30";
+		version = VersionFromUrl(rom_url);
+		if (version.empty()) {
+			version = (request.release == RiscosRelease::Nightly) ? "5.31" : "5.30";
+		}
 	}
+	/* Fetching the disc on its own leaves this empty, which is what should
+	   happen: the version here describes a ROM that is being downloaded, and
+	   none is. The disc does not need it - its own boot sequence reads the
+	   version from the running machine and sets itself up accordingly. */
 	outcome.version = version;
 
 	/* --- The ROM --- */
-	{
+	if (request.include_rom) {
 		Transfer transfer(reporter,
 		                  wxString::Format("Fetching RISC OS %s...", version),
 		                  make_loop);
@@ -1084,7 +1096,7 @@ RiscosFetchOutcome RiscosFetchPerform(const RiscosFetchRequest &request,
 	   Named for its version, and for a nightly also for the day it was
 	   built, so successive nightlies sit alongside each other in the ROM
 	   list rather than replacing one another. */
-	{
+	if (request.include_rom) {
 		wxString base = "ROM" + version;
 
 		base.Replace(".", "");

--- a/src/gui/riscos_fetch.cpp
+++ b/src/gui/riscos_fetch.cpp
@@ -678,109 +678,6 @@ int InstallDisc(const wxString &archive_path, const wxString &dest_dir,
 	return r;
 }
 
-/** True if @dir does not exist, or exists with nothing in it. */
-bool DirectoryIsEmpty(const wxString &dir)
-{
-	wxString name;
-
-	if (!wxDirExists(dir)) {
-		return true;
-	}
-
-	wxDir handle(dir);
-
-	return handle.IsOpened() &&
-	       !handle.GetFirst(&name, wxEmptyString, wxDIR_FILES | wxDIR_DIRS);
-}
-
-/** "5.30" to 530, matching the form RISC OS reports as Boot$OSVersion. */
-long BootOsVersionNumber(const wxString &version)
-{
-	long major = 0, minor = 0;
-
-	if (!version.BeforeFirst('.').ToLong(&major) ||
-	    !version.AfterFirst('.').ToLong(&minor)) {
-		return 0;
-	}
-
-	return major * 100 + minor;
-}
-
-/**
- * Set up !Boot.Choices the way the disc's own first boot would.
- *
- * HardDisc4 ships with an empty Choices directory and fills it on first start,
- * from whichever RO<version>Hook matches the machine. Until that has happened
- * there is no desktop boot file, so the first start of a freshly unpacked disc
- * ends at the supervisor prompt with an error, and only the second start
- * reaches the desktop. That is a poor introduction for somebody who has just
- * been promised a working machine, so the same copy is done here.
- *
- * Deliberately cautious. It only acts on a disc laid out as expected with
- * Choices still empty, and picks the highest hook not above the ROM's version,
- * which is how the disc itself resolves one: RISC OS 5.31 reports 530 and uses
- * RO530Hook, there being no RO531Hook. Anything unexpected is left alone, and
- * the disc then sets itself up on first boot as it always did.
- */
-void SeedBootChoices(const wxString &hostfs_dir, const wxString &version)
-{
-	const wxString sep = wxFileName::GetPathSeparator();
-	const wxString boot_dir = hostfs_dir + sep + "!Boot";
-	const wxString choices = boot_dir + sep + "Choices";
-	const long target = BootOsVersionNumber(version);
-	wxString best_hook;
-	long best_number = -1;
-	wxString name;
-
-	if (target == 0 || !wxDirExists(boot_dir) || !wxDirExists(choices)) {
-		return;
-	}
-
-	if (!DirectoryIsEmpty(choices)) {
-		return;		/* Already set up; not ours to touch */
-	}
-
-	wxDir dir(boot_dir);
-	if (!dir.IsOpened() || !dir.GetFirst(&name, "RO*Hook", wxDIR_DIRS)) {
-		return;
-	}
-
-	do {
-		const wxString digits = name.Mid(2, name.length() - 6);
-		long number = 0;
-
-		if (!digits.ToLong(&number) || number > target ||
-		    number <= best_number) {
-			continue;
-		}
-		if (!wxDirExists(boot_dir + sep + name + sep + "Boot")) {
-			continue;
-		}
-
-		best_number = number;
-		best_hook = name;
-	} while (dir.GetNext(&name));
-
-	if (best_hook.empty()) {
-		return;
-	}
-
-	if (ConfigPathsCopyDirectory(boot_dir + sep + best_hook + sep + "Boot",
-	                             choices + sep + "Boot")) {
-		rpclog("riscos_fetch: seeded !Boot.Choices from %s\n",
-		       static_cast<const char *>(best_hook.utf8_str()));
-		return;
-	}
-
-	/* Take a half-finished copy back out again. The disc's own setup skips
-	   a Choices that is not empty, so leaving one behind would turn a
-	   recoverable failure into a machine that never configures itself. */
-	rpclog("riscos_fetch: could not seed !Boot.Choices from %s; leaving the "
-	       "disc to configure itself on first boot\n",
-	       static_cast<const char *>(best_hook.utf8_str()));
-	RemoveTree(choices + sep + "Boot");
-}
-
 /** Write the configuration for a machine built around a fetched ROM. */
 bool WriteMachineConfig(const wxString &config_path, const wxString &name,
                         const wxString &rom_name)
@@ -1183,8 +1080,6 @@ RiscosFetchOutcome RiscosFetchPerform(const RiscosFetchRequest &request,
 			outcome.cancelled = cancelled;
 			return outcome;
 		}
-
-		SeedBootChoices(staged_hostfs, version);
 
 		/* Checked here as well as before the option was offered: the
 		   download takes time, and a machine that was empty when it

--- a/src/gui/riscos_fetch.h
+++ b/src/gui/riscos_fetch.h
@@ -57,9 +57,18 @@ enum class RiscosRelease {
  *
  * A hard disc always belongs to some machine, so include_disc without
  * create_machine needs machine_name to say which.
+ *
+ * Clearing include_rom asks for the disc on its own, for a machine that has a
+ * ROM already and only wants something to boot. Nothing about the machine
+ * needs to be known to do that: the disc carries a boot sequence that works
+ * with any version, reading the one it is running on and configuring itself
+ * to match the first time it starts.
  */
 struct RiscosFetchRequest {
 	RiscosRelease release = RiscosRelease::Stable;
+
+	/** Fetch the ROM. Cleared to fetch only the hard disc. */
+	bool include_rom = true;
 
 	/** Also fetch HardDisc4 and unpack it onto the machine's HostFS. */
 	bool include_disc = true;


### PR DESCRIPTION
Two related changes to the hard disc download, in separate commits.

## 1. Give the hard disc download a button of its own (b96105b)

The machine editor offered "Also download a ready-to-use hard disc", and ticking it did nothing.

It was not a setting. It was read in one place — by the Get RISC OS button, to decide whether that download brought a disc with it. `OnOk` never looked at it, and it was not written to the machine's configuration, so it was discarded when the dialogue closed. It read as a setting because it sat among Model, RAM and VRAM, was worded as an action, and every other control on that page is applied by OK.

It is a button now, next to the ROM it will boot, downloading when pressed like the button above it.

That needed the disc to be fetchable on its own, since the ROM download was unconditional: a machine that had its ROM and nothing to boot had to fetch the ROM again to get a disc. `RiscosFetchRequest` gains `include_rom`, defaulting to true, so the first-run dialogue, the new machine dialogue and `--fetch-riscos` are unaffected.

When the offer appears is unchanged — only while the machine's hard disc is untouched, rechecked after the download, with a note when it is not.

## 2. Stop seeding !Boot.Choices (23b0d03)

After unpacking the disc, the download copied the `RO<version>Hook` matching the machine's ROM into `!Boot.Choices`, to save the disc having to do it on first boot.

The disc does not need the help. HardDisc4 carries what RISC OS Open call the universal boot sequence: it works with any version of RISC OS, and configures itself for the one it finds itself running on the first time it starts. Nothing about the machine has to be known in advance, which is why the disc is published as a single download rather than one per release.

So this removes the copying and lets the disc do what it was built to do. A disc installed this way boots straight to the desktop, and sets up its own Choices in the process — see the testing below.

`DirectoryIsEmpty()` and `BootOsVersionNumber()` go with it, having had no other callers.

## Testing

Built clean, 15/15 unit tests.

Both commits were tested together, on new machines, with both releases:

- Created new machines and let them download RISC OS 5.30 and 5.31, with no hard disc
- Used **Get hard disc...** on each, which fetched HardDisc4 without re-fetching the ROM
- Both booted to the desktop, so removing the seeding breaks nothing on either release
- The button is greyed out afterwards, the disc no longer being empty

Reaching the desktop on the first boot of a disc that was never seeded is the direct test of the second commit: the disc configured itself, as its own boot sequence is written to do.
