### PR TITLE
CI: give the MSYS2 shell a git to find

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,6 +299,7 @@ jobs:
           msystem: MINGW64
           update: true
           install: >-
+            git
             mingw-w64-x86_64-toolchain
             mingw-w64-x86_64-cmake
             mingw-w64-x86_64-ninja


### PR DESCRIPTION
The Windows zip was named 1.1.12 while the binary inside reported 1.1.12-g49ad566. setup-msys2 installs no git, so get_version() falls back to VERSION; CMake finds the runner's own git and does not.