### PR TITLE
macOS: quit when the machine window closes, and show its menus (#53)

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -32,6 +32,7 @@ set(GUI_SOURCES
     package_sources_dialog.cpp
     riscos_fetch.cpp
     riscos_setup_dialog.cpp
+    help_actions.cpp
     support_bundle.cpp
     podule_config_dialog.cpp
     machine_inspector_window.cpp

--- a/src/gui/emulator_host.cpp
+++ b/src/gui/emulator_host.cpp
@@ -321,13 +321,6 @@ extern "C" void rpcemu_set_host_clipboard_image(int file_type, const void *data,
 	}
 }
 
-extern "C" void rpcemu_send_nat_rule_to_gui(PortForwardRule rule)
-{
-	if (g_emulator_host != nullptr) {
-		g_emulator_host->StoreNatRuleForGui(rule);
-	}
-}
-
 extern "C" void rpcemu_request_poweroff(void)
 {
 	/* Guest soft power-off: ask the active front-end to quit. Fall back to
@@ -1446,26 +1439,6 @@ std::string EmulatorHost::DisassembleAt(uint32_t address, int count)
 
 	disasm_cv_.wait(lock, [this]() { return disasm_ready_ || g_fatal_occurred.load(); });
 	return disasm_result_;
-}
-
-void EmulatorHost::StoreNatRuleForGui(PortForwardRule rule)
-{
-	{
-		std::lock_guard<std::mutex> lock(nat_rules_mutex_);
-		pending_nat_rules_.push_back(rule);
-	}
-
-	if (gui_bridge_ != nullptr) {
-		gui_bridge_->PostNatRule(rule);
-	}
-}
-
-std::vector<PortForwardRule> EmulatorHost::TakePendingNatRules()
-{
-	std::lock_guard<std::mutex> lock(nat_rules_mutex_);
-	std::vector<PortForwardRule> rules(pending_nat_rules_.begin(), pending_nat_rules_.end());
-	pending_nat_rules_.clear();
-	return rules;
 }
 
 void EmulatorHost::NotifyDebuggerStateChanged()

--- a/src/gui/emulator_host.h
+++ b/src/gui/emulator_host.h
@@ -25,7 +25,6 @@
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
-#include <deque>
 #include <mutex>
 #include <queue>
 #include <string>
@@ -220,11 +219,9 @@ public:
 	bool SaveState(const std::string &path);
 	bool LoadState(const std::string &path, std::string *error_out);
 
-	void StoreNatRuleForGui(PortForwardRule rule);
 	/* Host clipboard text, on its way to the guest (emulator thread). */
 	void HostClipboardChanged(int file_type, const std::string &data);
 	void ClipboardEnabled(bool enabled);
-	std::vector<PortForwardRule> TakePendingNatRules();
 
 	void IdleProcessEvents();
 	int64_t GetElapsedTimerNs() const;
@@ -276,9 +273,6 @@ private:
 	bool trace_ready_ = false;
 	std::vector<DebugTraceEvent> trace_result_{};
 	uint32_t trace_dropped_ = 0;
-
-	std::mutex nat_rules_mutex_;
-	std::deque<PortForwardRule> pending_nat_rules_;
 
 	std::atomic<bool> flyback_pending_{false};
 };

--- a/src/gui/gui_bridge.h
+++ b/src/gui/gui_bridge.h
@@ -42,7 +42,6 @@ public:
 	virtual void ShowError(const std::string &message) = 0;
 	virtual void ShowFatal(const std::string &message) = 0;
 
-	virtual void PostNatRule(PortForwardRule rule) = 0;
 	virtual void PostDebuggerStateChanged() = 0;
 	virtual void PostMachineSwitched(const std::string &machine_name) = 0;
 

--- a/src/gui/headless_bridge.cpp
+++ b/src/gui/headless_bridge.cpp
@@ -38,10 +38,6 @@ void HeadlessBridge::PostMoveHostMouse(const MouseMoveUpdate & /*update*/)
 {
 }
 
-void HeadlessBridge::PostNatRule(PortForwardRule /*rule*/)
-{
-}
-
 void HeadlessBridge::PostDebuggerStateChanged()
 {
 }

--- a/src/gui/headless_bridge.h
+++ b/src/gui/headless_bridge.h
@@ -45,7 +45,6 @@ public:
 	void ShowError(const std::string &message) override;
 	void ShowFatal(const std::string &message) override;
 
-	void PostNatRule(PortForwardRule rule) override;
 	void PostDebuggerStateChanged() override;
 	void PostMachineSwitched(const std::string &machine_name) override;
 	void PostGuestCommandResult(unsigned token, unsigned rc,

--- a/src/gui/help_actions.cpp
+++ b/src/gui/help_actions.cpp
@@ -1,0 +1,190 @@
+/*
+  RPCEmu - An Acorn system emulator
+
+  Copyright (C) 2026 Andy Timmins
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include "help_actions.h"
+
+#include <wx/msgdlg.h>
+#include <wx/utils.h>
+
+#include "about_dialog.h"
+#include "http_transfer.h"
+#include "riscos_fetch.h"
+
+extern "C" {
+#include "rpcemu.h"
+}
+
+namespace {
+
+/* "v1.1.12" -> 1, 1, 12. Anything unparsable leaves the fields at zero, which
+   compares as older than any real release and so offers the update. */
+void SplitVersion(const wxString &text, long out[3])
+{
+	wxString rest = text;
+
+	out[0] = out[1] = out[2] = 0;
+	if (rest.StartsWith("v")) {
+		rest = rest.Mid(1);
+	}
+	for (int i = 0; i < 3 && !rest.empty(); i++) {
+		wxString field = rest.BeforeFirst('.');
+
+		field.ToLong(&out[i]);
+		rest = rest.AfterFirst('.');
+	}
+}
+
+/* Numerically, so 1.1.9 is older than 1.1.10 rather than sorting after it. */
+bool IsNewerVersion(const wxString &candidate, const wxString &current)
+{
+	long a[3], b[3];
+
+	SplitVersion(candidate, a);
+	SplitVersion(current, b);
+	for (int i = 0; i < 3; i++) {
+		if (a[i] != b[i]) {
+			return a[i] > b[i];
+		}
+	}
+	return false;
+}
+
+/* The one field wanted out of the release JSON. The response has several
+   html_url members - the release, the uploader, others - so the tag is taken
+   and the page built from it rather than trusting their order. */
+wxString TagNameFromReleaseJson(const wxString &json)
+{
+	const wxString key = "\"tag_name\"";
+	const int at = json.Find(key);
+
+	if (at == wxNOT_FOUND) {
+		return wxString();
+	}
+
+	wxString rest = json.Mid(static_cast<size_t>(at) + key.length());
+	rest = rest.AfterFirst(':').Strip(wxString::both);
+	if (!rest.StartsWith("\"")) {
+		return wxString();
+	}
+	return rest.Mid(1).BeforeFirst('"');
+}
+
+} // namespace
+
+void
+HelpShowAbout(wxWindow *parent)
+{
+	AboutDialog dlg(parent);
+	dlg.ShowModal();
+}
+
+void
+HelpOpenOnlineManual(wxWindow *)
+{
+	wxLaunchDefaultBrowser(URL_MANUAL);
+}
+
+void
+HelpOpenWebsite(wxWindow *)
+{
+	wxLaunchDefaultBrowser(URL_WEBSITE);
+}
+
+void
+HelpReportIssue(wxWindow *)
+{
+	wxLaunchDefaultBrowser(URL_ISSUES);
+}
+
+void
+HelpShowAboutRiscos(wxWindow *)
+{
+	wxLaunchDefaultBrowser(URL_RISCOSOPEN);
+}
+
+void
+HelpCheckForUpdate(wxWindow *parent)
+{
+	const wxString current = VERSION;
+
+	/* A development build is ahead of the newest release, not behind it, so
+	   there is nothing useful to compare against. */
+	if (current.Contains("-")) {
+		if (wxMessageBox(
+		        wxString::Format(
+		            "This is a development build (%s), not a release.\n\n"
+		            "Open the releases page?", current),
+		        "RPCEmu Extended - Check for Update",
+		        wxOK | wxCANCEL | wxICON_INFORMATION, parent) == wxOK) {
+			wxLaunchDefaultBrowser(URL_RELEASES);
+		}
+		return;
+	}
+
+	if (!RPCEMU_HAVE_HTTP) {
+		wxMessageBox(HttpUnavailableMessage(), "RPCEmu Extended - Check for Update",
+		             wxOK | wxICON_INFORMATION, parent);
+		return;
+	}
+
+	wxString body, error;
+	{
+		RiscosFetchProgressReporter reporter(parent);
+		Transfer transfer(reporter, "Checking for a newer release...", {});
+
+		if (!transfer.ToMemory(URL_LATEST_RELEASE_API)) {
+			if (transfer.WasCancelled()) {
+				return;
+			}
+			error = transfer.Error();
+		} else {
+			body = transfer.Body();
+		}
+	}
+
+	if (!error.empty()) {
+		wxMessageBox(wxString::Format("Could not check for an update:\n\n%s", error),
+		             "RPCEmu Extended - Check for Update", wxOK | wxICON_ERROR, parent);
+		return;
+	}
+
+	const wxString tag = TagNameFromReleaseJson(body);
+	if (tag.empty()) {
+		wxMessageBox("The reply from GitHub did not name a release.",
+		             "RPCEmu Extended - Check for Update", wxOK | wxICON_ERROR, parent);
+		return;
+	}
+
+	if (!IsNewerVersion(tag, current)) {
+		wxMessageBox(wxString::Format("You are running the latest version (%s).", current),
+		             "RPCEmu Extended - Check for Update", wxOK | wxICON_INFORMATION, parent);
+		return;
+	}
+
+	if (wxMessageBox(
+	        wxString::Format(
+	            "RPCEmu Extended %s is available. You are running %s.\n\n"
+	            "Open the release page to read the notes and download it?",
+	            tag, current),
+	        "RPCEmu Extended - Check for Update",
+	        wxOK | wxCANCEL | wxICON_INFORMATION, parent) == wxOK) {
+		wxLaunchDefaultBrowser(wxString(URL_RELEASE_TAG) + tag);
+	}
+}

--- a/src/gui/help_actions.h
+++ b/src/gui/help_actions.h
@@ -1,0 +1,43 @@
+/*
+  RPCEmu - An Acorn system emulator
+
+  Copyright (C) 2026 Andy Timmins
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+/*
+ * help_actions.h - the Help menu items that need no machine.
+ *
+ * On macOS there are two menu bars: the machine window's, and the one the
+ * application owns for when no window is open. Both offer these, so they live
+ * here rather than on the frame and there is one implementation of each.
+ *
+ * @parent is the window to hang a dialogue off, or null when there is none.
+ */
+
+#ifndef HELP_ACTIONS_H
+#define HELP_ACTIONS_H
+
+class wxWindow;
+
+void HelpShowAbout(wxWindow *parent);
+void HelpShowAboutRiscos(wxWindow *parent);
+void HelpOpenOnlineManual(wxWindow *parent);
+void HelpOpenWebsite(wxWindow *parent);
+void HelpReportIssue(wxWindow *parent);
+void HelpCheckForUpdate(wxWindow *parent);
+
+#endif /* HELP_ACTIONS_H */

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -21,6 +21,7 @@
 #include <wx/wx.h>
 #include <wx/cmdline.h>
 #include <wx/display.h>
+#include <wx/evtloop.h>
 
 #include <cstdarg>
 #include <cstdio>
@@ -66,18 +67,24 @@ public:
 		return wxApp::OnExit();
 	}
 
