### PR TITLE
GUI: answer the signals a console can send

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,8 @@ built-in VNC server — useful for servers or always-on machines:
   to reach the machine. The VNC port/password come from that same config.
 - Press **Ctrl-C** (or send `SIGTERM`) to shut down cleanly — CMOS, disc images, and
   configuration are saved on exit, just as when closing the GUI window.
+- Send `SIGUSR1` to reset the machine without stopping it (see
+  [Resetting from outside](#resetting-from-outside-linux-and-macos)).
 
 Headless mode is genuinely display-less: it is handled before any GUI toolkit is
 initialised, so it needs **no display or desktop session** on any platform — on Linux
@@ -559,6 +561,20 @@ controls) are available from the menus and the toolbar instead.
 
 The toolbar provides one-click access to screenshot, floppy load, CD-ROM ISO load,
 reset, mute, full-screen, machine settings, and debugger controls.
+
+### Resetting from outside (Linux and macOS)
+
+Sending **`SIGUSR1`** resets the running machine, exactly as **Reset** on the File
+menu does, so a guest can be restarted from a script or another terminal without
+touching the window:
+
+```bash
+kill -USR1 $(pgrep rpcemu-recompiler)
+```
+
+This works whether the machine is running in the GUI or headless. If no machine is
+running — the machine selector is still open — the signal is noted in `rpclog.txt`
+and otherwise ignored. Windows has no equivalent.
 
 ---
 

--- a/src/gui/emulator_host.cpp
+++ b/src/gui/emulator_host.cpp
@@ -577,6 +577,19 @@ void EmulatorHost::Reset()
 	PostCommand(cmd);
 }
 
+void EmulatorResetForSignal(EmulatorHost *emulator)
+{
+	/* The menu asks before resetting, which a signal cannot do; past that this
+	   is the same reset. */
+	if (emulator == nullptr || !emulator->IsRunning()) {
+		rpclog("RPCEmu: SIGUSR1 received, but no machine is running\n");
+		return;
+	}
+
+	rpclog("RPCEmu: SIGUSR1 received, resetting the machine\n");
+	emulator->Reset();
+}
+
 void EmulatorHost::ReloadIdeImages()
 {
 	EmuCommand cmd;

--- a/src/gui/emulator_host.h
+++ b/src/gui/emulator_host.h
@@ -273,6 +273,16 @@ private:
 	std::atomic<bool> flyback_pending_{false};
 };
 
+/*
+ * Reset the machine on behalf of a signal, if there is one to reset.
+ *
+ * The signal means "reset" whether it arrives at the window or at a headless
+ * run, and in both cases it can turn up before a machine has been started or
+ * while one is going away. Shared so the two answer it identically, and so the
+ * log says the same thing either way.
+ */
+void EmulatorResetForSignal(EmulatorHost *emulator);
+
 extern std::atomic<int> instruction_count;
 extern std::atomic<int> iomd_timer_count;
 extern std::atomic<int> video_timer_count;

