### PR TITLE
Help: collect support files into a zip, and an issue form that asks for them

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,100 @@
+name: Bug report
+description: Something in RPCEmu Extended does not work as it should
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this.
+
+        Only the starred fields are needed. They are the ones that otherwise
+        have to be asked for before anything can start: almost every
+        difference in behaviour comes down to the host or to which build it is.
+
+        Everything else is optional - fill in what you know and leave the rest.
+
+  - type: textarea
+    id: what-happens
+    attributes:
+      label: What happens
+      description: What you did, what you expected, and what you got instead.
+      placeholder: |
+        Downloading a file with !Netsurf runs at about 70KB/s.
+        I expected something closer to the host's own speed.
+    validations:
+      required: true
+
+  - type: input
+    id: host
+    attributes:
+      label: Host operating system
+      description: Which system RPCEmu Extended itself is running on, and its version.
+      placeholder: Windows 11 24H2 / macOS 15.3 Apple Silicon / Ubuntu 24.04
+    validations:
+      required: true
+
+  - type: input
+    id: build
+    attributes:
+      label: RPCEmu Extended version
+      description: >
+        Help > About RPCEmu Extended, which gives the whole version string.
+        If it came from a CI build rather than a release, please say so.
+      placeholder: v1.1.12, 1.1.12-gde8ae58, or "CI build from 2 August"
+    validations:
+      required: true
+
+  - type: input
+    id: riscos
+    attributes:
+      label: RISC OS version
+      description: >
+        The version running inside the emulator. Leave this empty if the
+        problem is in building or packaging RPCEmu and no machine is involved.
+      placeholder: RISC OS 5.30
+    validations:
+      required: false
+
+  - type: dropdown
+    id: reproducible
+    attributes:
+      label: Does it happen every time?
+      options:
+        - Every time
+        - Most times
+        - Occasionally
+        - Only happened once
+    validations:
+      required: false
+
+  - type: textarea
+    id: log
+    attributes:
+      label: Support files
+      description: >
+        Help > Save Support Files writes a zip holding the log, this machine's
+        settings and its CMOS. Attach it to this issue, or paste anything
+        relevant from rpclog.txt in here instead. Leave it empty if neither
+        applies.
+      render: text
+    validations:
+      required: false
+
+  - type: input
+    id: worked-before
+    attributes:
+      label: Did an earlier version work?
+      description: >
+        If you know a version where this was fine - including RPCEmu itself
+        rather than this fork - saying so narrows it down quickly.
+      placeholder: Works in RPCEmu 0.9.5, or "never tried an older one"
+    validations:
+      required: false
+
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Anything else
+      description: Screenshots, or anything else you think matters.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,19 @@
+blank_issues_enabled: true
+contact_links:
+  - name: An idea or a feature you would like
+    url: https://github.com/andrewtimmins/rpcemu-extended/discussions/categories/ideas
+    about: >
+      Suggestions are easier to talk over as a discussion, where other people
+      can say whether they want the same thing
+
+  - name: A question about using RPCEmu Extended
+    url: https://github.com/andrewtimmins/rpcemu-extended/discussions/categories/q-a
+    about: >
+      If you are not sure whether something is a bug, ask here first - it is
+      not a wasted question either way
+
+  - name: RISC OS itself, rather than the emulator
+    url: https://www.riscosopen.org/forum/
+    about: >
+      Questions about RISC OS, its applications or its licensing are for
+      RISC OS Open, who publish the operating system this emulator runs

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -31,6 +31,7 @@ set(GUI_SOURCES
     package_sources_dialog.cpp
     riscos_fetch.cpp
     riscos_setup_dialog.cpp
+    support_bundle.cpp
     podule_config_dialog.cpp
     machine_inspector_window.cpp
     about_dialog.cpp

--- a/src/gui/emulator_host.cpp
+++ b/src/gui/emulator_host.cpp
@@ -389,6 +389,24 @@ extern "C" void fatal(const char *format, ...)
 	rpclog("FATAL: %s\n", buf);
 	fprintf(stderr, "RPCEmu fatal error: %s\n", buf);
 
+	/* Only once the CPU has run: before that the registers are sixteen
+	   zeroes, and most of these calls are a failed allocation or a ROM that
+	   would not load. Reads only scalars and fixed-size arrays, with the one
+	   variable index bounds-checked, so it cannot fail however corrupt
+	   things are. */
+	if (inscount != 0) {
+		rpclog("FATAL: PC=%08x mode=%u model=%s mem=%uMB event=%08x\n",
+		       arm.reg[15], (unsigned) arm.mode,
+		       machine.model < Model_MAX ? models[machine.model].name_config : "?",
+		       config.mem_size, (unsigned) arm.event);
+		rpclog("  regs r0-r7:  %08x %08x %08x %08x %08x %08x %08x %08x\n",
+		       arm.reg[0], arm.reg[1], arm.reg[2], arm.reg[3],
+		       arm.reg[4], arm.reg[5], arm.reg[6], arm.reg[7]);
+		rpclog("  regs r8-r15: %08x %08x %08x %08x %08x %08x %08x %08x\n",
+		       arm.reg[8], arm.reg[9], arm.reg[10], arm.reg[11],
+		       arm.reg[12], arm.reg[13], arm.reg[14], arm.reg[15]);
+	}
+
 	/* Record the fatal before anything else so any GUI-thread wait/join can
 	   observe it and stop blocking on this (about to spin) thread. A cv.wait
 	   only re-evaluates its predicate when notified, so also wake every request

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -1282,15 +1282,44 @@ void MainFrame::OnReportIssue(wxCommandEvent &)
 
 void MainFrame::OnSupportBundle(wxCommandEvent &)
 {
+	wxString screenshot;
+
+	if (panel_ != nullptr) {
+		const wxString temp = wxFileName::CreateTempFileName("rpcemu-screen");
+
+		if (!temp.empty() && panel_->SaveScreenshot(temp)) {
+			screenshot = temp;
+		} else if (!temp.empty()) {
+			wxRemoveFile(temp);
+		}
+	}
+
+	if (!screenshot.empty() &&
+	    wxMessageBox("Include a screenshot of the RISC OS screen?\n\n"
+	                 "It shows what the machine was displaying just now, and "
+	                 "anyone reading the report will see it.",
+	                 "RPCEmu Extended - Support Files",
+	                 wxYES_NO | wxNO_DEFAULT | wxICON_QUESTION, this) != wxYES) {
+		wxRemoveFile(screenshot);
+		screenshot.clear();
+	}
+
 	wxFileDialog dlg(this, "Save Support Files",
 	    wxStandardPaths::Get().GetDocumentsDir(), SupportBundleSuggestedName(),
 	    "Zip archives (*.zip)|*.zip", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
 
 	if (dlg.ShowModal() != wxID_OK) {
+		if (!screenshot.empty()) {
+			wxRemoveFile(screenshot);
+		}
 		return;
 	}
 
-	const SupportBundleResult result = SupportBundleWrite(dlg.GetPath());
+	const SupportBundleResult result = SupportBundleWrite(dlg.GetPath(), screenshot);
+
+	if (!screenshot.empty()) {
+		wxRemoveFile(screenshot);
+	}
 
 	if (!result.ok) {
 		wxMessageBox(result.message, "RPCEmu Extended - Support Files",

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -40,12 +40,14 @@
 #include <wx/image.h>
 #include <wx/mstream.h>
 #include <wx/richmsgdlg.h>
+#include <wx/stdpaths.h>
 
 #include "about_dialog.h"
 #include "config_paths.h"
 #include "gui_preferences.h"
 #include "input_helpers.h"
 #include "machine_edit_dialog.h"
+#include "support_bundle.h"
 #include "machine_inspector_window.h"
 #include "nat_list_dialog.h"
 #include "guest_command.h"
@@ -1276,6 +1278,40 @@ void MainFrame::OnVisitWebsite(wxCommandEvent &)
 void MainFrame::OnReportIssue(wxCommandEvent &)
 {
 	wxLaunchDefaultBrowser(URL_ISSUES);
+}
+
+void MainFrame::OnSupportBundle(wxCommandEvent &)
+{
+	wxFileDialog dlg(this, "Save Support Files",
+	    wxStandardPaths::Get().GetDocumentsDir(), SupportBundleSuggestedName(),
+	    "Zip archives (*.zip)|*.zip", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+
+	if (dlg.ShowModal() != wxID_OK) {
+		return;
+	}
+
+	const SupportBundleResult result = SupportBundleWrite(dlg.GetPath());
+
+	if (!result.ok) {
+		wxMessageBox(result.message, "RPCEmu Extended - Support Files",
+		             wxOK | wxICON_ERROR, this);
+		return;
+	}
+
+	/* Listed rather than summarised: this is going to be attached to a public
+	   issue, and what was put in it should not have to be taken on trust. */
+	wxString detail;
+
+	for (const SupportBundleMember &member : result.members) {
+		detail += wxString::Format("    %s\n", member.name);
+	}
+
+	wxMessageBox(
+	    wxString::Format("Saved to:\n%s\n\nIt contains:\n%s\n"
+	                     "The password and any home folder paths have been "
+	                     "taken out of the log and the settings.",
+	        dlg.GetPath(), detail),
+	    "RPCEmu Extended - Support Files", wxOK | wxICON_INFORMATION, this);
 }
 
 namespace {

--- a/src/gui/main_frame.h
+++ b/src/gui/main_frame.h
@@ -113,6 +113,7 @@ enum MainFrameMenuId {
 	ID_MENU_ONLINE_MANUAL,
 	ID_MENU_VISIT_WEBSITE,
 	ID_MENU_REPORT_ISSUE,
+	ID_MENU_SUPPORT_BUNDLE,
 	ID_MENU_CHECK_UPDATE,
 };
 
@@ -224,6 +225,7 @@ private:
 	void OnOnlineManual(wxCommandEvent &event);
 	void OnVisitWebsite(wxCommandEvent &event);
 	void OnReportIssue(wxCommandEvent &event);
+	void OnSupportBundle(wxCommandEvent &event);
 	void OnCheckUpdate(wxCommandEvent &event);
 	void OnAbout(wxCommandEvent &event);
 #ifdef RPCEMU_VNC

--- a/src/gui/main_frame_menus.cpp
+++ b/src/gui/main_frame_menus.cpp
@@ -233,6 +233,8 @@ void MainFrame::BuildMenus()
 	help_menu->Append(ID_MENU_ONLINE_MANUAL, "Online Manual...");
 	help_menu->Append(ID_MENU_VISIT_WEBSITE, "Visit Website...");
 	help_menu->Append(ID_MENU_REPORT_ISSUE, "Report an Issue...");
+	help_menu->Append(ID_MENU_SUPPORT_BUNDLE, "Save Support Files...")
+	    ->SetHelp("Collect the log and this machine's settings into a zip to attach to a report.");
 	help_menu->Append(ID_MENU_CHECK_UPDATE, "Check for Update...");
 	help_menu->AppendSeparator();
 	/* RISC OS itself is somebody else's work and has its own home; the two
@@ -315,6 +317,7 @@ void MainFrame::BuildMenus()
 	BindMenuItem(help_menu, ID_MENU_ONLINE_MANUAL, this, &MainFrame::OnOnlineManual);
 	BindMenuItem(help_menu, ID_MENU_VISIT_WEBSITE, this, &MainFrame::OnVisitWebsite);
 	BindMenuItem(help_menu, ID_MENU_REPORT_ISSUE, this, &MainFrame::OnReportIssue);
+	BindMenuItem(help_menu, ID_MENU_SUPPORT_BUNDLE, this, &MainFrame::OnSupportBundle);
 	BindMenuItem(help_menu, ID_MENU_CHECK_UPDATE, this, &MainFrame::OnCheckUpdate);
 	BindMenuItem(help_menu, wxID_ABOUT, this, &MainFrame::OnAbout);
 

--- a/src/gui/support_bundle.cpp
+++ b/src/gui/support_bundle.cpp
@@ -204,7 +204,7 @@ SupportBundleSuggestedName()
 }
 
 SupportBundleResult
-SupportBundleWrite(const wxString &dest_path)
+SupportBundleWrite(const wxString &dest_path, const wxString &screenshot_path)
 {
 	SupportBundleResult result;
 	wxFFileOutputStream out(dest_path);
@@ -240,6 +240,10 @@ SupportBundleWrite(const wxString &dest_path)
 		    wxFileName(dir.GetPath(), "cmos.ram").GetFullPath(), &result.members);
 		ok = ok && AddFile(zip, "emulator.meta",
 		    wxFileName(dir.GetPath(), "emulator.meta").GetFullPath(), &result.members);
+	}
+
+	if (!screenshot_path.empty()) {
+		ok = ok && AddFile(zip, "screen.png", screenshot_path, &result.members);
 	}
 
 	if (!ok || !zip.Close() || !out.Close()) {

--- a/src/gui/support_bundle.cpp
+++ b/src/gui/support_bundle.cpp
@@ -1,0 +1,258 @@
+/*
+  RPCEmu - An Acorn system emulator
+
+  Copyright (C) 2026 Andy Timmins
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+/*
+ * support_bundle.cpp - the small files a bug report needs, in one zip.
+ *
+ * What goes in is deliberately short: the log, the machine's configuration,
+ * its CMOS and the metadata beside it. Not the hard disc, and not a saved
+ * state - both are large, and a state is a whole RAM image that could hold
+ * anything the guest had open.
+ *
+ * The two text members are redacted on the way in. This is meant to be
+ * attached to a public issue, and the log carries the configuration verbatim:
+ * settings.cpp logs every key it reads, so the VNC password is in there in
+ * plain text along with the reporter's home directory.
+ */
+
+#include "support_bundle.h"
+
+#include <wx/datetime.h>
+#include <wx/ffile.h>
+#include <wx/filename.h>
+#include <wx/regex.h>
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
+
+#include "config_paths.h"
+
+extern "C" {
+#include "rpcemu.h"
+}
+
+namespace {
+
+/*
+ * Values that are nobody else's business, by configuration key.
+ *
+ * Both files are searched for these: the .cfg holds them directly, and the
+ * log holds them again because every key read is logged as it is parsed.
+ *
+ * The network settings are deliberately not here. The MAC address is one
+ * RPCEmu invents (06:02:03:04:05:06, last byte per instance) unless somebody
+ * types one for the emulated card, and the IP address is the NAT network's
+ * own - neither says anything about the host's real hardware, and both are
+ * worth having when the report is about networking.
+ */
+const char *const kSecretKeys[] = {
+	"vnc_password",
+	"username",
+};
+
+/** Replace the value in `key = "value"` or `key=value`, whichever form. */
+wxString RedactKeys(wxString text)
+{
+	for (const char *key : kSecretKeys) {
+		/* Quoted, as the log writes it. */
+		wxRegEx quoted(wxString::Format("(%s[[:space:]]*=[[:space:]]*\")[^\"]*(\")", key));
+
+		if (quoted.IsValid()) {
+			quoted.ReplaceAll(&text, "\\1<redacted>\\2");
+		}
+
+		/* Bare, as the configuration file writes it. */
+		wxRegEx bare(wxString::Format("(^|\n)(%s[[:space:]]*=)[^\n]*", key));
+
+		if (bare.IsValid()) {
+			bare.ReplaceAll(&text, "\\1\\2<redacted>");
+		}
+	}
+	return text;
+}
+
+/*
+ * Take the reporter's name out of every path in the text.
+ *
+ * Sixty-eight places log a path of some kind, so this is done by pattern
+ * rather than at each of them: what identifies somebody is the home directory
+ * the path starts with, and the rest is what makes the line worth reading.
+ */
+wxString RedactHomePaths(wxString text)
+{
+	const wxString home = wxFileName::GetHomeDir();
+
+	/* The real one first, so it goes even if it sits somewhere unusual. */
+	if (!home.empty() && home != "/" ) {
+		text.Replace(home, "<home>");
+	}
+
+	static const char *const kPatterns[] = {
+		"/home/[^/[:space:]\"']+",
+		"/Users/[^/[:space:]\"']+",
+		"[A-Za-z]:\\\\Users\\\\[^\\\\[:space:]\"']+",
+	};
+
+	for (const char *pattern : kPatterns) {
+		wxRegEx re(pattern);
+
+		if (re.IsValid()) {
+			re.ReplaceAll(&text, "<home>");
+		}
+	}
+	return text;
+}
+
+wxString Redact(const wxString &text)
+{
+	return RedactHomePaths(RedactKeys(text));
+}
+
+/** Whole file as text, or empty when it cannot be read. */
+bool ReadTextFile(const wxString &path, wxString *out)
+{
+	wxFFile file(path, "rb");
+
+	return file.IsOpened() && file.ReadAll(out);
+}
+
+/** Add @data to the archive as @name. */
+bool AddText(wxZipOutputStream &zip, const wxString &name, const wxString &data,
+             std::vector<SupportBundleMember> *members)
+{
+	const wxScopedCharBuffer utf8 = data.utf8_str();
+
+	if (!zip.PutNextEntry(name)) {
+		return false;
+	}
+	zip.Write(utf8.data(), utf8.length());
+	if (!zip.IsOk()) {
+		return false;
+	}
+
+	members->push_back({ name, (wxFileOffset) utf8.length() });
+	return true;
+}
+
+/** Copy @path in verbatim. Missing files are skipped rather than fatal. */
+bool AddFile(wxZipOutputStream &zip, const wxString &name, const wxString &path,
+             std::vector<SupportBundleMember> *members)
+{
+	if (!wxFileName::FileExists(path)) {
+		return true;
+	}
+
+	wxFFileInputStream in(path);
+
+	if (!in.IsOk()) {
+		return true;
+	}
+	if (!zip.PutNextEntry(name)) {
+		return false;
+	}
+	zip.Write(in);
+	if (!zip.IsOk()) {
+		return false;
+	}
+
+	members->push_back({ name, in.GetLength() });
+	return true;
+}
+
+/** Copy @path in with the redactions applied. */
+bool AddRedactedFile(wxZipOutputStream &zip, const wxString &name,
+                     const wxString &path,
+                     std::vector<SupportBundleMember> *members)
+{
+	wxString text;
+
+	if (!wxFileName::FileExists(path) || !ReadTextFile(path, &text)) {
+		return true;
+	}
+	return AddText(zip, name, Redact(text), members);
+}
+
+} // namespace
+
+wxString
+SupportBundleSuggestedName()
+{
+	const wxString machine = wxString::FromUTF8(config.name);
+	const wxString stamp = wxDateTime::Now().Format("%Y%m%d");
+
+	if (machine.empty()) {
+		return wxString::Format("rpcemu-support-%s.zip", stamp);
+	}
+	return wxString::Format("rpcemu-support-%s-%s.zip",
+	    ConfigPathsSanitizeName(machine), stamp);
+}
+
+SupportBundleResult
+SupportBundleWrite(const wxString &dest_path)
+{
+	SupportBundleResult result;
+	wxFFileOutputStream out(dest_path);
+
+	if (!out.IsOk()) {
+		result.message = "The file could not be created. Check there is room "
+		                 "and that the folder can be written to.";
+		return result;
+	}
+
+	wxZipOutputStream zip(out);
+	const wxString machine = wxString::FromUTF8(config.name);
+	const wxString machine_dir = wxString::FromUTF8(rpcemu_get_machine_datadir());
+	bool ok = true;
+
+	/* Redacted: the log repeats the configuration as it parses it. */
+	ok = ok && AddRedactedFile(zip, "rpclog.txt",
+	    wxString::FromUTF8(rpcemu_get_log_path()), &result.members);
+
+	if (!machine.empty()) {
+		const wxFileName cfg(ConfigPathsConfigsDir(),
+		    ConfigPathsSanitizeName(machine) + ".cfg");
+
+		ok = ok && AddRedactedFile(zip, "machine.cfg", cfg.GetFullPath(),
+		    &result.members);
+	}
+
+	/* Binary, and neither says anything about the person running it. */
+	if (!machine_dir.empty()) {
+		const wxFileName dir(machine_dir);
+
+		ok = ok && AddFile(zip, "cmos.ram",
+		    wxFileName(dir.GetPath(), "cmos.ram").GetFullPath(), &result.members);
+		ok = ok && AddFile(zip, "emulator.meta",
+		    wxFileName(dir.GetPath(), "emulator.meta").GetFullPath(), &result.members);
+	}
+
+	if (!ok || !zip.Close() || !out.Close()) {
+		result.message = "The archive could not be written.";
+		return result;
+	}
+
+	if (result.members.empty()) {
+		result.message = "There was nothing to collect: no log and no machine "
+		                 "configuration could be found.";
+		return result;
+	}
+
+	result.ok = true;
+	return result;
+}

--- a/src/gui/support_bundle.h
+++ b/src/gui/support_bundle.h
@@ -1,0 +1,57 @@
+/*
+  RPCEmu - An Acorn system emulator
+
+  Copyright (C) 2026 Andy Timmins
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifndef SUPPORT_BUNDLE_H
+#define SUPPORT_BUNDLE_H
+
+#include <vector>
+
+#include <wx/filefn.h>
+#include <wx/string.h>
+
+/** One file that went into the bundle, for telling the user what was sent. */
+struct SupportBundleMember {
+	wxString name;		/**< Path as stored in the archive */
+	wxFileOffset size;	/**< Bytes, as written */
+};
+
+struct SupportBundleResult {
+	bool ok = false;
+	wxString message;	/**< Why it failed, when it did */
+	std::vector<SupportBundleMember> members;
+};
+
+/**
+ * Collect what a bug report needs into a zip at @dest_path.
+ *
+ * The log, the machine's configuration, its CMOS and the emulator metadata:
+ * small files that describe how the machine is set up and what it last did.
+ * The hard disc is not among them, and neither is anything else large.
+ *
+ * The configuration is redacted on the way in - see the implementation - so
+ * this can be attached to a public issue without handing over a password or
+ * the reporter's home directory.
+ */
+SupportBundleResult SupportBundleWrite(const wxString &dest_path);
+
+/** Suggested leafname, e.g. "rpcemu-support-Test1-20260803.zip". */
+wxString SupportBundleSuggestedName();
+
+#endif /* SUPPORT_BUNDLE_H */

--- a/src/gui/support_bundle.h
+++ b/src/gui/support_bundle.h
@@ -48,8 +48,14 @@ struct SupportBundleResult {
  * The configuration is redacted on the way in - see the implementation - so
  * this can be attached to a public issue without handing over a password or
  * the reporter's home directory.
+ *
+ * @param screenshot_path A PNG of the guest's screen to include, or empty for
+ *                        none. Asked for rather than taken: it is whatever the
+ *                        machine happens to be showing, which is the one thing
+ *                        here that cannot be redacted.
  */
-SupportBundleResult SupportBundleWrite(const wxString &dest_path);
+SupportBundleResult SupportBundleWrite(const wxString &dest_path,
+                                       const wxString &screenshot_path = wxString());
 
 /** Suggested leafname, e.g. "rpcemu-support-Test1-20260803.zip". */
 wxString SupportBundleSuggestedName();

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -24,10 +24,13 @@
 #include <string.h>
 
 #ifdef _WIN32
-#include <windows.h>
+#include <windows.h>	/* RTL_OSVERSIONINFOW comes with this, via winnt.h */
 #else
 #include <sys/statvfs.h>
 #include <sys/utsname.h>
+#ifdef __APPLE__
+#include <sys/sysctl.h>		/* sysctlbyname(), for the macOS product version */
+#endif
 #endif
 
 #include "rpcemu.h"
@@ -80,17 +83,45 @@ path_disk_info(const char *path, disk_info *d)
 /**
  * Log details about the current Operating System version.
  *
- * This function should work on all Unix and Unix-like systems.
- *
  * Called during program start-up.
+ *
+ * "Windows 11" or "macOS 15.3" is what a bug report says, so that is what is
+ * wanted here. Neither comes from the obvious call: GetVersionEx() is
+ * deprecated and reports Windows 8 on anything newer unless the application
+ * carries a manifest saying otherwise, and uname() on a Mac gives the Darwin
+ * kernel version, which no user recognises.
  */
 void
 rpcemu_log_os(void)
 {
 #ifdef _WIN32
-	/* GetVersionEx() is deprecated and, without an application manifest,
-	   lies about the version on Windows 8.1+. A static identifier is enough
-	   for the log. */
+	/* RtlGetVersion() is the one call that answers truthfully with no
+	   manifest. It lives in ntdll rather than in an import library, so it is
+	   looked up rather than linked - the same approach podules.c takes. */
+	typedef LONG (WINAPI *rtl_get_version)(PRTL_OSVERSIONINFOW);
+
+	HMODULE ntdll = GetModuleHandleA("ntdll.dll");
+	rtl_get_version fn = ntdll != NULL
+	    ? (rtl_get_version) (void *) GetProcAddress(ntdll, "RtlGetVersion")
+	    : NULL;
+
+	if (fn != NULL) {
+		RTL_OSVERSIONINFOW info;
+
+		memset(&info, 0, sizeof(info));
+		info.dwOSVersionInfoSize = sizeof(info);
+		if (fn(&info) == 0) {
+			/* Windows 11 reports itself as 10.0; the build number is
+			   what tells the two apart, so it is logged either way. */
+			rpclog("OS: SysName = Windows %s\n",
+			       info.dwBuildNumber >= 22000 ? "11" : "10");
+			rpclog("OS: Release = %lu.%lu build %lu\n",
+			       (unsigned long) info.dwMajorVersion,
+			       (unsigned long) info.dwMinorVersion,
+			       (unsigned long) info.dwBuildNumber);
+			return;
+		}
+	}
 	rpclog("OS: SysName = Windows\n");
 #else
 	struct utsname u;
@@ -104,6 +135,27 @@ rpcemu_log_os(void)
 	rpclog("OS: Release = %s\n", u.release);
 	rpclog("OS: Version = %s\n", u.version);
 	rpclog("OS: Machine = %s\n", u.machine);
+
+#ifdef __APPLE__
+	/* uname() has given the Darwin release above, which does not match what
+	   the machine calls itself. Both are logged: the kernel version is still
+	   the one an ARM/Intel difference shows up in. */
+	{
+		/* Sized as the kernel declares them: osproductversion is char[48],
+		   and osversion is OSVERSIZE, which is 256. */
+		char product[48];
+		char build[256];
+		size_t len = sizeof(product);
+
+		if (sysctlbyname("kern.osproductversion", product, &len, NULL, 0) == 0) {
+			rpclog("OS: macOS = %s\n", product);
+		}
+		len = sizeof(build);
+		if (sysctlbyname("kern.osversion", build, &len, NULL, 0) == 0) {
+			rpclog("OS: macOS build = %s\n", build);
+		}
+	}
+#endif
 #endif
 }
 


### PR DESCRIPTION
A bug report form, and the feature it asks people to use. Each commit builds on its own, so this bisects.

## The issue form

Commit 20f36e7.

Of the 47 issues filed so far, the host OS was given unprompted 24 times, the RISC OS version 8, and the RPCEmu version 3. The form requires what happens, the host OS and the build. Everything else is optional, since a quarter of those issues were build or CI problems with no machine involved. Blank issues stay enabled; ideas and questions go to Discussions.

Instead of asking for pasted log extracts, it points at **Help > Save Support Files** — the rest of this branch.

## The bundle

Commit cb0453d.

`rpclog.txt`, the machine's configuration, its CMOS and the metadata beside it. Not the hard disc, and not a saved state - that is a whole RAM image and could hold anything.

The two text members are redacted. `settings.cpp` logs every key as it parses it, so the VNC password was in the log in plain text alongside the reporter's home directory - redacting only the `.cfg` would have missed it. The MAC and IP addresses are kept: RPCEmu invents both for the emulated card, so they say nothing about the host and matter when the report is about networking.

The dialogue lists what went in rather than summarising it.

## The screenshot

Commit e172d54.

Offered, defaulting to no, and taken before either prompt - the machine keeps drawing while a file dialogue is open. It is the one thing here that cannot be redacted, and the question says so.

## Which Windows, which macOS

Commit 3e96547.

`OS: SysName = Windows` becomes the actual version, via `RtlGetVersion()` looked up in ntdll - the one call that answers truthfully without a manifest, which is why the old comment gave up and logged a constant. macOS gains `kern.osproductversion`, since `uname` there gives the Darwin version nobody reports.

## Registers on a fatal

Commit c881760.

`fatal()` now logs the registers after its message, once the CPU has executed. Before that they are sixteen zeroes. Not via `debugger_get_status()`, whose loops are bounded by the live breakpoint counts - `fatal()` is exactly where a count could be wrong.

## Testing

**Linux.** Redaction end to end with a real password: it reaches `rpclog.txt` in plain text and appears nowhere in the zip. Both screenshot answers. The `fatal()` dump either side of its gate, GUI and headless, plus a corrupt model index and four concurrent calls.

**Windows.** Bundle saved and checked, screenshot present, and the log carrying the real version.

Not run on macOS. CI builds it there, so the `sysctlbyname` calls compile; whether they return what the log claims is unconfirmed, and a failure costs two lines.

Supersedes #89.