-	/* Whether wx ever asked the loop to stop, and whether the request could
-	   land: wxAppConsoleBase::ExitMainLoop() is a silent no-op unless the main
-	   loop exists and is running. */
+	/*
+	 * wxAppConsoleBase::ExitMainLoop() only acts while the main loop is the
+	 * active one, and IsRunning() means exactly that - GetActive() == this. A
+	 * request arriving from anywhere else is dropped without a word, which is
+	 * how closing the machine window left the application running.
+	 *
+	 * ScheduleExit() is wx's answer for that case: it marks the loop to finish
+	 * without needing it to be the active one. It does require the loop to have
+	 * been started, so fall back to the base version when there is none.
+	 */
 	void ExitMainLoop() override
 	{
-		const wxEventLoopBase *loop = wxEventLoopBase::GetActive();
+		wxEventLoopBase *loop = GetMainLoop();
 
-		rpclog("RPCEmu: ExitMainLoop, main loop %s, active loop %s\n",
-		       GetMainLoop() == nullptr ? "none" :
-		       GetMainLoop()->IsRunning() ? "running" : "not running",
-		       loop == nullptr ? "none" :
-		       loop == GetMainLoop() ? "is the main loop" : "is a nested loop");
+		if (loop != nullptr && !loop->IsRunning()) {
+			loop->ScheduleExit(0);
+			return;
+		}
 		wxApp::ExitMainLoop();
 	}
 

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -66,11 +66,18 @@ public:
 		return wxApp::OnExit();
 	}
 
