### PR TITLE
README: say how to open the macOS app on every release

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,14 +155,38 @@ else to install. Windows 10/11 (x64). Built with MinGW-w64 via MSYS2 — see
 a universal app (Intel and Apple Silicon); on Apple Silicon the Intel slice runs at full
 speed under Rosetta 2.
 
-The app is ad-hoc signed but not notarised by Apple, so the first launch is blocked with
-"RPCEmu cannot be opened because the developer cannot be verified". To open it the first
-time only: **right-click (or Control-click) the app, choose Open, then Open again** in the
-dialog. macOS remembers the choice and launches it normally thereafter. (On Sequoia and
-later, if Open is not offered, go to **System Settings > Privacy & Security** and click
-**Open Anyway**.) Nothing needs to be installed alongside it. As on Linux, machines,
-configs, ROMs, HostFS and logs are written to a visible **`~/RPCEmu/`** folder, never
-inside the app bundle, so the app stays read-only in Applications.
+Nothing needs to be installed alongside it. As on Linux, machines, configs, ROMs, HostFS
+and logs are written to a visible **`~/RPCEmu/`** folder, never inside the app bundle, so
+the app stays read-only in Applications.
+
+#### First launch is blocked — how to open it
+
+RPCEmu is not notarised by Apple, so the first launch is refused with *"RPCEmu cannot be
+opened because the developer cannot be verified"* or *"Apple could not verify RPCEmu is
+free of malware"*. This only has to be dealt with once — afterwards it opens by
+double-clicking like anything else.
+
+**macOS 15 Sequoia and macOS 26 Tahoe.** Control-clicking no longer offers a way past
+this. Try to open the app and dismiss the message, then go to **System Settings >
+Privacy & Security**, scroll to **Security**, and click **Open Anyway** beside the note
+about RPCEmu. Confirm with **Open**, authenticating if asked. The button only appears for
+about an hour after the blocked launch, so if it is not there, try opening the app again
+first.
+
+**macOS 14 Sonoma and earlier.** **Control-click (or right-click) the app, choose Open,
+then Open again** in the dialog. If Open is not offered, use **System Settings** (or
+**System Preferences**) **> Privacy & Security**, or **Security & Privacy > General** on
+older releases, and click **Open Anyway**.
+
+**If neither works**, macOS has quarantined the download more firmly than the dialogs can
+clear. Remove the flag from Terminal, which works on every version:
+
+```bash
+xattr -d com.apple.quarantine /Applications/RPCEmu.app
+```
+
+Then open the app normally. There is no need to change the "Allow applications from"
+setting to do any of this.
 
 ### Install the `.deb`
 
@@ -228,8 +252,9 @@ slice, then fuse and package:
 The app bundle keeps its read-only payload in `Contents/Resources` and seeds writable data
 into `~/RPCEmu` on first run. The `.icns` icon is built from `resources/rpcemu.png` with
 `iconutil`, and the app is ad-hoc signed (Apple Silicon will not run an unsigned binary);
-without an Apple Developer ID it is not notarised, so first launch needs a right-click >
-Open. On a single machine each slice is built for its own architecture (the other builds
+without an Apple Developer ID it is not notarised, so the first launch has to be allowed
+past Gatekeeper (see [First launch is blocked](#first-launch-is-blocked-how-to-open-it)).
+On a single machine each slice is built for its own architecture (the other builds
 under Rosetta); the `macos-x86_64`, `macos-arm64`, and `macos-universal` CI jobs do exactly
 this and fuse the result.
 

--- a/docs/macos-build.md
+++ b/docs/macos-build.md
@@ -66,11 +66,13 @@ worth the effort for the unverified path); the native/CI build keeps them.
 
 - The release is an **ad-hoc signed `RPCEmu.app`** in a `.dmg`, but it is **not
   notarised** — notarisation needs a paid Apple Developer ID, which the project
-  does not have. Gatekeeper therefore warns on first launch and the user must
-  right-click > Open once (documented in the README). Assembly, signing and the
-  DMG all happen in `build-macos.sh`; wire in `notarytool` + `stapler` there and
-  in the `macos-universal` CI job (behind repository secrets) if a Developer ID
-  becomes available.
+  does not have. Gatekeeper therefore refuses the first launch, and how the user
+  gets past it depends on the release: Control-click > Open up to Sonoma, and
+  System Settings > Privacy & Security > Open Anyway on Sequoia and Tahoe, where
+  the Control-click route was removed. Both are documented in the README.
+  Assembly, signing and the DMG all happen in `build-macos.sh`; wire in
+  `notarytool` + `stapler` there and in the `macos-universal` CI job (behind
+  repository secrets) if a Developer ID becomes available.
 - The `.icns` icon is generated from `resources/rpcemu.png`, which is only
   256×256; the 512/1024 icon variants are upscaled. Supply a 1024×1024 master for
   crisp Retina rendering.


### PR DESCRIPTION
Documentation only.

The README told macOS users to Control-click and choose Open. In #52 somebody on Monterey did exactly that, was still refused, and ended up setting "Allow apps downloaded from" to **App Store** — which is not needed and leaves the machine more restricted than before. The instructions were not so much wrong as incomplete, and the gap pushed someone towards a worse workaround.

## What changed

The route past Gatekeeper depends on the macOS release, so both are now written out.

**Sequoia (15) and Tahoe (26)** removed the Control-click override entirely, leaving **System Settings > Privacy & Security > Open Anyway**. That button lapses about an hour after the blocked launch, which is worth stating: an absent button otherwise reads as the instructions being wrong.

**Sonoma (14) and earlier** keep Control-click > Open, with the older **Security & Privacy > General** wording noted for the releases that use it.

Also added the `xattr -d com.apple.quarantine` fallback for when neither dialog clears the quarantine, and said outright that the "Allow applications from" setting does not need touching.

`docs/macos-build.md` described only the old route in its note about not being notarised; it now mentions both. The same stale advice in the README's build section links to the user-facing section rather than repeating it.

## Sources

- [Sequoia removes the Gatekeeper contextual menu override](https://mjtsai.com/blog/2024/07/05/sequoia-removes-gatekeeper-contextual-menu-override/) and [iDownloadBlog](https://www.idownloadblog.com/2024/08/07/apple-macos-sequoia-gatekeeper-change-install-unsigned-apps-mac/) — the Control-click route is gone from 15 onwards
- [Sweetwater](https://www.sweetwater.com/sweetcare/articles/macos-security-warnings-and-gatekeeper-de-mystified/) — Tahoe 26 behaves as Sequoia does
- [Macworld](https://www.macworld.com/article/672947/how-to-open-a-mac-app-from-an-unidentified-developer.html) — the one-hour window on Open Anyway
- [Homebrew#17979](https://github.com/Homebrew/brew/issues/17979) — `xattr -d com.apple.quarantine` still works on current macOS

## Testing

None of this is tested on a Mac — neither of us has one to hand. It is written from the reports in #52 and the sources above, so the exact wording of the System Settings panes on Sequoia and Tahoe, and the one-hour window, are worth confirming by somebody who can.

Notarisation would remove the need for any of this, and is tracked separately.