--- a/src/gui/headless_main.cpp
+++ b/src/gui/headless_main.cpp
@@ -56,16 +56,31 @@ extern "C" {
 namespace {
 
 /*
- * Set from a signal handler to request an orderly shutdown. The handler only
- * touches a sig_atomic_t (async-signal-safe); the actual teardown, which is not
- * async-safe, runs back on the main thread once it observes the flag.
+ * Set from a signal handler to request an orderly shutdown, and holding which
+ * signal asked, so the log can name it. The handler only touches a
+ * sig_atomic_t (async-signal-safe); the actual teardown, which is not
+ * async-safe, runs back on the main thread once it observes this.
  */
 volatile sig_atomic_t g_headless_stop = 0;
 
-void HeadlessSignalHandler(int /*signum*/)
+/*
+ * Counts resets asked for rather than flagging one, so two signals arriving
+ * close together are two resets and not one. The loop below subtracts what it
+ * has dealt with.
+ */
+volatile sig_atomic_t g_headless_reset = 0;
+
+void HeadlessSignalHandler(int signum)
 {
-	g_headless_stop = 1;
+	g_headless_stop = signum;
 }
+
+#ifndef _WIN32
+void HeadlessResetSignalHandler(int /*signum*/)
+{
+	g_headless_reset++;
+}
+#endif
 
 bool DirExists(const std::string &path)
 {
@@ -449,6 +464,12 @@ int RunHeadless(const char *machine_name, bool resume, const char *state_file)
 	/* Handle Ctrl-C / SIGTERM so CMOS, disc images and config are saved on exit. */
 	std::signal(SIGINT, HeadlessSignalHandler);
 	std::signal(SIGTERM, HeadlessSignalHandler);
+#ifndef _WIN32
+	/* SIGUSR1 is POSIX rather than ISO C and does not exist on Windows. Little
+	   is lost there: the emulator is linked as a GUI-subsystem binary, so it
+	   has no console attached and nothing arrives to be handled anyway. */
+	std::signal(SIGUSR1, HeadlessResetSignalHandler);
+#endif
 
 	rpcemu_start();
 
@@ -485,10 +506,31 @@ int RunHeadless(const char *machine_name, bool resume, const char *state_file)
 	   (which sets `quited`). The blocking teardown runs here, off the handler. */
 	while (g_headless_stop == 0 && quited == 0) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+		/* SIGUSR1 resets the machine rather than ending it, so it is handled
+		   here and the loop carries on. The count is taken down by what is
+		   about to be done, so a signal arriving in the meantime is not
+		   lost. */
+		const sig_atomic_t resets = g_headless_reset;
+
+		if (resets != 0) {
+			g_headless_reset -= resets;
+			EmulatorResetForSignal(emulator.get());
+		}
 	}
 
 	printf("\nRPCEmu headless: shutting down...\n");
 	fflush(stdout);
+
+	/* The console message goes to whoever is watching; this one is for whoever
+	   reads the log afterwards and needs to tell an exit that was asked for
+	   from one that was not. */
+	if (g_headless_stop != 0) {
+		rpclog("RPCEmu: %s received, shutting down\n",
+		       g_headless_stop == SIGINT ? "SIGINT" : "SIGTERM");
+	} else {
+		rpclog("RPCEmu: machine powered off, shutting down\n");
+	}
 
 	emulator->RequestExit();
 	emulator->Stop();

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -51,7 +51,101 @@ class RpcemuApp : public wxApp {
 public:
 	bool OnInit() override;
 	void OnInitCmdLine(wxCmdLineParser &parser) override;
+
+private:
+	void InstallSignalHandlers();
 };
+
+#ifndef __WXMSW__
+/*
+ * Ctrl-C, or a "please stop" from the system.
+ *
+ * Started from a terminal, the window is only half the story: the shell can
+ * still interrupt the process, and until now that killed it outright, losing
+ * the CMOS and any disc images written since the machine started. The same
+ * goes for the SIGTERM sent at logout or shutdown.
+ *
+ * Not a signal handler in the usual sense, despite the name. wxWidgets catches
+ * the signal itself, notes it, and calls this from the event loop afterwards,
+ * so it runs on the main thread with nothing to avoid - it can take locks,
+ * allocate and wait for the emulator thread, none of which a real handler
+ * could do.
+ */
+void HandleQuitSignal(int signum)
+{
+	auto *frame = dynamic_cast<MainFrame *>(wxTheApp->GetTopWindow());
+
+	/* Worth a line in the log: an exit nobody asked for looks the same as a
+	   crash afterwards, and which signal arrived says whether somebody pressed
+	   Ctrl-C or the machine was being shut down around it. */
+	rpclog("RPCEmu: %s received, shutting down\n",
+	       signum == SIGINT ? "SIGINT" : "SIGTERM");
+
+	if (frame != nullptr) {
+		frame->CloseForSignal();
+		return;
+	}
+
+	/* No machine window yet, so this is the selector or one of the dialogues
+	   that can precede it. Those run their own nested event loop, which
+	   ExitMainLoop() does not reach - the signal would be swallowed and the
+	   emulator would appear to ignore it. End the dialogue first, which
+	   unwinds that loop and lets the startup path fall through to its "no
+	   machine chosen" exit. */
+	for (auto node = wxTopLevelWindows.GetFirst(); node != nullptr;
+	     node = node->GetNext()) {
+		auto *dialog = dynamic_cast<wxDialog *>(node->GetData());
+
+		if (dialog != nullptr && dialog->IsModal()) {
+			dialog->EndModal(wxID_CANCEL);
+		}
+	}
+
+	wxTheApp->ExitMainLoop();
+}
+
+/*
+ * SIGUSR1: reset the machine, as the Reset item on the File menu does.
+ *
+ * A way to restart a guest from a script or another terminal without going
+ * near the window.
+ *
+ * Unlike the two signals above this does not end the process, so a machine
+ * that has not been started yet - the selector is still open, or the window is
+ * already closing - simply has nothing to reset, and the signal is noted and
+ * ignored rather than being allowed to kill the emulator by its default
+ * action.
+ */
+void HandleResetSignal(int /*signum*/)
+{
+	auto *frame = dynamic_cast<MainFrame *>(wxTheApp->GetTopWindow());
+
+	if (frame != nullptr) {
+		frame->ResetForSignal();
+	} else {
+		/* Selector still open, so there is no machine and nothing to do - said
+		   through the same helper so the log reads the same either way. */
+		EmulatorResetForSignal(nullptr);
+	}
+}
+#endif
+
+/*
+ * Answer the signals a console can send, on the platforms that have them.
+ *
+ * Windows has no equivalent of these two, and wxWidgets does not offer
+ * SetSignalHandler() there, so it keeps the behaviour it always had.
+ */
+void RpcemuApp::InstallSignalHandlers()
+{
+#ifndef __WXMSW__
+	if (!SetSignalHandler(SIGINT, HandleQuitSignal) ||
+	    !SetSignalHandler(SIGTERM, HandleQuitSignal) ||
+	    !SetSignalHandler(SIGUSR1, HandleResetSignal)) {
+		rpclog("main: could not install the interrupt handlers\n");
+	}
+#endif
+}
 
 /*
  * RPCEmu uses long options ("--machine") on every platform, so that a command
@@ -504,6 +598,11 @@ bool RpcemuApp::OnInit()
 	if (!wxApp::OnInit()) {
 		return false;
 	}
+
+	/* Before the selector rather than after the window, so the signals are
+	   answered for the whole life of the process. SIGUSR1 in particular kills
+	   by default, and choosing a machine is no reason to be killed. */
+	InstallSignalHandlers();
 
 	// Register image handlers (PNG etc.). wxGTK pulls these in implicitly, but
 	// wxMSW does not; without this, PNG bitmaps (toolbar icons, app icon) fail

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -1779,6 +1779,7 @@ void MainFrame::OnClose(wxCloseEvent &event)
 	// cases, so attempting it would block forever, and its state is not worth
 	// saving.
 	if (emulator_ && emulator_->IsRunning() && !fatal_occurred_ &&
+	    !closing_for_signal_ &&
 	    (config.suspend_on_exit || suspend_on_exit_requested_)) {
 		const wxString snapshot = ConfigPathsSnapshotForConfig(
 		    ConfigPathsAbsoluteConfigPath(wxString::FromUTF8(config_get_path())));
@@ -1790,6 +1791,28 @@ void MainFrame::OnClose(wxCloseEvent &event)
 	ShutdownEmulator();
 	shutting_down_ = true;
 	Destroy();
+}
+
+void MainFrame::CloseForSignal()
+{
+	if (shutting_down_) {
+		return;
+	}
+
+	closing_for_signal_ = true;
+
+	/* Close() rather than Destroy(), so the machine is taken down by the same
+	   OnClose() the window's own close button uses - the snapshot being the
+	   only part it skips. Forced, because a signal is not a request the window
+	   may decline. */
+	Close(true);
+}
+
+void MainFrame::ResetForSignal()
+{
+	/* Nothing to reset once the window is on its way out, whatever the
+	   emulator still looks like. */
+	EmulatorResetForSignal(shutting_down_ ? nullptr : emulator_.get());
 }
 
 void MainFrame::ShutdownEmulator()

--- a/src/gui/main_frame.h
+++ b/src/gui/main_frame.h
@@ -147,6 +147,15 @@ public:
 	void StartEmulator();
 	void UpdateMachineStatus();
 
+	/* Shut down because the process was signalled. Saves what a machine would
+	   not want to lose and closes, without writing a snapshot - see
+	   closing_for_signal_. */
+	void CloseForSignal();
+
+	/* Reset the running machine because the process was signalled. Does
+	   nothing when no machine is running, there being nothing to reset. */
+	void ResetForSignal();
+
 	bool IsWindowActive() const { return window_active_; }
 	bool IsFullScreen() const { return full_screen_; }
 
@@ -307,6 +316,12 @@ private:
 
 	bool shutting_down_ = false;
 	bool suspend_on_exit_requested_ = false;
+	/* Set when the window is closing because the process was signalled rather
+	   than because the user asked. A signal is a way out in a hurry, so the
+	   close it triggers saves what would otherwise be lost - CMOS, disc images,
+	   the configuration - and skips the machine snapshot, which can run to
+	   hundreds of megabytes and may not finish before the process is killed. */
+	bool closing_for_signal_ = false;
 	/* Set as soon as a fatal error is raised (possibly from the emulator
 	   thread, which then spins forever and can no longer service commands).
 	   Guards the save-on-exit so it never blocks trying to snapshot a machine


### PR DESCRIPTION
Linux and macOS only. Windows has neither of these signals, and wxWidgets does not offer `SetSignalHandler()` there, so it is unchanged.

## The problem

Started from a terminal, the GUI answered no signals at all. Ctrl-C killed the process outright, taking the CMOS and any disc images written since the machine started with it, and the same went for the SIGTERM sent at logout or shutdown. Headless has handled both since it was written.

## SIGINT and SIGTERM

The window now shuts down the way the close button already does, so there is a single path down: the machine is asked to stop, and the emulator thread saves CMOS, disc images and configuration as it exits.

The machine snapshot is the exception. A signal is a way out in a hurry and a snapshot runs to hundreds of megabytes, so "Suspend on exit" is skipped when the close came from a signal — matching what headless has always done — and honoured as before when somebody closes the window themselves.

Handlers go on before the machine selector rather than after the window, so a signal is answered for the whole life of the process. A modal dialogue is ended first: the selector runs its own event loop, which `ExitMainLoop()` does not reach.

## SIGUSR1

Resets the running machine, exactly as **Reset** on the File menu does, in both the window and headless — a way to restart a guest from a script or another terminal:

```bash
kill -USR1 $(pgrep rpcemu-recompiler)
```

Nothing is reset if no machine is running, and the signal is noted in `rpclog.txt` instead. Headless counts them, so two arriving together are two resets. The reset itself is shared between the two paths so they cannot answer it differently.

SIGHUP is deliberately left alone, keeping its default action, so a terminal genuinely going away still ends the process rather than resetting a guest and orphaning it.

## Implementation note

The GUI uses wxWidgets' `SetSignalHandler()` rather than `signal(2)`: it catches the signal itself and calls back from the event loop, so the handler runs on the main thread and can take locks and wait for the emulator thread, which a real signal handler could not. Headless has no event loop to be called from and keeps the `signal(2)` and polling loop it already had.

## Testing

Built clean, 15/15 unit tests.

Exercised on Linux: Ctrl-C and SIGTERM shut a running machine down cleanly, and with the selector open rather than a machine. SIGUSR1 resets a running machine, and is ignored with no machine running. SIGHUP still terminates.

macOS is not tested directly. The path is the same, and `SetSignalHandler()` is portable to it: `wx/unix/app.h` is used there, its implementation has no platform conditionals, and the wake-up pipe it registers reaches the run loop through `wxCFEventLoopSourcesManager`.