-	/* Whether wx ever asked the loop to stop, which is the step between the
-	   window being deleted and the process ending. */
+	/* Whether wx ever asked the loop to stop, and whether the request could
+	   land: wxAppConsoleBase::ExitMainLoop() is a silent no-op unless the main
+	   loop exists and is running. */
 	void ExitMainLoop() override
 	{
-		rpclog("RPCEmu: ExitMainLoop\n");
+		const wxEventLoopBase *loop = wxEventLoopBase::GetActive();
+
+		rpclog("RPCEmu: ExitMainLoop, main loop %s, active loop %s\n",
+		       GetMainLoop() == nullptr ? "none" :
+		       GetMainLoop()->IsRunning() ? "running" : "not running",
+		       loop == nullptr ? "none" :
+		       loop == GetMainLoop() ? "is the main loop" : "is a nested loop");
 		wxApp::ExitMainLoop();
 	}
 

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -58,12 +58,20 @@ public:
 	bool OnInit() override;
 	void OnInitCmdLine(wxCmdLineParser &parser) override;
 
-	/* Reached once the main loop has returned, so a process that is still
-	   around afterwards can be told apart from one whose loop never ended. */
+	/* Not proof that the loop ended: macOS also calls this straight from
+	   applicationWillTerminate: when the Dock quits the app. */
 	int OnExit() override
 	{
-		rpclog("RPCEmu: event loop finished, exiting\n");
+		rpclog("RPCEmu: OnExit\n");
 		return wxApp::OnExit();
+	}
+
+	/* Whether wx ever asked the loop to stop, which is the step between the
+	   window being deleted and the process ending. */
+	void ExitMainLoop() override
+	{
+		rpclog("RPCEmu: ExitMainLoop\n");
+		wxApp::ExitMainLoop();
 	}
 
 private:

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -37,7 +37,6 @@
 #include "data_dir_dialog.h"
 #include "gui_preferences.h"
 #include "config_selector_dialog.h"
-#include "help_actions.h"
 #include "main_frame.h"
 #include "headless_main.h"
 #include "http_transfer.h"	/* RPCEMU_HAVE_HTTP */
@@ -61,9 +60,6 @@ public:
 
 private:
 	void InstallSignalHandlers();
-#ifdef __WXOSX__
-	void BuildAppMenuBar();
-#endif
 };
 
 /*
@@ -154,91 +150,6 @@ void HandleResetSignal(int /*signum*/)
 		   through the same helper so the log reads the same either way. */
 		EmulatorResetForSignal(nullptr);
 	}
-}
-#endif
-
-#ifdef __WXOSX__
-/*
- * A window nobody sees, so that the menu bar has an owner.
- *
- * macOS has one menu bar for the application rather than one per window, and
- * something has to be on it before the first machine window opens and after
- * the last one closes. MacSetCommonMenuBar() will put a bar up with no window
- * behind it, but wxWidgets cannot then enable anything on it: EnableTop() and
- * Refresh() both start with wxCHECK_RET(IsAttached()), and IsAttached() means
- * "has a frame". Cocoa asks before opening a menu, wx answers from those, and
- * every item comes up greyed - including Quit, and a greyed item is never
- * dispatched at all.
- *
- * Owning the bar from a real frame answers that: the frame is never shown, so
- * there is nothing on screen, but IsAttached() is true and the items behave.
- */
-class AppMenuFrame : public wxFrame {
-public:
-	AppMenuFrame() : wxFrame(nullptr, wxID_ANY, wxEmptyString) { }
-
-	/* Or the application could never quit: IsLastBeforeExit() walks every
-	   top-level window and any one of them saying yes keeps the process
-	   alive, whether or not it is visible. wxWidgets overrides this the same
-	   way for its own help and log windows. */
-	bool ShouldPreventAppExit() const override { return false; }
-};
-
-/*
- * The menu bar the application owns, as distinct from a machine window's.
- *
- * Only the items that mean something with no machine running: everything else
- * would need an emulator to act on. wxWidgets supplies the application menu
- * itself - About, Hide, Services, Quit - and moves wxID_ABOUT into it.
- */
-void RpcemuApp::BuildAppMenuBar()
-{
-	auto *help_menu = new wxMenu;
-
-	help_menu->Append(ID_MENU_ONLINE_MANUAL, "Online Manual...");
-	help_menu->Append(ID_MENU_VISIT_WEBSITE, "Visit Website...");
-	help_menu->Append(ID_MENU_REPORT_ISSUE, "Report an Issue...");
-	help_menu->Append(ID_MENU_CHECK_UPDATE, "Check for Update...");
-	help_menu->AppendSeparator();
-	help_menu->Append(ID_MENU_ABOUT_RISCOS, "About RISC OS...");
-	help_menu->Append(wxID_ABOUT, "About RPCEmu Extended...");
-
-	auto *file_menu = new wxMenu;
-
-	file_menu->Append(wxID_EXIT, "E&xit");
-
-	auto *bar = new wxMenuBar;
-
-	bar->Append(file_menu, "&File");
-	bar->Append(help_menu, "&Help");
-
-	auto *frame = new AppMenuFrame;
-
-	/* SetMenuBar() rather than MacSetCommonMenuBar(): this is the frame's own
-	   bar, which is what makes it usable. */
-	frame->SetMenuBar(bar);
-
-	frame->Bind(wxEVT_MENU, [](wxCommandEvent &) { HelpShowAbout(nullptr); },
-	    wxID_ABOUT);
-	frame->Bind(wxEVT_MENU, [](wxCommandEvent &) { HelpShowAboutRiscos(nullptr); },
-	    ID_MENU_ABOUT_RISCOS);
-	frame->Bind(wxEVT_MENU, [](wxCommandEvent &) { HelpOpenOnlineManual(nullptr); },
-	    ID_MENU_ONLINE_MANUAL);
-	frame->Bind(wxEVT_MENU, [](wxCommandEvent &) { HelpOpenWebsite(nullptr); },
-	    ID_MENU_VISIT_WEBSITE);
-	frame->Bind(wxEVT_MENU, [](wxCommandEvent &) { HelpReportIssue(nullptr); },
-	    ID_MENU_REPORT_ISSUE);
-	frame->Bind(wxEVT_MENU, [](wxCommandEvent &) { HelpCheckForUpdate(nullptr); },
-	    ID_MENU_CHECK_UPDATE);
-
-	/* Quit has to do the work itself. What it falls back to, ExitMainLoop(),
-	   does nothing before OnRun(): the selector runs inside OnInit(), where
-	   there is no main loop yet. Ending the dialogue unwinds the loop that
-	   does exist, and startup then takes its "no machine chosen" path. */
-	frame->Bind(wxEVT_MENU, [](wxCommandEvent &) {
-		EndModalDialogues();
-		wxTheApp->ExitMainLoop();
-	}, wxID_EXIT);
 }
 #endif
 
