### PR TITLE
Name the window and the application after the fork

### DIFF
--- a/build-macos.sh
+++ b/build-macos.sh
@@ -97,8 +97,8 @@ write_info_plist() {
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleName</key><string>RPCEmu</string>
-	<key>CFBundleDisplayName</key><string>RPCEmu</string>
+	<key>CFBundleName</key><string>RPCEmu Extended</string>
+	<key>CFBundleDisplayName</key><string>RPCEmu Extended</string>
 	<key>CFBundleIdentifier</key><string>${BUNDLE_ID}</string>
 	<key>CFBundleExecutable</key><string>rpcemu</string>
 	<key>CFBundleIconFile</key><string>rpcemu</string>

--- a/src/gui/config_selector_dialog.cpp
+++ b/src/gui/config_selector_dialog.cpp
@@ -283,7 +283,7 @@ void ConfigSelectorDialog::OnStart(wxCommandEvent &)
 {
 	selected_config_path_ = SelectedConfigPath();
 	if (selected_config_path_.empty()) {
-		wxMessageBox("Select a machine configuration to start.", "RPCEmu", wxOK | wxICON_INFORMATION, this);
+		wxMessageBox("Select a machine configuration to start.", "RPCEmu Extended", wxOK | wxICON_INFORMATION, this);
 		return;
 	}
 	resume_selected_ = false;
@@ -317,7 +317,7 @@ void ConfigSelectorDialog::OnLoadStateFile(wxCommandEvent &)
 	if (state_get_machine_name(file.utf8_str().data(), name, sizeof(name)) != 0) {
 		wxMessageBox("This is not a valid RPCEmu state file, or it was made by a "
 		             "different version of RPCEmu.",
-		             "RPCEmu", wxOK | wxICON_WARNING, this);
+		             "RPCEmu Extended", wxOK | wxICON_WARNING, this);
 		return;
 	}
 	const wxString machine_name = wxString::FromUTF8(name);
@@ -335,7 +335,7 @@ void ConfigSelectorDialog::OnLoadStateFile(wxCommandEvent &)
 		                 "with that name exists.\n\nCreate or rename a machine to "
 		                 "'%s' and try again.",
 		                 machine_name, machine_name),
-		             "RPCEmu", wxOK | wxICON_WARNING, this);
+		             "RPCEmu Extended", wxOK | wxICON_WARNING, this);
 		return;
 	}
 

--- a/src/gui/config_selector_dialog.cpp
+++ b/src/gui/config_selector_dialog.cpp
@@ -39,7 +39,7 @@ extern "C" {
 }
 
 ConfigSelectorDialog::ConfigSelectorDialog(wxWindow *parent)
