### PR TITLE
Help: add Report an Issue and Check for Update

### DIFF
--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -1267,6 +1267,11 @@ void MainFrame::OnVisitWebsite(wxCommandEvent &)
 	wxLaunchDefaultBrowser(URL_WEBSITE);
 }
 
+void MainFrame::OnReportIssue(wxCommandEvent &)
+{
+	wxLaunchDefaultBrowser(URL_ISSUES);
+}
+
 /* RISC OS is not ours, and this is where it comes from. */
 void MainFrame::OnAboutRiscos(wxCommandEvent &)
 {

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -1272,6 +1272,132 @@ void MainFrame::OnReportIssue(wxCommandEvent &)
 	wxLaunchDefaultBrowser(URL_ISSUES);
 }
 
+namespace {
+
+/* "v1.1.12" -> 1, 1, 12. Anything unparsable leaves the fields at zero, which
+   compares as older than any real release and so offers the update. */
+void SplitVersion(const wxString &text, long out[3])
+{
+	wxString rest = text;
+
+	out[0] = out[1] = out[2] = 0;
+	if (rest.StartsWith("v")) {
+		rest = rest.Mid(1);
+	}
+	for (int i = 0; i < 3 && !rest.empty(); i++) {
+		wxString field = rest.BeforeFirst('.');
+
+		field.ToLong(&out[i]);
+		rest = rest.AfterFirst('.');
+	}
+}
+
+/* Numerically, so 1.1.9 is older than 1.1.10 rather than sorting after it. */
+bool IsNewerVersion(const wxString &candidate, const wxString &current)
+{
+	long a[3], b[3];
+
+	SplitVersion(candidate, a);
+	SplitVersion(current, b);
+	for (int i = 0; i < 3; i++) {
+		if (a[i] != b[i]) {
+			return a[i] > b[i];
+		}
+	}
+	return false;
+}
+
+/* The one field wanted out of the release JSON. The response has several
+   html_url members - the release, the uploader, others - so the tag is taken
+   and the page built from it rather than trusting their order. */
+wxString TagNameFromReleaseJson(const wxString &json)
+{
+	const wxString key = "\"tag_name\"";
+	const int at = json.Find(key);
+
+	if (at == wxNOT_FOUND) {
+		return wxString();
+	}
+
+	wxString rest = json.Mid(static_cast<size_t>(at) + key.length());
+	rest = rest.AfterFirst(':').Strip(wxString::both);
+	if (!rest.StartsWith("\"")) {
+		return wxString();
+	}
+	return rest.Mid(1).BeforeFirst('"');
+}
+
+} // namespace
+
+void MainFrame::OnCheckUpdate(wxCommandEvent &)
+{
+	const wxString current = VERSION;
+
+	/* A development build is ahead of the newest release, not behind it, so
+	   there is nothing useful to compare against. */
+	if (current.Contains("-")) {
+		if (wxMessageBox(
+		        wxString::Format(
+		            "This is a development build (%s), not a release.\n\n"
+		            "Open the releases page?", current),
+		        "RPCEmu - Check for Update",
+		        wxOK | wxCANCEL | wxICON_INFORMATION, this) == wxOK) {
+			wxLaunchDefaultBrowser(URL_RELEASES);
+		}
+		return;
+	}
+
+	if (!RPCEMU_HAVE_HTTP) {
+		wxMessageBox(HttpUnavailableMessage(), "RPCEmu - Check for Update",
+		             wxOK | wxICON_INFORMATION, this);
+		return;
+	}
+
+	wxString body, error;
+	{
+		RiscosFetchProgressReporter reporter(this);
+		Transfer transfer(reporter, "Checking for a newer release...", {});
+
+		if (!transfer.ToMemory(URL_LATEST_RELEASE_API)) {
+			if (transfer.WasCancelled()) {
+				return;
+			}
+			error = transfer.Error();
+		} else {
+			body = transfer.Body();
+		}
+	}
+
+	if (!error.empty()) {
+		wxMessageBox(wxString::Format("Could not check for an update:\n\n%s", error),
+		             "RPCEmu - Check for Update", wxOK | wxICON_ERROR, this);
+		return;
+	}
+
+	const wxString tag = TagNameFromReleaseJson(body);
+	if (tag.empty()) {
+		wxMessageBox("The reply from GitHub did not name a release.",
+		             "RPCEmu - Check for Update", wxOK | wxICON_ERROR, this);
+		return;
+	}
+
+	if (!IsNewerVersion(tag, current)) {
+		wxMessageBox(wxString::Format("You are running the latest version (%s).", current),
+		             "RPCEmu - Check for Update", wxOK | wxICON_INFORMATION, this);
+		return;
+	}
+
+	if (wxMessageBox(
+	        wxString::Format(
+	            "RPCEmu %s is available. You are running %s.\n\n"
+	            "Open the release page to read the notes and download it?",
+	            tag, current),
+	        "RPCEmu - Check for Update",
+	        wxOK | wxCANCEL | wxICON_INFORMATION, this) == wxOK) {
+		wxLaunchDefaultBrowser(wxString(URL_RELEASE_TAG) + tag);
+	}
+}
+
 /* RISC OS is not ours, and this is where it comes from. */
 void MainFrame::OnAboutRiscos(wxCommandEvent &)
 {

--- a/src/gui/main_frame.h
+++ b/src/gui/main_frame.h
@@ -113,6 +113,7 @@ enum MainFrameMenuId {
 	ID_MENU_ONLINE_MANUAL,
 	ID_MENU_VISIT_WEBSITE,
 	ID_MENU_REPORT_ISSUE,
+	ID_MENU_CHECK_UPDATE,
 };
 
 enum TimerId {
@@ -223,6 +224,7 @@ private:
 	void OnOnlineManual(wxCommandEvent &event);
 	void OnVisitWebsite(wxCommandEvent &event);
 	void OnReportIssue(wxCommandEvent &event);
+	void OnCheckUpdate(wxCommandEvent &event);
 	void OnAbout(wxCommandEvent &event);
 #ifdef RPCEMU_VNC
 	void OnVnc(wxCommandEvent &event);

--- a/src/gui/main_frame.h
+++ b/src/gui/main_frame.h
@@ -112,6 +112,7 @@ enum MainFrameMenuId {
 	ID_MENU_MACHINE_INSPECTOR,
 	ID_MENU_ONLINE_MANUAL,
 	ID_MENU_VISIT_WEBSITE,
+	ID_MENU_REPORT_ISSUE,
 };
 
 enum TimerId {
@@ -221,6 +222,7 @@ private:
 	void OnMachineInspector(wxCommandEvent &event);
 	void OnOnlineManual(wxCommandEvent &event);
 	void OnVisitWebsite(wxCommandEvent &event);
+	void OnReportIssue(wxCommandEvent &event);
 	void OnAbout(wxCommandEvent &event);
 #ifdef RPCEMU_VNC
 	void OnVnc(wxCommandEvent &event);

--- a/src/gui/main_frame_menus.cpp
+++ b/src/gui/main_frame_menus.cpp
@@ -232,6 +232,7 @@ void MainFrame::BuildMenus()
 	auto *help_menu = new wxMenu;
 	help_menu->Append(ID_MENU_ONLINE_MANUAL, "Online Manual...");
 	help_menu->Append(ID_MENU_VISIT_WEBSITE, "Visit Website...");
+	help_menu->Append(ID_MENU_REPORT_ISSUE, "Report an Issue...");
 	help_menu->AppendSeparator();
 	/* RISC OS itself is somebody else's work and has its own home; the two
 	   About entries sit together so that is plain. On macOS the RPCEmu one
@@ -312,6 +313,7 @@ void MainFrame::BuildMenus()
 
 	BindMenuItem(help_menu, ID_MENU_ONLINE_MANUAL, this, &MainFrame::OnOnlineManual);
 	BindMenuItem(help_menu, ID_MENU_VISIT_WEBSITE, this, &MainFrame::OnVisitWebsite);
+	BindMenuItem(help_menu, ID_MENU_REPORT_ISSUE, this, &MainFrame::OnReportIssue);
 	BindMenuItem(help_menu, wxID_ABOUT, this, &MainFrame::OnAbout);
 
 	BindAllMenuOpenCloseHandlers();

--- a/src/gui/main_frame_menus.cpp
+++ b/src/gui/main_frame_menus.cpp
@@ -233,6 +233,7 @@ void MainFrame::BuildMenus()
 	help_menu->Append(ID_MENU_ONLINE_MANUAL, "Online Manual...");
 	help_menu->Append(ID_MENU_VISIT_WEBSITE, "Visit Website...");
 	help_menu->Append(ID_MENU_REPORT_ISSUE, "Report an Issue...");
+	help_menu->Append(ID_MENU_CHECK_UPDATE, "Check for Update...");
 	help_menu->AppendSeparator();
 	/* RISC OS itself is somebody else's work and has its own home; the two
 	   About entries sit together so that is plain. On macOS the RPCEmu one
@@ -314,6 +315,7 @@ void MainFrame::BuildMenus()
 	BindMenuItem(help_menu, ID_MENU_ONLINE_MANUAL, this, &MainFrame::OnOnlineManual);
 	BindMenuItem(help_menu, ID_MENU_VISIT_WEBSITE, this, &MainFrame::OnVisitWebsite);
 	BindMenuItem(help_menu, ID_MENU_REPORT_ISSUE, this, &MainFrame::OnReportIssue);
+	BindMenuItem(help_menu, ID_MENU_CHECK_UPDATE, this, &MainFrame::OnCheckUpdate);
 	BindMenuItem(help_menu, wxID_ABOUT, this, &MainFrame::OnAbout);
 
 	BindAllMenuOpenCloseHandlers();

--- a/src/rpcemu.h
+++ b/src/rpcemu.h
@@ -62,6 +62,9 @@ extern "C" {
 #define URL_MANUAL  "https://github.com/andrewtimmins/rpcemu-extended/tree/main/docs"
 #define URL_WEBSITE "https://github.com/andrewtimmins/rpcemu-extended"
 #define URL_ISSUES  "https://github.com/andrewtimmins/rpcemu-extended/issues"
+#define URL_RELEASES "https://github.com/andrewtimmins/rpcemu-extended/releases"
+#define URL_RELEASE_TAG "https://github.com/andrewtimmins/rpcemu-extended/releases/tag/"
+#define URL_LATEST_RELEASE_API "https://api.github.com/repos/andrewtimmins/rpcemu-extended/releases/latest"
 /* RISC OS Open, who publish the operating system this emulator runs. */
 #define URL_RISCOSOPEN "https://www.riscosopen.org/"
 /* Their licensing terms, and their donations page: both are acknowledged before

--- a/src/rpcemu.h
+++ b/src/rpcemu.h
@@ -61,6 +61,7 @@ extern "C" {
 /* URLs used for the help menu weblinks */
 #define URL_MANUAL  "https://github.com/andrewtimmins/rpcemu-extended/tree/main/docs"
 #define URL_WEBSITE "https://github.com/andrewtimmins/rpcemu-extended"
+#define URL_ISSUES  "https://github.com/andrewtimmins/rpcemu-extended/issues"
 /* RISC OS Open, who publish the operating system this emulator runs. */
 #define URL_RISCOSOPEN "https://www.riscosopen.org/"
 /* Their licensing terms, and their donations page: both are acknowledged before


### PR DESCRIPTION
Two entries from the to-do list, under Help.

**Report an Issue...** opens the GitHub issues page for the project.

**Check for Update...** asks GitHub for the latest release, compares it with `VERSION`, and offers to open that release's page so the notes can be read and the right package chosen. A development build takes neither path: it came from CI and so is ahead of any release rather than behind it, so it says as much and offers the releases page without checking anything.

## Comparing versions

Field by field, as numbers. A string comparison gets this wrong in both directions, which is the whole reason the helper exists:

| latest | running | verdict | a string compare would say |
| --- | --- | --- | --- |
| v1.1.10 | 1.1.9 | newer | older |
| v2.21.101 | 2.21.99 | newer | older |
| v2.21.99 | 2.21.101 | up to date | **newer** |
| v2.21.101 | 2.22.0 | up to date | up to date |

Fields are arbitrary width, so `2.21.101` is fine. Anything unparsable leaves the field at zero and so reads as `0.0.0`, which reports "latest" rather than offering an update that does not exist - the safe direction to fail in.

## Reading the tag

By name, out of the reply. The release JSON carries several `html_url` members naming different things - the release, its author, its assets - so the page is built from `tag_name` rather than by trusting which URL comes first.

This is a fifteen-line string scan, not a JSON parser. It holds up against the awkward cases - a release body quoting `\"tag_name\"`, an `old_tag_name` member appearing first, a `null` value, no key at all - all of which yield either the right tag or nothing. Nothing is downloaded or run off the back of it: the tag is concatenated into a URL the user chooses to open, so the worst a bad parse can do is a 404.

## The fetch

Reuses the existing `Transfer`, so it inherits the progress dialog, Cancel, and the wxWebRequest-less build saying so instead of failing obscurely.

`http_transfer.h` is untouched. `User-Agent` is the only header GitHub actually requires - "requests with no `User-Agent` header will be rejected" - and `Transfer` already sends one. Confirmed against the live API: 200, with the tag present.

## Testing

Version comparison and tag extraction against the live API response and against malformed input, including the table above.

HTTP status handling, through the real `Transfer` against a local server:

| response | result |
| --- | --- |
| 200 | body read |
| 301/302/307 with `Location` | followed by the backend, body read |
| redirect loop | fails cleanly, no hang |
| 401/403/404/429/500/503 | fails, **body never read**, message shown |

That last row is the one that matters: a `!= 200` response never has its body parsed, so a GitHub error page cannot be mistaken for a release.

Slow and hung servers, since this is the first fetch on the GUI thread that a user triggers casually:

| | GUI timer ticks during fetch | outcome |
| --- | --- | --- |
| response dribbled over ~2.3s | 22 | body intact |
| server never replies, user cancels | 30 | silent return, no error box |