@@ -787,12 +698,6 @@ bool RpcemuApp::OnInit()
 	// wxMSW does not; without this, PNG bitmaps (toolbar icons, app icon) fail
 	// to load.
 	wxInitAllImageHandlers();
-
-#ifdef __WXOSX__
-	/* Before the selector, so there is a menu bar for the whole life of the
-	   process rather than only while a machine window is open. */
-	BuildAppMenuBar();
-#endif
 
 	/*
 	 * The only call that passes a prompt, so the first-run question can only

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -58,6 +58,14 @@ public:
 	bool OnInit() override;
 	void OnInitCmdLine(wxCmdLineParser &parser) override;
 
+	/* Reached once the main loop has returned, so a process that is still
+	   around afterwards can be told apart from one whose loop never ended. */
+	int OnExit() override
+	{
+		rpclog("RPCEmu: event loop finished, exiting\n");
+		return wxApp::OnExit();
+	}
+
 private:
 	void InstallSignalHandlers();
 };

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -59,14 +59,6 @@ public:
 	bool OnInit() override;
 	void OnInitCmdLine(wxCmdLineParser &parser) override;
 
-	/* Not proof that the loop ended: macOS also calls this straight from
-	   applicationWillTerminate: when the Dock quits the app. */
-	int OnExit() override
-	{
-		rpclog("RPCEmu: OnExit\n");
-		return wxApp::OnExit();
-	}
-
 	/*
 	 * wxAppConsoleBase::ExitMainLoop() only acts while the main loop is the
 	 * active one, and IsRunning() means exactly that - GetActive() == this. A

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -37,6 +37,7 @@
 #include "data_dir_dialog.h"
 #include "gui_preferences.h"
 #include "config_selector_dialog.h"
+#include "help_actions.h"
 #include "main_frame.h"
 #include "headless_main.h"
 #include "http_transfer.h"	/* RPCEMU_HAVE_HTTP */
@@ -60,9 +61,36 @@ public:
 
 private:
 	void InstallSignalHandlers();
+#ifdef __WXOSX__
+	void BuildAppMenuBar();
+#endif
 };
 
+/*
+ * Close any modal dialogue, so a nested event loop unwinds.
+ *
+ * The iterator is tested directly rather than against nullptr. wxWidgets
+ * defines wxWindowList::compatibility_iterator two different ways: with
+ * wxUSE_STL it is a class offering operator bool() and no comparison with
+ * nullptr_t, and without it a wrapper that converts to a node pointer. Only the
+ * second form compiles against nullptr, so a build with the STL containers
+ * enabled - which is what Homebrew's wx gives on macOS - failed here with
+ * "invalid operands to binary expression". Truth-testing works in both.
+ * Reported by Septercius, issue #30.
+ */
 #ifndef __WXMSW__
+static void EndModalDialogues()
+{
+	for (auto node = wxTopLevelWindows.GetFirst(); node;
+	     node = node->GetNext()) {
+		auto *dialog = dynamic_cast<wxDialog *>(node->GetData());
+
+		if (dialog != nullptr && dialog->IsModal()) {
+			dialog->EndModal(wxID_CANCEL);
+		}
+	}
+}
+
 /*
  * Ctrl-C, or a "please stop" from the system.
  *
@@ -98,22 +126,7 @@ void HandleQuitSignal(int signum)
 	   emulator would appear to ignore it. End the dialogue first, which
 	   unwinds that loop and lets the startup path fall through to its "no
 	   machine chosen" exit. */
-	/* The iterator is tested directly rather than against nullptr. wxWidgets
-	   defines wxWindowList::compatibility_iterator two different ways: with
-	   wxUSE_STL it is a class offering operator bool() and no comparison with
-	   nullptr_t, and without it a wrapper that converts to a node pointer. Only
-	   the second form compiles against nullptr, so a build with the STL
-	   containers enabled - which is what Homebrew's wx gives on macOS - failed
-	   here with "invalid operands to binary expression". Truth-testing works in
-	   both. Reported by Septercius, issue #30. */
-	for (auto node = wxTopLevelWindows.GetFirst(); node;
-	     node = node->GetNext()) {
-		auto *dialog = dynamic_cast<wxDialog *>(node->GetData());
-
-		if (dialog != nullptr && dialog->IsModal()) {
-			dialog->EndModal(wxID_CANCEL);
-		}
-	}
+	EndModalDialogues();
 
 	wxTheApp->ExitMainLoop();
 }
@@ -141,6 +154,91 @@ void HandleResetSignal(int /*signum*/)
 		   through the same helper so the log reads the same either way. */
 		EmulatorResetForSignal(nullptr);
 	}