-	: wxDialog(parent, wxID_ANY, "RPCEmu - Select Machine",
+	: wxDialog(parent, wxID_ANY, "RPCEmu Extended - Select Machine",
 	           wxDefaultPosition, wxSize(520, 420),
 	           wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
 {

--- a/src/gui/machine_selector.c
+++ b/src/gui/machine_selector.c
@@ -199,7 +199,7 @@ machine_selector_draw(MachineSelector *m, TextScreen *s)
 	text_screen_set_scale(s, text_screen_auto_scale(s));
 
 	text_screen_clear(s, COLOUR_BG);
-	text_screen_centre(s, ROW_HEIGHT, "RPCEmu", COLOUR_TITLE);
+	text_screen_centre(s, ROW_HEIGHT, "RPCEmu Extended", COLOUR_TITLE);
 
 	if (m->count == 0) {
 		text_screen_centre(s, list_top, "No machines found.", COLOUR_TEXT);

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -655,6 +655,8 @@ wxIMPLEMENT_APP_NO_MAIN(RpcemuApp);
 
 bool RpcemuApp::OnInit()
 {
+	SetAppName("RPCEmu Extended");
+
 	if (!wxApp::OnInit()) {
 		return false;
 	}

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -241,7 +241,7 @@ static void ConsoleMessageFlush(void)
 		fputs(g_msg_text.c_str(), g_msg_is_error ? stderr : stdout);
 		fflush(g_msg_is_error ? stderr : stdout);
 	} else {
-		MessageBoxA(nullptr, g_msg_text.c_str(), "RPCEmu",
+		MessageBoxA(nullptr, g_msg_text.c_str(), "RPCEmu Extended",
 		            MB_OK | (g_msg_is_error ? MB_ICONERROR : MB_ICONINFORMATION));
 	}
 
@@ -865,7 +865,7 @@ bool RpcemuApp::OnInit()
 			    wxString::Format("Could not load the machine state:\n%s\n\n"
 			                     "Performing a normal boot instead.",
 			                     wxString::FromUTF8(errbuf)),
-			    "RPCEmu", wxOK | wxICON_WARNING, frame);
+			    "RPCEmu Extended", wxOK | wxICON_WARNING, frame);
 		}
 	}
 

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -72,6 +72,12 @@ extern "C" {
 
 namespace {
 
+wxString WindowTitleFor(const wxString &machine_name)
+{
+	return wxString::Format("RPCEmu Extended - %s",
+	    machine_name.empty() ? wxString("(unnamed machine)") : machine_name);
+}
+
 struct DiscTypeFileMap {
 	const char *display_name;
 	const char *extension;
@@ -209,7 +215,7 @@ wxEND_EVENT_TABLE()
 
 MainFrame::MainFrame()
 	: wxFrame(nullptr, wxID_ANY,
-	          wxString::Format("RPCEmu v%s", wxString(VERSION)),
+	          WindowTitleFor(wxString::FromUTF8(config.name)),
 	          wxDefaultPosition, wxSize(800, 600)),
 	  mips_timer_(this, ID_TIMER_MIPS),
 	  video_timer_(this, ID_TIMER_VIDEO),
@@ -492,7 +498,7 @@ void MainFrame::OnRecentMachine(wxCommandEvent &event)
 
 	AddRecentMachine(machine_name.utf8_str().data());
 	UpdateRecentMachinesMenu();
-	SetTitle(wxString::Format("RPCEmu - %s", machine_name));
+	SetTitle(WindowTitleFor(machine_name));
 
 	if (emulator_) {
 		emulator_->SwitchMachine(config_path.utf8_str().data());
@@ -779,7 +785,7 @@ void MainFrame::EnterFullScreen()
 		wxRichMessageDialog dlg(this,
 		                        "This window will now be switched to full-screen mode.\n\n"
 		                        "To leave full-screen mode press Alt+Enter.",
-		                        "RPCEmu - Full-screen mode",
+		                        "RPCEmu Extended - Full-screen mode",
 		                        wxOK | wxCANCEL | wxICON_INFORMATION);
 		dlg.SetOKCancelLabels("OK", "Cancel");
 		dlg.ShowCheckBox("Do not show this message again");
@@ -1340,7 +1346,7 @@ void MainFrame::OnCheckUpdate(wxCommandEvent &)
 		        wxString::Format(
 		            "This is a development build (%s), not a release.\n\n"
 		            "Open the releases page?", current),
-		        "RPCEmu - Check for Update",
+		        "RPCEmu Extended - Check for Update",
 		        wxOK | wxCANCEL | wxICON_INFORMATION, this) == wxOK) {
 			wxLaunchDefaultBrowser(URL_RELEASES);
 		}
@@ -1348,7 +1354,7 @@ void MainFrame::OnCheckUpdate(wxCommandEvent &)
 	}
 
 	if (!RPCEMU_HAVE_HTTP) {
-		wxMessageBox(HttpUnavailableMessage(), "RPCEmu - Check for Update",
+		wxMessageBox(HttpUnavailableMessage(), "RPCEmu Extended - Check for Update",
 		             wxOK | wxICON_INFORMATION, this);
 		return;
 	}
@@ -1370,29 +1376,29 @@ void MainFrame::OnCheckUpdate(wxCommandEvent &)
 
 	if (!error.empty()) {
 		wxMessageBox(wxString::Format("Could not check for an update:\n\n%s", error),
-		             "RPCEmu - Check for Update", wxOK | wxICON_ERROR, this);
+		             "RPCEmu Extended - Check for Update", wxOK | wxICON_ERROR, this);
 		return;
 	}
 
 	const wxString tag = TagNameFromReleaseJson(body);
 	if (tag.empty()) {
 		wxMessageBox("The reply from GitHub did not name a release.",
-		             "RPCEmu - Check for Update", wxOK | wxICON_ERROR, this);
+		             "RPCEmu Extended - Check for Update", wxOK | wxICON_ERROR, this);
 		return;
 	}
 
 	if (!IsNewerVersion(tag, current)) {
 		wxMessageBox(wxString::Format("You are running the latest version (%s).", current),
-		             "RPCEmu - Check for Update", wxOK | wxICON_INFORMATION, this);
+		             "RPCEmu Extended - Check for Update", wxOK | wxICON_INFORMATION, this);
 		return;
 	}
 
 	if (wxMessageBox(
 	        wxString::Format(
-	            "RPCEmu %s is available. You are running %s.\n\n"
+	            "RPCEmu Extended %s is available. You are running %s.\n\n"
 	            "Open the release page to read the notes and download it?",
 	            tag, current),
-	        "RPCEmu - Check for Update",
+	        "RPCEmu Extended - Check for Update",
 	        wxOK | wxCANCEL | wxICON_INFORMATION, this) == wxOK) {
 		wxLaunchDefaultBrowser(wxString(URL_RELEASE_TAG) + tag);
 	}
