### PR TITLE
Version: say which commit a build came from

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,34 @@ concurrency:
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
+  # A release is named by its tag but the binaries carry what VERSION says, so
+  # the two disagreeing publishes a release whose contents claim to be something
+  # else. Checked before anything is built, so a mistyped tag costs seconds.
+  version-matches-tag:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-tags: true
+
+      - name: The tag and the VERSION file must agree
+        run: |
+          tag="${GITHUB_REF#refs/tags/v}"
+          file="$(tr -d ' \t\r\n' < VERSION)"
+          if [ "$tag" != "$file" ]; then
+            echo "::error::tag v$tag does not match VERSION ($file)"
+            echo "Update VERSION to $tag, or tag v$file instead."
+            exit 1
+          fi
+          echo "tag v$tag matches VERSION"
+
   linux-amd64:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-tags: true
 
       - name: Install dependencies
         run: bash setup-build-env.sh
@@ -127,6 +151,8 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-tags: true
 
       - name: Install dependencies
         run: bash setup-build-env.sh
@@ -227,6 +253,8 @@ jobs:
         shell: msys2 {0}
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-tags: true
 
       - name: Set up MSYS2 / MinGW-w64
         uses: msys2/setup-msys2@v2
@@ -369,6 +397,8 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-tags: true
 
       - name: Install Rosetta 2
         run: softwareupdate --install-rosetta --agree-to-license
@@ -424,6 +454,8 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-tags: true
 
       - name: Install dependencies
         run: |
@@ -459,6 +491,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-tags: true
 
       - name: Download x86_64 slice
         uses: actions/download-artifact@v8
@@ -606,7 +640,7 @@ jobs:
 
   release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    needs: [linux-amd64, linux-arm64, windows-amd64, macos-universal]
+    needs: [version-matches-tag, linux-amd64, linux-arm64, windows-amd64, macos-universal]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,50 @@
 cmake_minimum_required(VERSION 3.16)
 
-file(READ "${CMAKE_SOURCE_DIR}/VERSION" RPCEMU_VERSION)
-string(STRIP "${RPCEMU_VERSION}" RPCEMU_VERSION)
+# The release number. project() and the Debian package need a bare x.y.z, so
+# this stays exactly what the file says.
+file(READ "${CMAKE_SOURCE_DIR}/VERSION" RPCEMU_RELEASE)
+string(STRIP "${RPCEMU_RELEASE}" RPCEMU_RELEASE)
 
-project(rpcemu VERSION ${RPCEMU_VERSION} LANGUAGES C)
+project(rpcemu VERSION ${RPCEMU_RELEASE} LANGUAGES C)
+
+# What the emulator reports and what the archives are named. The number is
+# always the one in VERSION; git only says which commit this is, so that a build
+# from anywhere but a release tag cannot be mistaken for the release itself.
+# Nothing is inferred from the tags, so a clone that is missing some cannot
+# quietly report an older release than the source says it is.
+#
+# Released builds are the exception: on a release tag the number stands alone,
+# and the workflow refuses to publish a tag that disagrees with VERSION.
+set(RPCEMU_VERSION "${RPCEMU_RELEASE}")
+find_package(Git QUIET)
+if(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" rev-parse --short HEAD
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        OUTPUT_VARIABLE _rpcemu_commit
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE _rpcemu_commit_result)
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" describe --tags --exact-match --match "v[0-9]*"
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        OUTPUT_QUIET ERROR_QUIET
+        RESULT_VARIABLE _rpcemu_on_tag)
+    if(_rpcemu_commit_result EQUAL 0 AND _rpcemu_commit AND NOT _rpcemu_on_tag EQUAL 0)
+        execute_process(
+            COMMAND "${GIT_EXECUTABLE}" status --porcelain --untracked-files=no
+            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+            OUTPUT_VARIABLE _rpcemu_dirty
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET)
+        if(_rpcemu_dirty)
+            set(RPCEMU_VERSION "${RPCEMU_RELEASE}-g${_rpcemu_commit}-dirty")
+        else()
+            set(RPCEMU_VERSION "${RPCEMU_RELEASE}-g${_rpcemu_commit}")
+        endif()
+    endif()
+endif()
+message(STATUS "RPCEmu version: ${RPCEMU_VERSION} (release ${RPCEMU_RELEASE})")
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/build-macos.sh
+++ b/build-macos.sh
@@ -68,7 +68,21 @@ done
 # Given in either order, an explicit --fuse wins over --arch's default.
 [ "$FUSE_REQUESTED" = true ] && DO_FUSE=true
 
-get_version() { [ -f VERSION ] && tr -d ' \t\r\n' < VERSION || echo "0.0.0"; }
+get_version() {
+	# See build.sh: number from VERSION, commit from git unless on a tag.
+	release="$([ -f VERSION ] && tr -d ' \t\r\n' < VERSION || echo 0.0.0)"
+	if command -v git >/dev/null 2>&1 && [ -d .git ] \
+	   && ! git describe --tags --exact-match --match 'v[0-9]*' >/dev/null 2>&1; then
+		commit="$(git rev-parse --short HEAD 2>/dev/null)"
+		if [ -n "$commit" ]; then
+			if [ -n "$(git status --porcelain --untracked-files=no 2>/dev/null)" ]; then
+				printf '%s-g%s-dirty\n' "$release" "$commit"; return
+			fi
+			printf '%s-g%s\n' "$release" "$commit"; return
+		fi
+	fi
+	printf '%s\n' "$release"
+}
 VERSION=$(get_version)
 njobs() { sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 4; }
 

--- a/build-windows.sh
+++ b/build-windows.sh
@@ -47,7 +47,21 @@ else
 	BIN=rpcemu-recompiler.exe
 fi
 