+}
+#endif
+
+#ifdef __WXOSX__
+/*
+ * A window nobody sees, so that the menu bar has an owner.
+ *
+ * macOS has one menu bar for the application rather than one per window, and
+ * something has to be on it before the first machine window opens and after
+ * the last one closes. MacSetCommonMenuBar() will put a bar up with no window
+ * behind it, but wxWidgets cannot then enable anything on it: EnableTop() and
+ * Refresh() both start with wxCHECK_RET(IsAttached()), and IsAttached() means
+ * "has a frame". Cocoa asks before opening a menu, wx answers from those, and
+ * every item comes up greyed - including Quit, and a greyed item is never
+ * dispatched at all.
+ *
+ * Owning the bar from a real frame answers that: the frame is never shown, so
+ * there is nothing on screen, but IsAttached() is true and the items behave.
+ */
+class AppMenuFrame : public wxFrame {
+public:
+	AppMenuFrame() : wxFrame(nullptr, wxID_ANY, wxEmptyString) { }
+
+	/* Or the application could never quit: IsLastBeforeExit() walks every
+	   top-level window and any one of them saying yes keeps the process
+	   alive, whether or not it is visible. wxWidgets overrides this the same
+	   way for its own help and log windows. */
+	bool ShouldPreventAppExit() const override { return false; }
+};
+
+/*
+ * The menu bar the application owns, as distinct from a machine window's.
+ *
+ * Only the items that mean something with no machine running: everything else
+ * would need an emulator to act on. wxWidgets supplies the application menu
+ * itself - About, Hide, Services, Quit - and moves wxID_ABOUT into it.
+ */
+void RpcemuApp::BuildAppMenuBar()
+{
+	auto *help_menu = new wxMenu;
+
+	help_menu->Append(ID_MENU_ONLINE_MANUAL, "Online Manual...");
+	help_menu->Append(ID_MENU_VISIT_WEBSITE, "Visit Website...");
+	help_menu->Append(ID_MENU_REPORT_ISSUE, "Report an Issue...");
+	help_menu->Append(ID_MENU_CHECK_UPDATE, "Check for Update...");
+	help_menu->AppendSeparator();
+	help_menu->Append(ID_MENU_ABOUT_RISCOS, "About RISC OS...");
+	help_menu->Append(wxID_ABOUT, "About RPCEmu Extended...");
+
+	auto *file_menu = new wxMenu;
+
+	file_menu->Append(wxID_EXIT, "E&xit");
+
+	auto *bar = new wxMenuBar;
+
+	bar->Append(file_menu, "&File");
+	bar->Append(help_menu, "&Help");
+
+	auto *frame = new AppMenuFrame;
+
+	/* SetMenuBar() rather than MacSetCommonMenuBar(): this is the frame's own
+	   bar, which is what makes it usable. */
+	frame->SetMenuBar(bar);
+
+	frame->Bind(wxEVT_MENU, [](wxCommandEvent &) { HelpShowAbout(nullptr); },
+	    wxID_ABOUT);
+	frame->Bind(wxEVT_MENU, [](wxCommandEvent &) { HelpShowAboutRiscos(nullptr); },
+	    ID_MENU_ABOUT_RISCOS);
+	frame->Bind(wxEVT_MENU, [](wxCommandEvent &) { HelpOpenOnlineManual(nullptr); },
+	    ID_MENU_ONLINE_MANUAL);
+	frame->Bind(wxEVT_MENU, [](wxCommandEvent &) { HelpOpenWebsite(nullptr); },
+	    ID_MENU_VISIT_WEBSITE);
+	frame->Bind(wxEVT_MENU, [](wxCommandEvent &) { HelpReportIssue(nullptr); },
+	    ID_MENU_REPORT_ISSUE);
+	frame->Bind(wxEVT_MENU, [](wxCommandEvent &) { HelpCheckForUpdate(nullptr); },
+	    ID_MENU_CHECK_UPDATE);
+
+	/* Quit has to do the work itself. What it falls back to, ExitMainLoop(),
+	   does nothing before OnRun(): the selector runs inside OnInit(), where
+	   there is no main loop yet. Ending the dialogue unwinds the loop that
+	   does exist, and startup then takes its "no machine chosen" path. */
+	frame->Bind(wxEVT_MENU, [](wxCommandEvent &) {
+		EndModalDialogues();
+		wxTheApp->ExitMainLoop();
+	}, wxID_EXIT);
 }
 #endif
 
@@ -689,6 +787,12 @@ bool RpcemuApp::OnInit()
 	// wxMSW does not; without this, PNG bitmaps (toolbar icons, app icon) fail
 	// to load.
 	wxInitAllImageHandlers();
+
+#ifdef __WXOSX__
+	/* Before the selector, so there is a menu bar for the whole life of the
+	   process rather than only while a machine window is open. */
+	BuildAppMenuBar();
+#endif
 
 	/*
 	 * The only call that passes a prompt, so the first-run question can only

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -45,6 +45,7 @@
 
 #include "about_dialog.h"
 #include "config_paths.h"
+#include "help_actions.h"
 #include "gui_preferences.h"
 #include "input_helpers.h"
 #include "machine_edit_dialog.h"
@@ -1269,17 +1270,17 @@ void MainFrame::OnMachineInspector(wxCommandEvent &)
 
 void MainFrame::OnOnlineManual(wxCommandEvent &)
 {
-	wxLaunchDefaultBrowser(URL_MANUAL);
+	HelpOpenOnlineManual(this);
 }
 
 void MainFrame::OnVisitWebsite(wxCommandEvent &)
 {
-	wxLaunchDefaultBrowser(URL_WEBSITE);
+	HelpOpenWebsite(this);
 }
 
 void MainFrame::OnReportIssue(wxCommandEvent &)
 {
-	wxLaunchDefaultBrowser(URL_ISSUES);
+	HelpReportIssue(this);
 }
 
 void MainFrame::OnSupportBundle(wxCommandEvent &)
@@ -1345,136 +1346,15 @@ void MainFrame::OnSupportBundle(wxCommandEvent &)
 	    "RPCEmu Extended - Support Files", wxOK | wxICON_INFORMATION, this);
 }
 
-namespace {
-
-/* "v1.1.12" -> 1, 1, 12. Anything unparsable leaves the fields at zero, which
-   compares as older than any real release and so offers the update. */
-void SplitVersion(const wxString &text, long out[3])
-{
-	wxString rest = text;
-
-	out[0] = out[1] = out[2] = 0;
-	if (rest.StartsWith("v")) {
-		rest = rest.Mid(1);
-	}
-	for (int i = 0; i < 3 && !rest.empty(); i++) {
-		wxString field = rest.BeforeFirst('.');
-
-		field.ToLong(&out[i]);
-		rest = rest.AfterFirst('.');
-	}
-}
-
-/* Numerically, so 1.1.9 is older than 1.1.10 rather than sorting after it. */
-bool IsNewerVersion(const wxString &candidate, const wxString &current)
-{
-	long a[3], b[3];
-
-	SplitVersion(candidate, a);
-	SplitVersion(current, b);
-	for (int i = 0; i < 3; i++) {
-		if (a[i] != b[i]) {
-			return a[i] > b[i];
-		}
-	}
-	return false;
-}
-
-/* The one field wanted out of the release JSON. The response has several
-   html_url members - the release, the uploader, others - so the tag is taken
-   and the page built from it rather than trusting their order. */
-wxString TagNameFromReleaseJson(const wxString &json)
-{
-	const wxString key = "\"tag_name\"";
-	const int at = json.Find(key);
-
-	if (at == wxNOT_FOUND) {
-		return wxString();
-	}
-
-	wxString rest = json.Mid(static_cast<size_t>(at) + key.length());
-	rest = rest.AfterFirst(':').Strip(wxString::both);
-	if (!rest.StartsWith("\"")) {
-		return wxString();
-	}
-	return rest.Mid(1).BeforeFirst('"');
-}
-
-} // namespace
-
 void MainFrame::OnCheckUpdate(wxCommandEvent &)
 {
-	const wxString current = VERSION;
-
-	/* A development build is ahead of the newest release, not behind it, so
-	   there is nothing useful to compare against. */
-	if (current.Contains("-")) {
-		if (wxMessageBox(
-		        wxString::Format(
-		            "This is a development build (%s), not a release.\n\n"
-		            "Open the releases page?", current),
-		        "RPCEmu Extended - Check for Update",
-		        wxOK | wxCANCEL | wxICON_INFORMATION, this) == wxOK) {
-			wxLaunchDefaultBrowser(URL_RELEASES);
-		}
-		return;
-	}
-
-	if (!RPCEMU_HAVE_HTTP) {
-		wxMessageBox(HttpUnavailableMessage(), "RPCEmu Extended - Check for Update",
-		             wxOK | wxICON_INFORMATION, this);
-		return;
-	}
-
-	wxString body, error;
-	{
-		RiscosFetchProgressReporter reporter(this);
-		Transfer transfer(reporter, "Checking for a newer release...", {});
-
-		if (!transfer.ToMemory(URL_LATEST_RELEASE_API)) {
-			if (transfer.WasCancelled()) {
-				return;
-			}
-			error = transfer.Error();
-		} else {
-			body = transfer.Body();
-		}
-	}
-
-	if (!error.empty()) {
-		wxMessageBox(wxString::Format("Could not check for an update:\n\n%s", error),
-		             "RPCEmu Extended - Check for Update", wxOK | wxICON_ERROR, this);
-		return;
-	}
-
-	const wxString tag = TagNameFromReleaseJson(body);
-	if (tag.empty()) {
-		wxMessageBox("The reply from GitHub did not name a release.",
-		             "RPCEmu Extended - Check for Update", wxOK | wxICON_ERROR, this);
-		return;
-	}
-
-	if (!IsNewerVersion(tag, current)) {
-		wxMessageBox(wxString::Format("You are running the latest version (%s).", current),
-		             "RPCEmu Extended - Check for Update", wxOK | wxICON_INFORMATION, this);
-		return;
-	}
-
-	if (wxMessageBox(
-	        wxString::Format(
-	            "RPCEmu Extended %s is available. You are running %s.\n\n"
-	            "Open the release page to read the notes and download it?",
-	            tag, current),
-	        "RPCEmu Extended - Check for Update",
-	        wxOK | wxCANCEL | wxICON_INFORMATION, this) == wxOK) {
-		wxLaunchDefaultBrowser(wxString(URL_RELEASE_TAG) + tag);
-	}
+	HelpCheckForUpdate(this);
 }
 
 /* RISC OS is not ours, and this is where it comes from. */
 void MainFrame::OnAboutRiscos(wxCommandEvent &)
 {
-	wxLaunchDefaultBrowser(URL_RISCOSOPEN);
+	HelpShowAboutRiscos(this);
 }
 
 void MainFrame::OnAbout(wxCommandEvent &)
