### PR TITLE
Ignore the configurations and ROMs a run leaves behind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,15 @@
 !/machines/README.txt
 /shared/
 
+# Machine configurations and ROM images, for the same reason: a machine is made
+# by the person running the emulator, and the ROM is downloaded from RISC OS
+# Open rather than shipped. Both directories are packaged from whatever is on
+# disk, so ignoring their contents costs a local build nothing.
+/configs/*
+!/configs/README.txt
+/roms/*
+!/roms/roms.txt
+
 # Legacy single-machine state (CMOS now lives under machines/<name>/)
 /cmos.ram
 /rpc.cfg


### PR DESCRIPTION
`machines/` is already git ignored, because what is under it is made by whoever runs the emulator rather than being source. `configs/` and `roms/` are the same kind of directory and were not: a machine's configuration is written by the machine editor, and its ROM is downloaded from RISC OS Open. Neither belongs in the repository, and a ROM is four megabytes.

Same shape as the existing rule, so the note and the ROM list that keep the directories in a checkout stay tracked:

```
/configs/*
!/configs/README.txt
/roms/*
!/roms/roms.txt
```
