### PR TITLE
Headless: imply VNC rather than refusing to start without it

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,9 +454,18 @@ built-in VNC server — useful for servers or always-on machines:
   back up from a snapshot — useful when a service manager restarts it.
 - `--list-machines` prints the available machine names and exits.
 - `--help` (or `-h`) prints usage and exits. All three of these run without a display.
-- The chosen machine **must have the VNC server enabled** (`vnc_enabled=1`) in its
-  configuration; headless mode refuses to start otherwise, as there would be no way
-  to reach the machine. The VNC port/password come from that same config.
+- VNC is the only way into a headless machine, so `--headless` **implies it**: the
+  server is started for the session even if the machine has `vnc_enabled=0`. The
+  machine's own setting is your choice and is left alone — the config file is not
+  rewritten, so running headless once does not enable VNC for the GUI afterwards.
+  The port and password come from that same config (port defaulting to 5900). A
+  machine that has never enabled VNC will not have a password set, so set one if
+  the port is reachable from anywhere untrusted; headless says so at startup.
+- **Running more than one machine at once needs a different `vnc_port` for each.**
+  Ports are not allocated automatically and every machine defaults to 5900, so a
+  second machine left at the default cannot bind and exits with an error rather
+  than starting unreachable. The port and password can also be changed while a
+  machine is running from **Settings > VNC Server** in the GUI.
 - Press **Ctrl-C** (or send `SIGTERM`) to shut down cleanly — CMOS, disc images, and
   configuration are saved on exit, just as when closing the GUI window.
 - Send `SIGUSR1` to reset the machine without stopping it (see
@@ -486,6 +495,7 @@ Each machine is defined by a `.cfg` file in `configs/` and a data directory unde
 | **Refresh rate** | 20–100 Hz |
 | **Network** | Off, NAT, Ethernet Bridging, IP Tunnelling |
 | **Hard discs** | HardDisc 4 and 5 — create 256 MB, 512 MB, 1 GB, or 2 GB images |
+| **VNC server** | On/off, port (default 5900) and password — see [Settings > VNC Server](#headless-mode). Give each machine its own port if you run more than one at a time |
 
 Configuration keys are stored under a `[General]` group (wxFileConfig INI format).
 NAT port-forward rules are stored in a separate `[nat_port_forward_rules]` group.

--- a/src/gui/headless_main.cpp
+++ b/src/gui/headless_main.cpp
@@ -294,9 +294,11 @@ void HeadlessPrintUsage(const char *argv0)
 	    "                        The file is left in place. Requires --machine, and\n"
 	    "                        cannot be combined with --resume.\n"
 	    "  --headless            Run a machine without the GUI window; access it\n"
-	    "                        over the built-in VNC server. Requires --machine\n"
-	    "                        and a machine config with VNC enabled. Needs no\n"
-	    "                        display or desktop session on any platform.\n"
+	    "                        over the built-in VNC server, which is started for\n"
+	    "                        the session even if the machine has VNC disabled\n"
+	    "                        (its configuration is left unchanged). Requires\n"
+	    "                        --machine. Needs no display or desktop session on\n"
+	    "                        any platform.\n"
 	    "  --list-machines       List available machine configs and exit.\n"
 	    "  --fetch-riscos[=which]\n"
 	    "                        Download RISC OS from RISC OS Open, unpack it and\n"
@@ -434,15 +436,14 @@ int RunHeadless(const char *machine_name, bool resume, const char *state_file)
 		state_to_load = state_file;
 	}
 
-	/* The whole point of headless mode is VNC access, so refuse to start a
-	   machine that has no way to be reached. */
-	if (!config.vnc_enabled) {
-		fprintf(stderr, "error: machine '%s' has the VNC server disabled.\n", config.name);
-		fprintf(stderr,
-		        "       Headless mode is only reachable over VNC. Enable the VNC server\n"
-		        "       in this machine's configuration (vnc_enabled=1) and try again.\n");
-		return 1;
-	}
+	/* VNC is the only way into a headless machine, so --headless implies it
+	   whatever the machine's own setting says. That setting is left exactly as
+	   the user wrote it: config.vnc_enabled is deliberately not touched here,
+	   because endrpcemu() calls config_save() on the way out and would write an
+	   implied enable back into the config file. Nothing below reads the flag -
+	   VncServer::start() is driven by its arguments - so passing the port and
+	   password straight in starts the server without disturbing the config. */
+	const bool vnc_implied = !config.vnc_enabled;
 
 	HeadlessBridge bridge;
 	auto emulator = std::make_unique<EmulatorHost>(&bridge);
@@ -451,6 +452,10 @@ int RunHeadless(const char *machine_name, bool resume, const char *state_file)
 	g_vnc_server = vnc.get();
 	if (!vnc->start(config.vnc_port, std::string(config.vnc_password))) {
 		fprintf(stderr, "error: failed to start the VNC server on port %d.\n", config.vnc_port);
+		fprintf(stderr,
+		        "       The port is most likely already in use - each machine needs its\n"
+		        "       own vnc_port, and machines that have never had VNC enabled all\n"
+		        "       default to 5900. Set a different port for this machine.\n");
 		g_vnc_server = nullptr;
 		return 1;
 	}
@@ -458,6 +463,14 @@ int RunHeadless(const char *machine_name, bool resume, const char *state_file)
 	printf("RPCEmu headless: machine '%s' running.\n", config.name);
 	printf("VNC server listening on port %d%s.\n", config.vnc_port,
 	       config.vnc_password[0] == '\0' ? " (no password set)" : "");
+	if (vnc_implied) {
+		printf("This machine has the VNC server disabled; --headless has started it\n"
+		       "for this session only. The machine's configuration is unchanged.\n");
+		if (config.vnc_password[0] == '\0') {
+			printf("No password is set, so anyone who can reach port %d can use it.\n",
+			       config.vnc_port);
+		}
+	}
 	printf("Press Ctrl-C to shut down.\n");
 	fflush(stdout);
 

--- a/src/gui/vnc_server.cpp
+++ b/src/gui/vnc_server.cpp
@@ -93,11 +93,26 @@ void VncServer::copyFrameLines(const uint32_t *buffer, int width, int start_y, i
 
 bool VncServer::start(int port, const std::string &password)
 {
-	std::lock_guard<std::mutex> lock(mutex_);
+	bool restart_needed;
 
-	if (running_) {
-		return true;
+	{
+		std::lock_guard<std::mutex> lock(mutex_);
+
+		if (running_ && listen_port_ == port && current_password_ == password) {
+			return true;
+		}
+		restart_needed = running_;
 	}
+
+	/* Settings > VNC Server can change the port or password while the server is
+	   running. Returning early in that case would leave it listening on the old
+	   port with the old password while the config claimed otherwise, so rebind
+	   instead. stop() takes the lock itself, hence the scoped block above. */
+	if (restart_needed) {
+		stop();
+	}
+
+	std::lock_guard<std::mutex> lock(mutex_);
 
 	current_password_ = password;
 	password_list_[0] = nullptr;
@@ -141,6 +156,26 @@ bool VncServer::start(int port, const std::string &password)
 	}
 
 	rfbInitServer(rfb_screen_);
+
+	/* rfbInitServer() returns void and leaves socketState at READY even when the
+	   port was taken, so that field cannot be used to detect a clash. What does
+	   distinguish the two is the listening sockets: a server that bound has at
+	   least one valid descriptor, while one that lost the port has both set to
+	   -1. Checking here means a second machine on the same port fails loudly
+	   rather than reporting success and never accepting a connection. */
+	if (rfb_screen_->listenSock < 0 && rfb_screen_->listen6Sock < 0) {
+		rpclog("VNC: could not listen on port %d (is it already in use?)\n", port);
+		free(rfb_screen_->frameBuffer); /* freed here, as stop() does, not by the library */
+		rfb_screen_->frameBuffer = nullptr;
+		rfbScreenCleanup(rfb_screen_);
+		rfb_screen_ = nullptr;
+		if (password_list_[0] != nullptr) {
+			free(password_list_[0]);
+			password_list_[0] = nullptr;
+		}
+		return false;
+	}
+
 	listen_port_ = port;
 	running_ = true;
 	event_thread_ = std::thread([this]() { eventLoop(); });

--- a/tests/vnc_smoke.py
+++ b/tests/vnc_smoke.py
@@ -225,9 +225,10 @@ def make_test_config(dst_cfg: str, name: str, port: int) -> None:
     install. Stating the settings here also means the test says what it is
     testing against instead of inheriting whatever a default happened to be.
 
-    VNC has to be on - headless mode refuses to start without it - and the
-    "name" field matters as much as the filename, because config_load() derives
-    the machine data directory from it.
+    VNC is set explicitly rather than relied on: --headless would start the
+    server anyway, but this test connects to a known port with no password, so
+    it states all three. The "name" field matters as much as the filename,
+    because config_load() derives the machine data directory from it.
     """
     with open(dst_cfg, "w", encoding="utf-8") as f:
         f.write(
@@ -264,6 +265,47 @@ def seed_boot_file(hostfs: str) -> None:
         f.write("Desktop\n")
 
 
+def port_is_free(host: str, port: int) -> bool:
+    """Is `port` bindable on both IP families the emulator listens on?
+
+    VncServer sets rfb_screen_->port and ->ipv6port to the same number and only
+    gives up when *both* fail, so a port where just one family is taken would
+    start a server that is half-reachable. Probing both keeps the port we hand
+    over honest. SO_REUSEADDR matches what the server does, so a socket left in
+    TIME_WAIT is not mistaken for a live listener.
+    """
+    for family, addr in ((socket.AF_INET, host), (socket.AF_INET6, "::1")):
+        try:
+            with socket.socket(family, socket.SOCK_STREAM) as s:
+                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                s.bind((addr, port))
+        except OSError:
+            return False
+    return True
+
+
+def pick_free_port(host: str, preferred: int) -> int:
+    """Find a free VNC port, starting with the one asked for.
+
+    Ports are not allocated automatically by the emulator: every machine
+    defaults to 5900, so a CI runner (or a developer) with anything already on
+    that port would otherwise see the emulator exit and the test blame the boot.
+    Scanning upwards from the default keeps the usual run on the usual port and
+    only moves when it has to.
+
+    The range deliberately sits below the ephemeral range (32768+ on Linux), so
+    the port cannot be snatched by an unrelated outbound connection between this
+    check and the emulator binding it. That is also why binding to port 0 is not
+    used: it returns an ephemeral port with exactly that race.
+    """
+    for port in range(preferred, preferred + 64):
+        if port_is_free(host, port):
+            return port
+    raise SmokeError(
+        f"no free port found in {preferred}-{preferred + 63} for the VNC server"
+    )
+
+
 def wait_for_port(host: str, port: int, proc: subprocess.Popen, timeout: float) -> None:
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -280,7 +322,9 @@ def wait_for_port(host: str, port: int, proc: subprocess.Popen, timeout: float) 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--binary", required=True, help="emulator to run")
-    ap.add_argument("--port", type=int, default=5900, help="VNC port to use")
+    ap.add_argument("--port", type=int, default=5900,
+                    help="first VNC port to try; the next free port upwards is "
+                         "used if it is taken (default 5900)")
     ap.add_argument("--host", default="127.0.0.1")
     ap.add_argument("--boot-timeout", type=float, default=60.0,
                     help="seconds to wait for the VNC server to come up "
@@ -334,9 +378,15 @@ def main() -> int:
               file=sys.stderr)
         return 1
 
+    # Settle on the port before writing the config: the config and the client
+    # below must agree, and the emulator has no way to report a port it chose.
+    port = pick_free_port(args.host, args.port)
+    if port != args.port:
+        print(f"==> port {args.port} is in use; using {port} instead", flush=True)
+
     test_name = "vncsmoke"
     test_cfg = os.path.join(configs, f"{test_name}.cfg")
-    make_test_config(test_cfg, test_name, args.port)
+    make_test_config(test_cfg, test_name, port)
 
     # The machine directory is keyed by the config's "name" field, which
     # make_test_config() has just set to test_name, so the test gets a directory
@@ -371,14 +421,14 @@ def main() -> int:
 
     rc = 1
     try:
-        wait_for_port(args.host, args.port, proc, args.boot_timeout)
-        print(f"==> VNC accepted on {args.host}:{args.port}; "
+        wait_for_port(args.host, port, proc, args.boot_timeout)
+        print(f"==> VNC accepted on {args.host}:{port}; "
               f"letting RISC OS settle for {args.settle:.0f}s", flush=True)
         # The server accepts as soon as it is listening, which is well before
         # the desktop is drawn. Give the guest time to get there.
         time.sleep(args.settle)
 
-        w, h, fb = vnc_capture(args.host, args.port)
+        w, h, fb = vnc_capture(args.host, port)
         if args.save:
             with open(args.save, "wb") as f:
                 f.write(encode_png(w, h, fb))

--- a/tools/mcp/README.md
+++ b/tools/mcp/README.md
@@ -79,8 +79,12 @@ CPU (directly, or via a breakpoint/watchpoint hit) freezes the whole machine
 - The MCP Python SDK: `pip install -r requirements.txt` (installs `mcp[cli]`).
 - A running RPCEmu machine with **HostCmd enabled** (on by default) and, for the
   screen/input tools, the **VNC server enabled** (`vnc_enabled=1` in the
-  machine's `.cfg`). Headless mode already requires VNC, so a `--headless`
-  machine works out of the box.
+  machine's `.cfg`). A `--headless` machine works out of the box: headless
+  implies VNC and starts the server whatever that setting says.
+- The screen/input tools only speak **passwordless VNC**, so leave `vnc_password`
+  empty on a machine you drive from here. Set `RPCEMU_VNC_PORT` to match the
+  machine's `vnc_port` when it is not the 5900 default — each machine needs its
+  own port, so this matters as soon as you run more than one.
 
 ## Configuration (environment variables)
 


### PR DESCRIPTION
`--headless` refused to start a machine whose config had the VNC server disabled. VNC is the only way into a headless machine, so the setting is better read as implied by `--headless` than as a precondition for it.

## Headless implies VNC (6fd9415)

The machine's own setting stays the user's choice and is left alone. `config.vnc_enabled` is deliberately not touched: `endrpcemu()` calls `config_save()` on the way out, so setting it would write the implied enable back into the config file and turn VNC on for the GUI too. Nothing below the old check reads the flag — `VncServer::start()` is driven by its arguments — so the port and password are passed straight in.

Startup says when VNC was implied, and separately when no password is set, which a machine that never enabled VNC will not have.

## Port clashes were silent (a245975)

Ports are not allocated automatically: every machine defaults to 5900, so two at once need a different `vnc_port` for each. That mattered less when a machine had to opt into VNC, and more now.

It was also failing silently. `rfbInitServer()` returns void, and `start()` took that as success, setting `running_` and returning true whether or not the port had been bound — so the second machine reported "listening on port 5900" and then accepted nothing. `socketState` is no help, staying `READY` when the bind failed, but the listening sockets are: both are `-1` when the port was lost. Checking those makes it fail with a message naming the cause.

Same commit fixes a related case: Settings > VNC Server can change the port or password while the server is running, but `start()` returned early when already running, so the new port went into the config while the server carried on listening on the old one. It now rebinds.

## Test (07c90fc)

`vnc_smoke.py` wrote 5900 into its config, so anything already on that port made the emulator exit and the test blame the boot. It now scans upwards for a free port, staying on 5900 unless it has to move.

## Testing

CI is green on all four platforms. On Linux: a machine with `vnc_enabled=0` starts and is reachable, and the config file is byte-identical afterwards; a second machine on the same port exits 1 with the new message; a non-default `vnc_port` is honoured. The smoke test passes both with 5900 free and with it deliberately occupied.

Tested VNC rebind by connecting to a machine over VNC, and with the machine running changing the VNC port (Settings > VNC Server). Reconnected VNC on the new port without having to restart emulator.