@@ -1482,9 +1362,7 @@ void MainFrame::OnAbout(wxCommandEvent &)
 	if (panel_ != nullptr) {
 		panel_->ReleaseMouseCapture();
 	}
-
-	AboutDialog dlg(this);
-	dlg.ShowModal();
+	HelpShowAbout(this);
 }
 
 #ifdef RPCEMU_VNC

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -1808,6 +1808,10 @@ void MainFrame::OnActivate(wxActivateEvent &event)
 	} else if (panel_ != nullptr) {
 		panel_->FocusPanel();
 	}
+	/* wxFrame's own handler is what puts this window's menu bar up on macOS,
+	   where the bar belongs to the application rather than to a window. Without
+	   this the File, Disc and Settings menus never appeared at all. */
+	event.Skip();
 }
 
 /* Let the guest change screen mode to match the host display.

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -250,7 +250,6 @@ MainFrame::MainFrame()
 	}
 
 	emulator_ = std::make_unique<EmulatorHost>(this);
-	nat_list_dialog_ = std::make_unique<NatListDialog>(this, emulator_.get());
 
 #ifdef RPCEMU_VNC
 	/*
@@ -753,9 +752,9 @@ void MainFrame::OnMachine(wxCommandEvent &) { EditMachineConfiguration(); }
 void MainFrame::OnNatList(wxCommandEvent &)
 {
 #ifdef RPCEMU_NETWORKING
-	if (nat_list_dialog_) {
-		nat_list_dialog_->ShowRules();
-	}
+	NatListDialog dlg(this, emulator_.get());
+
+	dlg.ShowRules();
 #else
 	/* Networking (and the NAT list) is not compiled in - nothing to do.
 	   (The handler's wxCommandEvent parameter is unnamed, so nothing to void.) */
@@ -1852,11 +1851,6 @@ void MainFrame::ShowFatal(const std::string &message)
 	// which would themselves try to join the spinning thread).
 	fflush(nullptr);
 	std::_Exit(EXIT_FAILURE);
-}
-
-void MainFrame::PostNatRule(PortForwardRule rule)
-{
-	CallAfter([rule]() { NatListDialogNotifyRule(rule); });
 }
 
 void MainFrame::PostDebuggerStateChanged()

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -1956,9 +1956,22 @@ void MainFrame::OnClose(wxCloseEvent &event)
 	wxWakeUpIdle();
 
 	/* Anything still open here keeps wx from treating this as the last window
-	   and ending the loop. */
+	   and ending the loop, so say what they are. */
 	rpclog("MainFrame: closed, %u top level windows remain\n",
 	       (unsigned) wxTopLevelWindows.GetCount());
