### PR TITLE
Make the Menu key work on Windows

### DIFF
--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -1550,7 +1550,7 @@ void MainFrame::ProcessEmulatorKeyEvent(wxKeyEvent &event, bool key_down)
 		/* Nothing to escape from, so the guest gets the key. */
 	}
 
-	if (key_code == WXK_MENU) {
+	if (key_code == WXK_MENU || key_code == WXK_WINDOWS_MENU) {
 		if (emulator_) {
 			if (key_down) {
 				emulator_->MousePress(4);


### PR DESCRIPTION
Reported twice: the Menu key does nothing on Windows. It works on Linux.

wx names the key differently per platform:

| key pressed | GTK | MSW |
| --- | --- | --- |
| Menu / Application | `WXK_MENU` | `WXK_WINDOWS_MENU` |
| Alt | `WXK_ALT` | `WXK_ALT` |

`src/msw/window.cpp` maps `VK_APPS` to `WXK_WINDOWS_MENU`, and gives `WXK_ALT` to `VK_MENU` - which is the Alt key, despite the name. Nothing on Windows produces `WXK_MENU`, so the existing check could never match.

Accepting both fixes it. `WXK_WINDOWS_MENU` is defined on every platform and only generated on Windows, so this needs no `#ifdef` and the path stays exercised on Linux.

## Testing

Tested under Linux and Windows, to confirm the fix.