@@ -1908,7 +1914,7 @@ void MainFrame::PostGuestCommandResult(unsigned token, unsigned rc,
 void MainFrame::PostMachineSwitched(const std::string &machine_name)
 {
 	CallAfter([this, machine_name]() {
-		SetTitle(wxString::Format("RPCEmu - %s", wxString::FromUTF8(machine_name.c_str())));
+		SetTitle(WindowTitleFor(wxString::FromUTF8(machine_name.c_str())));
 		config_deep_copy(&config_copy_, &config);
 		model_copy_ = machine.model;
 		if (panel_ != nullptr) {

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -96,8 +96,8 @@ const DiscTypeFileMap kDiscTypeFileMaps[] = {
 bool HostResetQuestion(wxWindow *parent)
 {
 	return wxMessageBox(
-	           "This will reset RPCEmu!\n\nOkay to continue?",
-	           "RPCEmu",
+	           "This will reset RPCEmu Extended!\n\nOkay to continue?",
+	           "RPCEmu Extended",
 	           wxOK | wxCANCEL | wxICON_WARNING,
 	           parent) == wxOK;
 }
@@ -378,7 +378,7 @@ void MainFrame::OnScreenshot(wxCommandEvent &)
 	}
 
 	if (panel_ == nullptr || !panel_->SaveScreenshot(dlg.GetPath())) {
-		wxMessageBox("Error saving screenshot", "RPCEmu", wxOK | wxICON_WARNING, this);
+		wxMessageBox("Error saving screenshot", "RPCEmu Extended", wxOK | wxICON_WARNING, this);
 	}
 }
 
@@ -418,7 +418,7 @@ void MainFrame::OnSaveState(wxCommandEvent &)
 
 	if (emulator_) {
 		if (!emulator_->SaveState(dlg.GetPath().utf8_str().data())) {
-			wxMessageBox("Failed to save the machine state.", "RPCEmu",
+			wxMessageBox("Failed to save the machine state.", "RPCEmu Extended",
 			             wxOK | wxICON_WARNING, this);
 		}
 	}
@@ -441,7 +441,7 @@ void MainFrame::OnLoadState(wxCommandEvent &)
 		if (!emulator_->LoadState(dlg.GetPath().utf8_str().data(), &error)) {
 			wxMessageBox(error.empty() ? wxString("Failed to load the machine state.")
 			                           : wxString::FromUTF8(error.c_str()),
-			             "RPCEmu", wxOK | wxICON_WARNING, this);
+			             "RPCEmu Extended", wxOK | wxICON_WARNING, this);
 		}
 	}
 }
@@ -1871,13 +1871,13 @@ void MainFrame::PostFatal(const std::string &message)
 
 void MainFrame::ShowError(const std::string &message)
 {
-	wxMessageBox(wxString::FromUTF8(message), "RPCEmu Error", wxOK | wxICON_WARNING, this);
+	wxMessageBox(wxString::FromUTF8(message), "RPCEmu Extended Error", wxOK | wxICON_WARNING, this);
 }
 
 void MainFrame::ShowFatal(const std::string &message)
 {
 	fatal_occurred_ = true;
-	wxMessageBox(wxString::FromUTF8(message), "RPCEmu Fatal Error", wxOK | wxICON_ERROR, this);
+	wxMessageBox(wxString::FromUTF8(message), "RPCEmu Extended Fatal Error", wxOK | wxICON_ERROR, this);
 
 	// The machine has failed unrecoverably, so terminate the process rather
 	// than attempting a clean shutdown. A normal shutdown joins the emulator

--- a/src/gui/nat_list_dialog.cpp
+++ b/src/gui/nat_list_dialog.cpp
@@ -188,7 +188,7 @@ void NatListDialog::OnDeleteRule(wxCommandEvent &)
 	    rule.emu_port,
 	    rule.host_port);
 
-	if (wxMessageBox(message, "RPCEmu", wxYES_NO | wxICON_QUESTION | wxNO_DEFAULT, this) != wxYES) {
+	if (wxMessageBox(message, "RPCEmu Extended", wxYES_NO | wxICON_QUESTION | wxNO_DEFAULT, this) != wxYES) {
 		return;
 	}
 

--- a/src/gui/vnc_overlay.cpp
+++ b/src/gui/vnc_overlay.cpp
@@ -135,7 +135,7 @@ void draw(VncServer &server)
 		const int indent = CONSOLE_FONT_WIDTH * screen.scale * 3;
 
 		text_screen_clear(&screen, COLOUR_BG);
-		text_screen_centre(&screen, row * 2, "RPCEmu", COLOUR_TITLE);
+		text_screen_centre(&screen, row * 2, "RPCEmu Extended", COLOUR_TITLE);
 		text_screen_centre(&screen, row * 3,
 		    config.name[0] != '\0' ? config.name : "(unnamed machine)", COLOUR_TEXT);
 

--- a/src/gui/vnc_server.cpp
+++ b/src/gui/vnc_server.cpp
@@ -126,7 +126,11 @@ bool VncServer::start(int port, const std::string &password)
 		return false;
 	}
 
-	rfb_screen_->desktopName = const_cast<char *>("RPCEmu - RISC OS");
+	/* libvncserver keeps the pointer rather than copying, so this outlives it. */
+	desktop_name_ = config.name[0] != '\0'
+	    ? std::string("RPCEmu Extended - ") + config.name
+	    : std::string("RPCEmu Extended");
+	rfb_screen_->desktopName = const_cast<char *>(desktop_name_.c_str());
 	rfb_screen_->alwaysShared = TRUE;
 	rfb_screen_->deferUpdateTime = 0;
 	rfb_screen_->port = port;

--- a/src/gui/vnc_server.h
+++ b/src/gui/vnc_server.h
@@ -156,6 +156,7 @@ private:
 	bool running_ = false;
 	char *password_list_[2] = {nullptr, nullptr};
 	std::string current_password_;
+	std::string desktop_name_;
 };
 
 extern VncServer *g_vnc_server;


### PR DESCRIPTION
The title bar carried the version, which the About box already gives and which says nothing useful while a machine is running. It now names the machine, and the fork names itself consistently wherever the user sees it.

## The window title

`RPCEmu v1.1.12` becomes `RPCEmu Extended - <machine>`, so several machines running at once can be told apart.

Two of the three places that set the title already said `RPCEmu - <machine>`; only the constructor carried the version, which is why this looked inconsistent the moment you switched machines. All three now go through one helper, so they cannot drift apart again. The machine name comes from `config.name`, which `rpcemu_prestart()` fills in 37 lines before the frame is built - and `config_load()` already falls back to the configuration's filename when the name field is empty, so the "(unnamed machine)" case is belt and braces rather than expected.

## The application name

| where | was | now |
| --- | --- | --- |
| macOS application menu | RPCEmu | RPCEmu Extended |
| `wxApp` name | *(unset)* | RPCEmu Extended |
| VNC desktop name | RPCEmu - RISC OS | RPCEmu Extended - [machine] |
| dialogue captions | RPCEmu | RPCEmu Extended |
| text overlays | RPCEmu | RPCEmu Extended |

`CFBundleName` is what macOS puts in the application menu, so About/Hide/Quit now agree with the window. It is exactly 15 characters, which is Apple's documented limit, with nothing to spare.

`SetAppName()` was never set. It names the window manager's grouping and captions any dialogue given no title of its own.

The VNC desktop name gains the machine, which matters more here than elsewhere: several machines can run headless at once and a fixed string made them indistinguishable in a client's title bar. The string is held in a member because libvncserver keeps the pointer it is given rather than copying it - a temporary would have dangled.

## What deliberately keeps the old name

| | why |
| --- | --- |
| `wxConfig("RPCEmu", "RPCEmu")` | registry key and settings path - renaming strands existing settings |
| `~/RPCEmu` (GUI and headless) | machines, ROMs, hostfs |
| ATA vendor string in `ide.c` | 8 bytes exactly, and seen by the guest |
| About dialogue | already distinguishes upstream from the fork, and its credits separate the two sets of authors. Left for separate work |

Prose that mentions RPCEmu in passing is also untouched - file dialogue filters, the invalid-state-file warning, the ROM setup text - since some of it is about the emulator generally rather than this build of it.

## Testing

Linux, built clean with the full test suite passing. The first two commits were each built in isolation, so the history bisects rather than only building at the tip.

The overlay titles are centred with `(width - w) / 2`, which goes negative if the text is wider than the screen. `draw_glyph()` bounds-checks every pixel, so that clips rather than corrupting memory; at 120px in a 640px display there is no clipping to begin with.

Not verified: the dialogues have not been eyeballed, and the macOS bundle name has not been seen on a Mac.