+	for (auto node = wxTopLevelWindows.GetFirst(); node;
+	     node = node->GetNext()) {
+		const wxWindow *win = node->GetData();
+		const auto *tlw = dynamic_cast<const wxTopLevelWindow *>(win);
+
+		rpclog("  %s \"%s\"%s%s%s\n",
+		       (const char *) wxString(win->GetClassInfo()->GetClassName()).utf8_str(),
+		       (const char *) win->GetLabel().utf8_str(),
+		       win == this ? " (this)" : "",
+		       win->IsShown() ? " shown" : " hidden",
+		       tlw != nullptr && tlw->ShouldPreventAppExit() ?
+		       " prevents exit" : "");
+	}
 }
 
 void MainFrame::CloseForSignal()

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -299,6 +299,11 @@ MainFrame::MainFrame()
 
 MainFrame::~MainFrame()
 {
+	/* Reached only once wx prunes wxPendingDelete on an idle pass, which is
+	   also what ends the event loop. Says whether a process still running
+	   after its window closed ever got this far. */
+	rpclog("MainFrame: window destroyed\n");
+
 #ifdef RPCEMU_VNC
 	if (vnc_server_) {
 		/* Detached, not stopped: the server outlives this window, and a client
@@ -1943,6 +1948,17 @@ void MainFrame::OnClose(wxCloseEvent &event)
 	ShutdownEmulator();
 	shutting_down_ = true;
 	Destroy();
+
+	/* Destroy() only queues the window; wx deletes it on the next idle pass,
+	   and deleting the last one is what ends the loop. ShutdownEmulator() has
+	   just stopped the timers, so on macOS nothing else would wake the run loop
+	   and that pass would never come. */
+	wxWakeUpIdle();
+
+	/* Anything still open here keeps wx from treating this as the last window
+	   and ending the loop. */
+	rpclog("MainFrame: closed, %u top level windows remain\n",
+	       (unsigned) wxTopLevelWindows.GetCount());
 }
 
 void MainFrame::CloseForSignal()

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -299,11 +299,6 @@ MainFrame::MainFrame()
 
 MainFrame::~MainFrame()
 {
-	/* Reached only once wx prunes wxPendingDelete on an idle pass, which is
-	   also what ends the event loop. Says whether a process still running
-	   after its window closed ever got this far. */
-	rpclog("MainFrame: window destroyed\n");
-
 #ifdef RPCEMU_VNC
 	if (vnc_server_) {
 		/* Detached, not stopped: the server outlives this window, and a client
@@ -1948,30 +1943,6 @@ void MainFrame::OnClose(wxCloseEvent &event)
 	ShutdownEmulator();
 	shutting_down_ = true;
 	Destroy();
-
-	/* Destroy() only queues the window; wx deletes it on the next idle pass,
-	   and deleting the last one is what ends the loop. ShutdownEmulator() has
-	   just stopped the timers, so on macOS nothing else would wake the run loop
-	   and that pass would never come. */
-	wxWakeUpIdle();
-
-	/* Anything still open here keeps wx from treating this as the last window
-	   and ending the loop, so say what they are. */
-	rpclog("MainFrame: closed, %u top level windows remain\n",
-	       (unsigned) wxTopLevelWindows.GetCount());
-	for (auto node = wxTopLevelWindows.GetFirst(); node;
-	     node = node->GetNext()) {
-		const wxWindow *win = node->GetData();
-		const auto *tlw = dynamic_cast<const wxTopLevelWindow *>(win);
-
-		rpclog("  %s \"%s\"%s%s%s\n",
-		       (const char *) wxString(win->GetClassInfo()->GetClassName()).utf8_str(),
-		       (const char *) win->GetLabel().utf8_str(),
-		       win == this ? " (this)" : "",
-		       win->IsShown() ? " shown" : " hidden",
-		       tlw != nullptr && tlw->ShouldPreventAppExit() ?
-		       " prevents exit" : "");
-	}
 }
 
 void MainFrame::CloseForSignal()

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -1943,6 +1943,13 @@ void MainFrame::OnClose(wxCloseEvent &event)
 	ShutdownEmulator();
 	shutting_down_ = true;
 	Destroy();
+
+#ifdef __WXOSX__
+	/* Linux and Windows exit when the last frame goes; wxOSX does not. Queued
+	   on the application, not this frame: Destroy() is deferred, and a callback
+	   queued on a window that is then deleted is dropped. */
+	wxTheApp->CallAfter([] { wxTheApp->ExitMainLoop(); });
+#endif
 }
 
 void MainFrame::CloseForSignal()

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -1943,13 +1943,6 @@ void MainFrame::OnClose(wxCloseEvent &event)
 	ShutdownEmulator();
 	shutting_down_ = true;
 	Destroy();
-
-#ifdef __WXOSX__
-	/* Linux and Windows exit when the last frame goes; wxOSX does not. Queued
-	   on the application, not this frame: Destroy() is deferred, and a callback
-	   queued on a window that is then deleted is dropped. */
-	wxTheApp->CallAfter([] { wxTheApp->ExitMainLoop(); });
-#endif
 }
 
 void MainFrame::CloseForSignal()

--- a/src/gui/main_frame.h
+++ b/src/gui/main_frame.h
@@ -171,7 +171,6 @@ public:
 	void PostMoveHostMouse(const MouseMoveUpdate &update) override;
 	void ShowError(const std::string &message) override;
 	void ShowFatal(const std::string &message) override;
