### PR TITLE
chore: Ignore Package Manager cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@
 /roms/*
 !/roms/roms.txt
 
+# Package Manager cache
+/pkgcache/
+
 # Legacy single-machine state (CMOS now lives under machines/<name>/)
 /cmos.ram
 /rpc.cfg


### PR DESCRIPTION
During development and testing locally, `pkgcache/` gets created.

Add this to `.gitignore` to avoid it being committed.