-get_version() { [ -f VERSION ] && tr -d ' \t\r\n' < VERSION || echo "0.0.0"; }
+get_version() {
+	# See build.sh: number from VERSION, commit from git unless on a tag.
+	release="$([ -f VERSION ] && tr -d ' \t\r\n' < VERSION || echo 0.0.0)"
+	if command -v git >/dev/null 2>&1 && [ -d .git ] \
+	   && ! git describe --tags --exact-match --match 'v[0-9]*' >/dev/null 2>&1; then
+		commit="$(git rev-parse --short HEAD 2>/dev/null)"
+		if [ -n "$commit" ]; then
+			if [ -n "$(git status --porcelain --untracked-files=no 2>/dev/null)" ]; then
+				printf '%s-g%s-dirty\n' "$release" "$commit"; return
+			fi
+			printf '%s-g%s\n' "$release" "$commit"; return
+		fi
+	fi
+	printf '%s\n' "$release"
+}
 VERSION=$(get_version)
 
 njobs() { nproc 2>/dev/null || echo 4; }

--- a/build.sh
+++ b/build.sh
@@ -27,11 +27,30 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
 get_version() {
+	# The number always comes from VERSION; git only says which commit this is,
+	# so a build from anywhere but a release tag cannot be mistaken for the
+	# release. Matches the logic in CMakeLists.txt.
+	local release
 	if [ -f VERSION ]; then
-		tr -d ' \t\r\n' < VERSION
+		release="$(tr -d ' \t\r\n' < VERSION)"
+	else
+		echo "0.0.0"
 		return
 	fi
-	echo "0.0.0"
+	if command -v git >/dev/null 2>&1 && [ -d .git ] \
+	   && ! git describe --tags --exact-match --match 'v[0-9]*' >/dev/null 2>&1; then
+		local commit
+		commit="$(git rev-parse --short HEAD 2>/dev/null)"
+		if [ -n "$commit" ]; then
+			if [ -n "$(git status --porcelain --untracked-files=no 2>/dev/null)" ]; then
+				printf '%s-g%s-dirty\n' "$release" "$commit"
+			else
+				printf '%s-g%s\n' "$release" "$commit"
+			fi
+			return
+		fi
+	fi
+	printf '%s\n' "$release"
 }
 
 normalize_linux_arch() {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,7 +125,7 @@ target_include_directories(rpcemu_core PRIVATE
 
 target_compile_definitions(rpcemu_core PUBLIC
     CONFIG_SLIRP
-    RPCEMU_VERSION="${PROJECT_VERSION}"
+    RPCEMU_VERSION="${RPCEMU_VERSION}"
 )
 
 target_compile_definitions(rpcemu_core PRIVATE _DEFAULT_SOURCE)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -88,7 +88,7 @@ target_include_directories(${RPCEMU_GUI_TARGET} PRIVATE
 )
 
 target_compile_definitions(${RPCEMU_GUI_TARGET} PRIVATE
-    RPCEMU_VERSION="${PROJECT_VERSION}"
+    RPCEMU_VERSION="${RPCEMU_VERSION}"
     RPCEMU_INSTALL_DATADIR="${CMAKE_INSTALL_PREFIX}/share/rpcemu"
 )
 


### PR DESCRIPTION
Every build reports whatever `VERSION` says, so a CI build from any commit calls itself the release - in the About box, the window title, the logs and the archive names. Nothing tells it apart from the real thing, which matters more now that CI publishes artefacts for every push.

## What changes

The number still comes from `VERSION`. Git only says which commit it is:

| build | version |
| --- | --- |
| on tag `v1.1.12` | `1.1.12` |
| any other commit | `1.1.12-g30cf686` |
| with uncommitted changes | `1.1.12-g30cf686-dirty` |
| no git history (tarball) | `1.1.12` |

`project()` and the Debian package still get the bare `x.y.z`, since neither accepts anything else. The three build scripts derive the version the same way as CMake, so the archives are named after what is in them.

## Deliberately not git describe

The first version of this used `git describe`, which takes the number from the nearest reachable tag rather than from `VERSION`. That is subtly wrong: the two can disagree, and there is then no way to tell which is right.

It showed up immediately. My fork had never fetched `v1.1.11` or `v1.1.12`, so CI cheerfully built binaries calling themselves `1.1.10-197-g6028f81` while `VERSION` said `1.1.12`. A clone missing a tag should not be able to change what a build claims to be.

## Tag and VERSION are now checked

A release is named by its tag, but the binaries carry what `VERSION` says, and nothing compared the two. Tagging `v1.1.99` with `VERSION` still saying `1.1.12` would publish a release whose contents claim to be something else.

A job gated on `refs/tags/v*` now fails the build if they disagree. It runs before anything is compiled, so a mistyped tag costs seconds rather than five platform builds.

`fetch-tags` is added to the checkouts: a release build has to know it is on the tag. The history is not needed - the number never comes from it - so `fetch-depth` is left alone.

## Testing

Linux, and each case separately: on a synthetic tag both CMake and the build scripts report the bare number; off a tag they report the commit; a `git archive` export with no `.git` falls back to `VERSION`; a `--depth=1` clone still gets it right. CMake, `build.sh`, `build-windows.sh` and `build-macos.sh` were checked against each other and agree. `ctest` passes.

The version-matches-tag job is skipped on anything but a tag, so this PR will not exercise it. It was tested by hand against `v1.1.12` (passes), `v1.1.99` and `v2.0.0` (both fail with the message naming both values).

Windows and macOS get the same helper as Linux but run it under MSYS2 and macOS bash; the archive names in the CI artefacts are what confirm those.