-	void PostNatRule(PortForwardRule rule) override;
 	void PostDebuggerStateChanged() override;
 	void PostMachineSwitched(const std::string &machine_name) override;
 	void PostGuestCommandResult(unsigned token, unsigned rc,
@@ -294,7 +293,6 @@ private:
 	Config config_copy_{};
 	Model model_copy_ = Model_RPCARM710;
 	std::unique_ptr<EmulatorHost> emulator_;
-	std::unique_ptr<NatListDialog> nat_list_dialog_;
 	MachineInspectorWindow *machine_inspector_window_ = nullptr;
 #ifdef RPCEMU_VNC
 	/* Borrowed from vnc_app: the process owns the server, this window only points

--- a/src/gui/nat_edit_dialog.h
+++ b/src/gui/nat_edit_dialog.h
@@ -34,10 +34,6 @@ class NatEditDialog : public wxDialog {
 public:
 	NatEditDialog(NatListDialog *parent);
 
-	/* As for the list dialog it belongs to: built up front, hidden until
-	   wanted, and not something to keep the application alive. */
-	bool ShouldPreventAppExit() const override { return false; }
-
 	void SetValues(bool is_edit, PortForwardRule rule);
 
 private:

--- a/src/gui/nat_edit_dialog.h
+++ b/src/gui/nat_edit_dialog.h
@@ -34,6 +34,10 @@ class NatEditDialog : public wxDialog {
 public:
 	NatEditDialog(NatListDialog *parent);
 
+	/* As for the list dialog it belongs to: built up front, hidden until
+	   wanted, and not something to keep the application alive. */
+	bool ShouldPreventAppExit() const override { return false; }
+
 	void SetValues(bool is_edit, PortForwardRule rule);
 
 private:

--- a/src/gui/nat_list_dialog.cpp
+++ b/src/gui/nat_list_dialog.cpp
@@ -28,8 +28,6 @@ enum {
 	ID_NAT_LIST_DELETE,
 };
 
-static NatListDialog *g_active_nat_list_dialog = nullptr;
-
 NatListDialog::NatListDialog(wxWindow *parent, EmulatorHost *emulator_host)
 	: wxDialog(parent, wxID_ANY, "Configure NAT Port Forwarding Rules", wxDefaultPosition, wxSize(560, 360),
 	           wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxCLOSE_BOX)
@@ -39,23 +37,6 @@ NatListDialog::NatListDialog(wxWindow *parent, EmulatorHost *emulator_host)
 	LoadRulesFromConfig();
 	Fit();
 	CentreOnParent();
-
-	g_active_nat_list_dialog = this;
-}
-
-NatListDialog::~NatListDialog()
-{
-	if (g_active_nat_list_dialog == this) {
-		g_active_nat_list_dialog = nullptr;
-	}
-	delete nat_edit_dialog_;
-}
-
-void NatListDialogNotifyRule(PortForwardRule rule)
-{
-	if (g_active_nat_list_dialog != nullptr) {
-		g_active_nat_list_dialog->AddNatRule(rule);
-	}
 }
 
 void NatListDialog::BuildUi()

--- a/src/gui/nat_list_dialog.h
+++ b/src/gui/nat_list_dialog.h
@@ -35,13 +35,6 @@ class NatEditDialog;
 class NatListDialog : public wxDialog {
 public:
 	NatListDialog(wxWindow *parent, EmulatorHost *emulator_host);
-	~NatListDialog() override;
-
-	/* Built once at startup and kept hidden until asked for, so it is not a
-	   window the user would think of as open. Every top level window claims
-	   otherwise by default, which would leave wx believing the machine window
-	   was not the last one and stop it ending the application. */
-	bool ShouldPreventAppExit() const override { return false; }
 
 	void AddNatRule(PortForwardRule rule);
 
@@ -72,6 +65,5 @@ private:
 	NatEditDialog *nat_edit_dialog_ = nullptr;
 };
 
-void NatListDialogNotifyRule(PortForwardRule rule);
 
 #endif

--- a/src/gui/nat_list_dialog.h
+++ b/src/gui/nat_list_dialog.h
@@ -37,6 +37,12 @@ public:
 	NatListDialog(wxWindow *parent, EmulatorHost *emulator_host);
 	~NatListDialog() override;
 
+	/* Built once at startup and kept hidden until asked for, so it is not a
+	   window the user would think of as open. Every top level window claims
+	   otherwise by default, which would leave wx believing the machine window
+	   was not the last one and stop it ending the application. */
+	bool ShouldPreventAppExit() const override { return false; }
+
 	void AddNatRule(PortForwardRule rule);
 
 	/* Show the dialog, re-reading the rules first. The dialog is built once at

--- a/src/network-nat.c
+++ b/src/network-nat.c
@@ -313,8 +313,6 @@ network_nat_open(void)
 		for (i = 0; i < MAX_PORT_FORWARDS; i++) {
 			if (port_forward_rules[i].type != PORT_FORWARD_NONE) {
 				network_nat_forward_add(port_forward_rules[i]);
-
-				rpcemu_send_nat_rule_to_gui(port_forward_rules[i]);
 			}
 		}
 	}

--- a/src/rpcemu.h
+++ b/src/rpcemu.h
@@ -466,7 +466,6 @@ extern int debugger_swi_hook(uint32_t swinum, uint32_t opcode);
 extern void rpcemu_video_update(const uint32_t *buffer, int xsize, int ysize, int yl, int yh, int double_size, int host_xsize, int host_ysize);
 extern void rpcemu_move_host_mouse(uint16_t x, uint16_t y);
 extern void rpcemu_idle_process_events(void);
-extern void rpcemu_send_nat_rule_to_gui(PortForwardRule rule);
 extern uint64_t rpcemu_nsec_timer_ticks(void);
 
 extern int drawscre;

--- a/tests/test_stubs.c
+++ b/tests/test_stubs.c
@@ -58,7 +58,6 @@ void rpcemu_video_update(const uint32_t *buffer, int xsize, int ysize, int yl,
 void rpcemu_move_host_mouse(uint16_t x, uint16_t y) { (void) x; (void) y; }
 void rpcemu_idle_process_events(void) {}
 void rpcemu_request_poweroff(void) {}
-void rpcemu_send_nat_rule_to_gui(void) {}
 /* Emulated time. Most tests never run a timer and are happy with zero, but a
    test that boots a machine must have time advance or the IOMD timers never fire
    and RISC OS waits for an interrupt for ever. Such a test defines


### PR DESCRIPTION
Fixes #53, reported by @riscos-richard: closing a machine left RPCEmu running in the Dock with a menu bar that did nothing, and the application menu was a stub before any machine started.

Three separate faults.

## 1. The machine window's menus never appeared

`MainFrame::OnActivate()` handled the event without calling `event.Skip()`. On macOS the menu bar belongs to the application rather than to a window, and `wxFrame::OnActivate()` is what installs the active window's bar (`src/osx/carbon/frame.cpp:214`). Skipping the event lets wx's own handler run.

## 2. Two hidden dialogues kept the application alive

`NatListDialog` and its `NatEditDialog` are built with the machine window and stay hidden until asked for: the list dialogue has to exist so the port forwarding rules read at NAT startup have somewhere to go.

`wxTopLevelWindow::ShouldPreventAppExit()` returns true by default and takes no notice of whether a window is shown (`include/wx/toplevel.h:231`), so wx counted both and never treated the machine window as the last one. Both now say otherwise.

## 3. The request to exit was dropped in silence

`wxAppConsoleBase::ExitMainLoop()` only acts while the main loop is the *active* one - `IsRunning()` is literally `GetActive() == this` (`include/wx/evtloop.h:366`) - and returns without a word otherwise. Closing the machine window asked to exit at a point where no loop was active at all.

`ScheduleExit()` is wx's answer for exactly this: it marks the loop to finish without needing it to be active, requiring only that `Run()` has been entered.

## Testing

Verified on macOS: the red X and Cmd-Q both quit cleanly, the Dock icon goes, and the machine window's File, Disc, Settings, Tools and Debug menus all work.

Linux and Windows are unaffected - fault 1 is inside `OnActivate`, fault 3's branch is unreachable while the loop is active, which it always is there, and fault 2 was verified on wxGTK (a frame plus a hidden dialogue still exits). Builds clean; 34/35 tests pass, with `test_openbus_decode` failing identically on `main`.

## Note on the selector

Before a machine starts, the application menu is minimal. That is deliberate: the machine selector is a modal dialogue, exactly as on Windows and Linux, neither of which offers a menu bar there. Richer menus at that point need a non-modal selector, which is worth doing separately.

## Two things worth splitting out

- `help_actions.{h,cpp}` extracts the six Help handlers out of `main_frame.cpp`. It was added for an application menu bar that this branch no longer builds, so it is now a one-caller indirection - happy to drop it if you would rather.
- `NatListDialog` is constructed eagerly only to catch rules that arrive once at startup. `EmulatorHost::TakePendingNatRules()` already exists and looks made for building it on demand instead, which would remove two hidden windows per machine on every platform.
