### PR TITLE
rpcemu-shell: fix the exit key on Windows, and tidy the greeting

### DIFF
--- a/src/hostcmd.c
+++ b/src/hostcmd.c
@@ -831,12 +831,16 @@ hostcmd_poll(void)
 			int c = accept(hc.listen_fd, NULL, NULL);
 
 			if (c >= 0) {
+				char greeting[320];	/* over the 288 a full name needs */
+
 				hc_set_nonblock(c);
 				hc.client_fd = c;
 				hc.in_len = 0;
 				hc.in_overflow = 0;
 				hc.out_head = hc.out_tail = 0;
-				hc_notice("RPCEmu HostCmd v1\n");
+				snprintf(greeting, sizeof(greeting),
+				    "RPCEmu HostCmd v1 (running on %s)\n", config.name);
+				hc_notice(greeting);
 			}
 		}
 		return;

--- a/src/tools/rpcemu_run.c
+++ b/src/tools/rpcemu_run.c
@@ -335,7 +335,14 @@ main(int argc, char **argv)
 	{
 		char line[1024];
 
+		/* End-of-file is Ctrl-D on Unix but Ctrl-Z (then Return) on Windows,
+		   where Ctrl-D is not EOF at all - it just enters ASCII 4, which would
+		   be sent to the guest as a command. Name the key that works here. */
+#ifdef _WIN32
+		fprintf(stderr, "rpcemu-shell: connected. Ctrl-Z then Return to exit.\n");
+#else
 		fprintf(stderr, "rpcemu-shell: connected. Ctrl-D to exit.\n");
+#endif
 		for (;;) {
 			int rc;
 

--- a/src/tools/rpcemu_run.c
+++ b/src/tools/rpcemu_run.c
@@ -154,6 +154,56 @@ read_exact(int fd, void *buf, size_t n)
 }
 
 /*
+ * Print any frames the server has already sent, without waiting for more.
+ *
+ * The server greets a new client with a notice, but nothing reads the socket
+ * until a command is sent, so the greeting used to appear interleaved with the
+ * first command's output - or never at all, if the user quit without running
+ * one. Draining here puts it above the first prompt, where it belongs.
+ *
+ * Only whole frames that have already arrived are consumed: the loop stops as
+ * soon as the socket has nothing more to offer, so it cannot block waiting for
+ * a frame that is not coming.
+ */
+static void
+drain_pending(int fd)
+{
+	for (;;) {
+		struct pollfd pfd;
+		uint8_t hdr[5];
+		uint32_t len;
+
+		pfd.fd = fd;
+		pfd.events = POLLIN;
+		pfd.revents = 0;
+		if (poll(&pfd, 1, 0) <= 0 || !(pfd.revents & POLLIN)) {
+			return;
+		}
+		if (read_exact(fd, hdr, 5) != 0) {
+			return;
+		}
+		len = ((uint32_t) hdr[1] << 24) | ((uint32_t) hdr[2] << 16) |
+		      ((uint32_t) hdr[3] << 8) | hdr[4];
+
+		{
+			FILE *out = (hdr[0] == 'O') ? stdout : stderr;
+			uint8_t buf[4096];
+
+			while (len > 0) {
+				size_t chunk = (len < sizeof(buf)) ? len : sizeof(buf);
+
+				if (read_exact(fd, buf, chunk) != 0) {
+					return;
+				}
+				fwrite(buf, 1, chunk, out);
+				len -= (uint32_t) chunk;
+			}
+			fflush(out);
+		}
+	}
+}
+
+/*
  * Send a command line and stream the response until the 'D' frame.
  * Returns the guest return code, or -1 on a connection error.
  */
@@ -343,6 +393,20 @@ main(int argc, char **argv)
 #else
 		fprintf(stderr, "rpcemu-shell: connected. Ctrl-D to exit.\n");
 #endif
+		/* The server's greeting is on its way but has not necessarily landed
+		   yet, so wait briefly for it rather than printing the first prompt
+		   above it. Nothing is lost if it does not arrive in time: the next
+		   command's read picks it up, which is what used to happen anyway. */
+		{
+			struct pollfd pfd;
+
+			pfd.fd = fd;
+			pfd.events = POLLIN;
+			pfd.revents = 0;
+			poll(&pfd, 1, 250);
+		}
+		drain_pending(fd);
+
 		for (;;) {
 			int rc;
 


### PR DESCRIPTION
Three things noticed while using `rpcemu-shell`.

## Ctrl-D does nothing on Windows (1855e53)

The shell tells everyone to press Ctrl-D to exit. That is EOF on Unix, but on Windows it is not EOF at all - it enters ASCII 4, so `fgets()` returns a line holding that character and the shell sends it to the guest as a command. The advice did the wrong thing on the platform it was read on.

Windows uses Ctrl-Z followed by Return, so it says that there.

## The greeting arrived after the first command (216e25e)

The server sends a notice as soon as it accepts a client, but nothing in `rpcemu-run` reads the socket until a command has been sent. In the shell that put the greeting in the middle of the first command's output, and dropped it entirely for anyone who quit without running one.

It now reads whatever has already arrived after connecting, before the prompt. The wait is bounded and short - the greeting is normally there already - and if it somehow has not landed, the next command picks it up as it always did. One-shot `rpcemu-run` is unchanged: it sends immediately, so the greeting was already being read with the reply.

## The greeting does not say which machine (e07e53a)

Somebody running more than one machine had no way to tell which a shell was attached to. The emulator knows, so it says:

```
rpcemu-shell: connected. Ctrl-D to exit.
RPCEmu HostCmd v1 (running on Test1)
*
```

## Testing

Tested on Linux and Windows.
