### PR TITLE
Full-screen mode: the exit key, what the interface claims, and associated bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,7 +735,7 @@ controls) are available from the menus and the toolbar instead.
 
 | Key | Action |
 | --- | --- |
-| **Ctrl+End** | Release the captured mouse, or exit full-screen |
+| **Alt+Enter** | Release the captured mouse, or exit full-screen |
 
 The toolbar provides one-click access to screenshot, floppy load, CD-ROM ISO load,
 reset, mute, full-screen, machine settings, and debugger controls.

--- a/src/gui/input_helpers.cpp
+++ b/src/gui/input_helpers.cpp
@@ -218,13 +218,9 @@ unsigned InputNativeScancodeFromKeyEvent(const wxKeyEvent &event)
 
 bool InputIsReleaseMouseCaptureKey(const wxKeyEvent &event)
 {
-	/* Only Ctrl+End releases the mouse / exits full-screen, so that Esc itself
-	 * passes through to RISC OS as a normal key. */
+	/* Alt+Enter, as DOSBox uses. Alt and Option are the same physical key, so
+	   the shortcut is the same on every platform. */
 	const int key_code = event.GetKeyCode();
-	if ((key_code == WXK_END || key_code == WXK_NUMPAD_END) &&
-	    (event.GetModifiers() & wxMOD_CONTROL)) {
-		return true;
-	}
-
-	return false;
+	return (key_code == WXK_RETURN || key_code == WXK_NUMPAD_ENTER) &&
+	       (event.GetModifiers() & wxMOD_ALT) != 0;
 }

