### PR TITLE
Take the status bar away in full-screen, do not just hide it

### DIFF
--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -808,6 +808,14 @@ void MainFrame::EnterFullScreen()
 	if (tool_bar_ != nullptr) {
 		tool_bar_->Show(false);
 	}
+	/* Removed rather than hidden. Hiding it leaves the space it occupied
+	   reserved - measurably so: the frame's client height does not change -
+	   and on macOS that shows as an empty strip along the bottom of the
+	   screen. BuildStatusBar() puts it back on the way out. */
+	if (wxStatusBar *bar = GetStatusBar()) {
+		SetStatusBar(nullptr);
+		bar->Destroy();
+	}
 	ShowFullScreen(true, wxFULLSCREEN_ALL);
 	full_screen_ = true;
 
@@ -848,6 +856,9 @@ void MainFrame::ExitFullScreen()
 	}
 	if (tool_bar_ != nullptr) {
 		tool_bar_->Show(true);
+	}
+	if (GetStatusBar() == nullptr) {
+		BuildStatusBar();
 	}
 	/* No Fit(): ShowFullScreen(false) has already restored the size, and
 	   fitting would shrink-wrap the frame to a panel that has no minimum. */
@@ -1451,6 +1462,14 @@ void MainFrame::OnMipsTimer(wxTimerEvent &)
 	}
 
 	UpdateMachineStatus();
+}
+
+void MainFrame::SetStatusText(const wxString &text, int number)
+{
+	if (GetStatusBar() == nullptr) {
+		return;
+	}
+	wxFrame::SetStatusText(text, number);
 }
 
 void MainFrame::OnFdcLedTimer(wxTimerEvent &) { SetStatusText(wxString(L'\u25cb'), STATUS_FDC_LED); }

--- a/src/gui/main_frame.h
+++ b/src/gui/main_frame.h
@@ -257,6 +257,10 @@ private:
 	void BuildMenus();
 	void BuildToolBar();
 	void BuildStatusBar();
+
+	/* The timers keep running in full-screen, where there is no status bar to
+	   write to - wx asserts on that rather than ignoring it. */
+	void SetStatusText(const wxString &text, int number = 0) override;
 	void BindMenuOpenClose(wxMenu *menu);
 	void BindAllMenuOpenCloseHandlers();
 


### PR DESCRIPTION
Reported on macOS: the status bar stays on screen in full-screen mode. It does not on Linux or Windows.

`ShowFullScreen(true, wxFULLSCREEN_ALL)` is meant to cover it, and `wxFULLSCREEN_ALL` does include `wxFULLSCREEN_NOSTATUSBAR`. But only `src/gtk/frame.cpp` and `src/msw/frame.cpp` act on that flag. `EnterFullScreen()` already hides the menu bar and the toolbar by hand, so the status bar was the one piece of furniture left to a flag macOS ignores.

## Hiding it is not enough

The first attempt called `Show(false)` on it. The reporter came back with: the text stops drawing, but an empty band with rounded corners remains along the bottom.

That is measurable, and not macOS-specific. On GTK, with a 400x300 frame:

| | client height |
| --- | --- |
| status bar shown | 277 |
| after `Show(false)` | **277** |
| after removing it | 300 |

Hiding the widget never reclaims the space on any platform. Linux and Windows just do not render anything in the gap, so nobody noticed.

## So it is removed and rebuilt

Destroyed on the way in, and `BuildStatusBar()` called on the way out - that already creates the bar, sets the field widths and fills in every field, so it is the whole of what is needed.

Measured over three enter/leave cycles: the window returns to 692x569 each time, with the field count and contents intact. An isolated removal does shrink the frame, but `ShowFullScreen(false)` restores the geometry before the bar is rebuilt, so it never shows.

The MIPS and LED timers keep running in full-screen, and wx asserts on `SetStatusText()` when there is no bar rather than ignoring it. `MainFrame` now overrides `SetStatusText()` to drop writes that have nowhere to go - eleven call sites, one guard.

No `#ifdef`: removing the bar is right on every platform. Linux and Windows already looked correct and now do so for a better reason, which also means the whole path gets exercised outside macOS.

## Testing

Linux, by hand: enter and leave full-screen repeatedly, with and without Fit to Window, and the bar goes and comes back with the window at its previous size.