--- a/src/gui/machine_edit_dialog.cpp
+++ b/src/gui/machine_edit_dialog.cpp
@@ -220,7 +220,7 @@ wxWindow *MachineEditDialog::BuildSystemPage(wxWindow *parent)
 	fullscreen_check_ = new wxCheckBox(page, wxID_ANY, "Start this machine full screen");
 	fullscreen_check_->SetToolTip(
 	    "Go full screen as soon as this machine starts, rather than opening a "
-	    "window first. Press Ctrl+End or use Settings > Full Screen to leave it.");
+	    "window first. Press Alt+Enter or use Settings > Full Screen to leave it.");
 	default_machine_check_ = new wxCheckBox(page, wxID_ANY,
 	    "Open this machine automatically at startup");
 	default_machine_check_->SetToolTip(

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -1526,8 +1526,9 @@ void MainFrame::ProcessEmulatorKeyEvent(wxKeyEvent &event, bool key_down)
 		if (panel_ != nullptr && !config_copy_.mousehackon && mouse_captured) {
 			panel_->ReleaseMouseCapture();
 			UpdateMachineStatus();
+			return;
 		}
-		return;
+		/* Nothing to escape from, so the guest gets the key. */
 	}
 
 	if (key_code == WXK_MENU) {

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -307,7 +307,7 @@ void MainFrame::UpdateMachineStatus()
 	wxString status = wxString::Format("Machine: %s", wxString::FromUTF8(config_copy_.name));
 	if (!config_copy_.mousehackon) {
 		if (mouse_captured) {
-			status += " - Press Ctrl+End to release mouse";
+			status += " - Press Alt+Enter to release mouse";
 		} else {
 			status += " - Click to capture mouse";
 		}
@@ -778,7 +778,7 @@ void MainFrame::EnterFullScreen()
 		   means what it says. */
 		wxRichMessageDialog dlg(this,
 		                        "This window will now be switched to full-screen mode.\n\n"
-		                        "To leave full-screen mode press Ctrl+End.",
+		                        "To leave full-screen mode press Alt+Enter.",
 		                        "RPCEmu - Full-screen mode",
 		                        wxOK | wxCANCEL | wxICON_INFORMATION);
 		dlg.SetOKCancelLabels("OK", "Cancel");
@@ -1510,7 +1510,7 @@ void MainFrame::ProcessEmulatorKeyEvent(wxKeyEvent &event, bool key_down)
 	/* No keyboard shortcuts are intercepted here: menu/toolbar actions are
 	 * mouse-driven so that every key (function keys like F12, Ctrl combos, etc.)
 	 * passes straight through to RISC OS. The only exception is the mouse-capture
-	 * / full-screen release key (Ctrl+End), handled below. */
+	 * / full-screen release key (Alt+Enter), handled below. */
 
 	const int key_code = event.GetKeyCode();
 	if (key_code == WXK_NONE || key_code == 0) {

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -39,6 +39,7 @@
 #include <wx/icon.h>
 #include <wx/image.h>
 #include <wx/mstream.h>
+#include <wx/richmsgdlg.h>
 
 #include "about_dialog.h"
 #include "config_paths.h"
@@ -770,13 +771,18 @@ void MainFrame::EnterFullScreen()
 	}
 
 	if (config_copy_.show_fullscreen_message) {
-		wxMessageDialog dlg(this,
-		                    "This window will now be switched to full-screen mode.\n\n"
-		                    "To leave full-screen mode press Ctrl+End.\n\n"
-		                    "Select 'No' on the next prompt to hide this message in future.",
-		                    "RPCEmu - Full-screen mode",
-		                    wxOK | wxCANCEL | wxICON_INFORMATION);
+		/* One dialogue with a checkbox rather than two. Asking "do not show
+		   this again?" and answering Yes/No made the reader work out a double
+		   negative, and the first dialogue named the wrong button anyway: it
+		   said to answer No, while the code acted on Yes. A ticked checkbox
+		   means what it says. */
+		wxRichMessageDialog dlg(this,
+		                        "This window will now be switched to full-screen mode.\n\n"
+		                        "To leave full-screen mode press Ctrl+End.",
+		                        "RPCEmu - Full-screen mode",
+		                        wxOK | wxCANCEL | wxICON_INFORMATION);
 		dlg.SetOKCancelLabels("OK", "Cancel");
+		dlg.ShowCheckBox("Do not show this message again");
 
 		if (dlg.ShowModal() != wxID_OK) {
 			if (fullscreen_menu_item_ != nullptr) {
@@ -785,10 +791,7 @@ void MainFrame::EnterFullScreen()
 			return;
 		}
 
-		if (wxMessageBox("Do not show the full-screen message again?",
-		                  "RPCEmu - Full-screen mode",
-		                  wxYES_NO | wxICON_QUESTION,
-		                  this) == wxYES) {
+		if (dlg.IsCheckBoxChecked()) {
 			if (emulator_) {
 				emulator_->ShowFullscreenMessageOff();
 			}

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -849,8 +849,9 @@ void MainFrame::ExitFullScreen()
 	if (tool_bar_ != nullptr) {
 		tool_bar_->Show(true);
 	}
+	/* No Fit(): ShowFullScreen(false) has already restored the size, and
+	   fitting would shrink-wrap the frame to a panel that has no minimum. */
 	Layout();
-	Fit();
 	full_screen_ = false;
 
 	/* Force a full repaint once the windowed layout has settled (see the note

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -829,7 +829,7 @@ void MainFrame::EnterFullScreen()
 		panel_->UpdateMouseCursor();
 	}
 	if (fullscreen_menu_item_ != nullptr) {
-		fullscreen_menu_item_->Check(false);
+		fullscreen_menu_item_->Check(true);
 	}
 }
 

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -901,6 +901,7 @@ void MainFrame::OnIntegerScaling(wxCommandEvent &event)
 	if (panel_ != nullptr) {
 		panel_->SetFitToWindow(config_copy_.fit_to_window != 0);
 		panel_->SetIntegerScaling(config_copy_.integer_scaling != 0);
+		Layout();
 	}
 	if (emulator_) {
 		emulator_->IntegerScaling();
@@ -926,6 +927,7 @@ void MainFrame::OnFitToWindow(wxCommandEvent &event)
 	if (panel_ != nullptr) {
 		panel_->SetIntegerScaling(config_copy_.integer_scaling != 0);
 		panel_->SetFitToWindow(config_copy_.fit_to_window != 0);
+		Layout();
 	}
 	if (emulator_) {
 		emulator_->FitToWindow();

--- a/src/gui/main_frame_menus.cpp
+++ b/src/gui/main_frame_menus.cpp
@@ -333,35 +333,35 @@ void MainFrame::BuildToolBar()
 
 	// Normal operations (left)
 	tool_bar_->AddTool(ID_MENU_SCREENSHOT, wxEmptyString, ToolbarIconScreenshot(icon_size),
-	                   "Save screenshot (F12)");
+	                   "Save screenshot");
 	tool_bar_->AddSeparator();
 	tool_bar_->AddTool(ID_MENU_LOAD_DISC0, wxEmptyString, ToolbarIconFloppy(icon_size),
-	                   "Load floppy disc into drive :0 (Ctrl+1)");
+	                   "Load floppy disc into drive :0");
 	tool_bar_->AddTool(ID_MENU_CDROM_ISO, wxEmptyString, ToolbarIconCdrom(icon_size),
 	                   "Load CD-ROM ISO image");
 	tool_bar_->AddSeparator();
 	tool_bar_->AddTool(ID_MENU_RESET, wxEmptyString, ToolbarIconReset(icon_size),
-	                   "Reset machine (Ctrl+R)");
+	                   "Reset machine");
 	tool_bar_->AddSeparator();
 	tb_mute_tool_ = tool_bar_->AddCheckTool(ID_MENU_MUTE, wxEmptyString,
 	                                        ToolbarIconMute(false, icon_size), wxNullBitmap,
-	                                        "Toggle sound mute (F10)");
+	                                        "Toggle sound mute");
 	tool_bar_->AddTool(ID_MENU_FULLSCREEN, wxEmptyString, ToolbarIconFullscreen(icon_size),
-	                   "Toggle full-screen mode (F11)");
+	                   "Toggle full-screen mode (Ctrl+End to leave)");
 	tool_bar_->AddTool(ID_MENU_MACHINE, wxEmptyString, ToolbarIconConfigure(icon_size),
-	                   "Edit machine settings (Ctrl+,)");
+	                   "Edit machine settings");
 
 	// Debugger (right)
 	tool_bar_->AddStretchableSpace();
 	tool_bar_->AddSeparator();
 	tool_bar_->AddTool(ID_MENU_DEBUG_RUN, wxEmptyString, ToolbarIconDebugRun(icon_size),
-	                   "Run emulation (F5)");
+	                   "Run emulation");
 	tool_bar_->AddTool(ID_MENU_DEBUG_PAUSE, wxEmptyString, ToolbarIconDebugPause(icon_size),
-	                   "Pause emulation (F6)");
+	                   "Pause emulation");
 	tool_bar_->AddTool(ID_MENU_DEBUG_STEP, wxEmptyString, ToolbarIconDebugStep(icon_size),
-	                   "Single step (F7)");
+	                   "Single step");
 	tool_bar_->AddTool(ID_MENU_MACHINE_INSPECTOR, wxEmptyString, ToolbarIconInspector(icon_size),
-	                   "Open Machine Inspector (F9)");
+	                   "Open Machine Inspector");
 	tool_bar_->Realize();
 
 	tool_bar_->Bind(wxEVT_TOOL, &MainFrame::OnScreenshot, this, ID_MENU_SCREENSHOT);

--- a/src/gui/main_frame_menus.cpp
+++ b/src/gui/main_frame_menus.cpp
@@ -347,7 +347,7 @@ void MainFrame::BuildToolBar()
 	                                        ToolbarIconMute(false, icon_size), wxNullBitmap,
 	                                        "Toggle sound mute");
 	tool_bar_->AddTool(ID_MENU_FULLSCREEN, wxEmptyString, ToolbarIconFullscreen(icon_size),
-	                   "Toggle full-screen mode (Ctrl+End to leave)");
+	                   "Toggle full-screen mode (Alt+Enter to leave)");
 	tool_bar_->AddTool(ID_MENU_MACHINE, wxEmptyString, ToolbarIconConfigure(icon_size),
 	                   "Edit machine settings");
 


### PR DESCRIPTION
Seven things found while going over full-screen mode. Two are Windows bugs a user would hit, one is a Mac user being unable to leave full-screen at all, and the rest are the interface not telling the truth.

## The window came back the wrong size (046577c)

`ExitFullScreen()` called `Fit()` after `ShowFullScreen(false)`. The latter has already restored the size the window had before, so fitting only replaced it with the sizer's best size - and with Fit to Window that best size is tiny, because the panel deliberately contributes no minimum in that mode. The frame collapsed to little more than the toolbar.

Easy to miss on Linux, where focusing another application and coming back triggers a re-layout that puts it right. Windows sends no such event and the window stays wrong.

## The status bar went translucent (149129d)

Turning Fit to Window or Pixel Perfect off pins the panel back to the guest size, and `ResizeToHostDisplay()` does that by calling `SetSize()` on the panel itself - outside the sizer. The frame's layout is then stale and the status bar is left drawn over ground the panel now claims: only the field being updated repaints, and minimising and restoring the window puts it right.

Only the way in laid out again, via `ApplyFitToWindowSize()`. The way out had nothing.

## Ctrl+End does not exist on a Mac keyboard (cabd6ab, 1779124)

A Mac laptop or compact keyboard has no End key - it is fn+Right Arrow, and some third-party keyboards have no fn either - so the only way out of full-screen was unreachable on the hardware most Mac users have. Worse, on macOS `wxMOD_CONTROL` is the Command key, so the binding was really Cmd+End there, which nothing documented.

Alt+Enter instead, which is what DOSBox uses for the same job and for the same reason: Alt and Option are the same physical key, so unlike Ctrl it needs no per-platform spelling. One shortcut, one line in the documentation, no `#ifdef`.

Ctrl+End is gone rather than kept alongside. RISC OS does not use Alt+Enter - checked in Edit - so nothing is lost from the guest.

The second commit passes Alt+Enter through to RISC OS when there is nothing to leave. It was being swallowed even in a plain window, where it did nothing at all.

## The interface said things that were not true (42b614a, c2a05a0, 4e0cd88)

**The full-screen prompt asked a double negative.** Two dialogues: one explaining the mode, then "Do not show the full-screen message again?" with Yes and No - where Yes meant do not show. The first dialogue told the reader to answer No, while the code acted on Yes, so following the instruction kept the message rather than hiding it. Now one dialogue with a checkbox.

**Settings > Full-screen Mode never showed a tick.** `EnterFullScreen()` unchecked it on the way out, including at startup with `start_fullscreen` set, where the machine came up full-screen with the menu saying otherwise.

**Three toolbar tooltips claimed shortcuts that do not exist** - F10 for mute, F11 for full-screen, Ctrl+, for machine settings. None are bound: F10 and F11 go to the guest as ordinary scancodes, and there is no accelerator table in the GUI at all. Implementing them would be wrong here, since RISC OS wants its function keys, so the tooltips now say what the buttons do.

## Testing

Linux and Windows, by hand, for the two sizing bugs: resize, toggle each scaling mode, enter and leave full-screen, and check the window comes back as it was and the status bar stays solid. The rest verified on Linux. `ctest` passes.

macOS is not tested - I have no Mac. The Alt+Enter change is the one that matters there, and it is worth someone confirming, though Alt+Enter working on Linux and Windows does exercise the same code path.
