### PR TITLE
Keyboard: identify keys by position rather than by character (#88, #91, part of #70)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,12 @@
 /roms/*
 !/roms/roms.txt
 
-# Package Manager cache
+# Package Manager cache, and the repository list it writes beside it. Both are
+# created in whatever the emulator takes as its data directory, so running
+# something like --pkg-list from a source tree without RPCEMU_DATADIR set leaves
+# them here rather than in an installation.
 /pkgcache/
+/pkgsources
 
 # Legacy single-machine state (CMOS now lives under machines/<name>/)
 /cmos.ram

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Build with **CMake** — see [COMPILE.md](COMPILE.md) for full details.
 | `docs/kinetic.md` | Kinetic StrongARM: how the card is detected, its 512MB memory map, and the three paths a new memory region needs |
 | `docs/usb.md` | USB: the emulated OHCI host controller, passing real devices through to the guest, streaming from a camera, USB drives, and why it is OHCI |
 | `docs/mmu-permissions.md` | MMU access permissions: the defect that made ADFFS unusable, how it was fixed, and the regression test that holds it |
+| `docs/keyboard.md` | Keyboard: how a host key reaches RISC OS, why it is mapped by physical position rather than by character, non-UK layouts, and diagnosing it with `RPCEMU_KEYBOARD_DEBUG` |
 | `docs/clipboard.md` | Shared clipboard: copying text and images between the host and RISC OS |
 | `docs/vnc.md` | VNC: using a machine remotely, choosing one over VNC in headless mode, and the control menu for a running machine |
 | `docs/multi-machine.md` | Running several machines at once: how it works today, the virtual switch planned, and why the core is one machine per process |

--- a/docs/keyboard.md
+++ b/docs/keyboard.md
@@ -1,0 +1,166 @@
+# Keyboard
+
+How a key press on the host becomes a key press in RISC OS, why it is done by
+physical position rather than by character, and how to diagnose it on a platform
+you cannot sit in front of.
+
+## The chain
+
+```
+host key event
+  -> X11 keycode          ("native scancode" throughout the source)
+  -> PS/2 Set 2 make code (keyboard_x.c)
+  -> IOMD keyboard port   (keyboard.c)
+  -> RISC OS, which applies its own keyboard layout
+```
+
+The middle currency is an **X11 hardware keycode**. That is a historical choice
+rather than an X11 dependency: the value identifies a key by **where it is on
+the keyboard**, and `keyboard_map_key()` in `src/gui/keyboard_x.c` is the single
+table that turns a position into the make codes a PS/2 keyboard would send.
+
+Two things produce that currency:
+
+| Producer | Source file | Notes |
+| --- | --- | --- |
+| The GUI | `src/gui/input_helpers.cpp` | A wxWidgets key event |
+| VNC | `src/gui/vnc_server.cpp` | An RFB keysym |
+
+## Positions, not characters
+
+**RISC OS applies its own keyboard layout.** So RPCEmu must tell it *which key
+was pressed*, not *which character the host decided that key types*. If the host
+translates first, the layout is applied twice and the result is wrong in ways
+that depend on both layouts.
+
+Where each platform hides the position:
+
+| Platform | Where wxWidgets puts it | What it is |
+| --- | --- | --- |
+| Linux / GTK | `GetRawKeyFlags()` | An X11 keycode already, so nothing to translate |
+| Windows | `GetRawKeyFlags()` | The `WM_KEY*` `lParam`: scancode in bits 16-23, extended flag in bit 24 |
+| macOS | `GetRawKeyCode()` | `[NSEvent keyCode]`, an ADB keycode |
+
+`src/gui/keymap_platform.c` holds the Windows and macOS tables. Neither is
+conditionally compiled, which is what lets `tests/test_keymap.c` check all three
+platforms' mappings from whichever one the test happens to run on.
+
+For Windows the mapping is arithmetic, not a table: **X11 keycode = Set 1
+scancode + 8**, for everything from Escape (`0x01` to `0x09`) to F12 (`0x58` to
+`0x60`). Linux derives its evdev keycodes from the same AT numbering with the
+same offset. Only the `E0`-prefixed keys need a table, because they duplicate
+scancodes from the main block. For macOS a full table is unavoidable, since ADB
+numbered keys by the 1984 keyboard's matrix.
+
+### The macOS keycode numbers are checked by the compiler
+
+`keymap_platform.c` must hold literal numbers so it compiles and can be tested
+everywhere, which leaves the risk that a literal is simply wrong. So when built
+on macOS it asserts every one of them against Apple's own `kVK_` constants from
+`<Carbon/HIToolbox/Events.h>`. A mistyped number is a **macOS build failure**
+rather than a key that quietly does the wrong thing on someone else's Mac. The
+include is optional (`__has_include`), so it can never be the reason a build
+fails to configure.
+
+## What this fixed
+
+Until August 2026 the Windows and macOS paths mapped the **character** that
+`GetKeyCode()` reported onto a table written for a **UK** layout. Three reported
+faults came from that one decision.
+
+- **[#88](https://github.com/andrewtimmins/rpcemu-extended/issues/88), German
+  keyboards.** Umlauts and `ß < > |` were completely dead, because no entry in a
+  UK table types those characters. `z` and `y` swapped "the wrong way around"
+  when the RISC OS layout was changed, because Windows had already applied German
+  and RISC OS then applied it again. Digits worked, because the digit row is in
+  the same place on both layouts. A UK host layout with a German RISC OS layout
+  worked perfectly, which is the system working by accident.
+- **[#91](https://github.com/andrewtimmins/rpcemu-extended/issues/91), the third
+  mouse button on macOS.** wxWidgets reports **Command** as `WXK_CONTROL` and the
+  physical Control key as `WXK_RAW_CONTROL`, so at the character level Command and
+  Control are one key and neither could be spared for the menu button. By
+  position they are four distinct keys.
+- **[#70](https://github.com/andrewtimmins/rpcemu-extended/issues/70), partly.**
+  Left and right Shift, and left and right Ctrl, were reported to the guest as
+  the left-hand key in both cases. See the caveat below for the part of #70 this
+  does not explain.
+
+Also fixed along the way: **AltGr reached nothing at all, on every platform.**
+Windows and macOS reported it as left Alt, and X11 reported keycode `0x6c` which
+`keyboard_x.c` had no entry for. A German keyboard cannot manage without it.
+
+## macOS: the two keys a RiscPC has not got
+
+Handled as policy in `input_helpers.cpp`, deliberately not in the mapping table,
+so the table stays a one-to-one statement about positions and can be checked for
+collisions:
+
+| Mac key | Sent to RISC OS as | Why |
+| --- | --- | --- |
+| Left Command | Ctrl | RISC OS uses Ctrl where macOS uses Command, so Cmd+C copies |
+| Right Command | Menu | A Mac has no menu key, and RPCEmu offers that as the third mouse button |
+| Left / right Option | Left / right Alt | |
+| Left / right Control | Left / right Ctrl | |
+
+## Diagnosing a keyboard fault
+
+Set `RPCEMU_KEYBOARD_DEBUG` in the environment and every key event is written to
+`rpclog.txt`:
+
+```
+Keyboard: down raw=0x0000001e flags=0x001e0001 wxkey=65 position=0x26 scancode=0x26 ps2=yes
+```
+
+- `raw` and `flags` are what the host reported, untouched.
+- `wxkey` is the character wxWidgets made of it, which is what the old code used.
+- `position` is the physical key as an X11 keycode. **Zero means the physical
+  tables did not place the key** and the character fallback was used, which is
+  the shape of #88 and #91.
+- `scancode` is what RPCEmu will send, after the macOS policy above.
+- `ps2` says whether `keyboard_map_key()` could deliver it. `DROPPED` means the
+  guest received nothing.
+
+This exists because Windows and macOS keyboard behaviour cannot be reproduced on
+a Linux development machine. A reporter can be asked for a log rather than for
+adjectives. Attach it with *Help → Save Support Files*.
+
+## Testing
+
+`tests/test_keymap.c`, 99 checks, on every platform. It asserts the properties
+that were actually violated rather than restating the tables:
+
+- Every mapped position resolves to a key `keyboard_map_key()` can deliver, swept
+  exhaustively over both tables. No dead ends.
+- No two positions collide on one RISC OS key.
+- Both tables agree with each other about where a key is.
+- A position means the same thing whatever the host layout claims it types
+  (the #88 cases, including AltGr and the two international keys).
+- Left and right modifiers stay distinct, and Command stays distinguishable from
+  Control (the #91 and #70 cases).
+- The `lParam` unpacking ignores the repeat count, the transition bits and the
+  Alt context bit, and honours bit 24.
+
+The test was checked by breaking the code on purpose: reintroducing the #88 Y/Z
+swap, deleting the AltGr entry, and collapsing right Command onto Control each
+make it fail.
+
+## Known gaps
+
+- **AltGr on Windows also generates a phantom left Ctrl.** Windows sends a
+  synthetic left-Ctrl press before right Alt, indistinguishable from a real one
+  except by timestamp, so the guest sees Ctrl+AltGr. Whether this stops German
+  AltGr characters working in RISC OS is unconfirmed; the debug log above will
+  show the extra Ctrl if it does.
+- **The rest of [#70](https://github.com/andrewtimmins/rpcemu-extended/issues/70)
+  is not explained by any of this.** The report is that with Shift held, the
+  first thirteen letters came out uppercase and the rest lowercase, and that
+  toggling Caps Lock fixed it. Upper and lower case letters map to the *same*
+  position, so the mapping cannot produce a case error: something is
+  desynchronising the guest's Shift or Caps Lock state. The leading theory is
+  that macOS reports Caps Lock as a toggle through `flagsChanged` rather than as
+  a press and release, and `NativeKeyPress()` drops a press for a key already
+  held, so the guest's caps state can end up inverted relative to the host. That
+  is a theory, not a diagnosis, and it needs a Mac.
+- Print Screen has no X11 keycode entry and is not passed through.
+- The GUI keyboard path is only tested at the mapping layer. Nothing exercises
+  wxWidgets event delivery itself.

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -43,6 +43,7 @@ set(GUI_SOURCES
     plt_sound.cpp
     toolbar_icons.cpp
     keyboard_x.c
+    keymap_platform.c
 )
 
 if(RPCEMU_ENABLE_VNC)

--- a/src/gui/input_helpers.cpp
+++ b/src/gui/input_helpers.cpp
@@ -20,9 +20,25 @@
 
 #include "input_helpers.h"
 
+#include <stdlib.h>
+
+#include "keymap_platform.h"
+
 extern "C" {
 #include "keyboard.h"
+#include "rpcemu.h"
 }
+
+/*
+ * X11 keycodes this file needs by name. The full set lives in keymap_platform.c;
+ * these are the few the macOS policy below has to reason about.
+ */
+enum {
+	X11_LEFTCTRL = 0x25,
+	X11_LEFTWIN = 0x85,
+	X11_RIGHTWIN = 0x86,
+	X11_MENU = 0x87
+};
 
 static unsigned scancode_from_wx_key_code(int key_code)
 {
@@ -180,14 +196,16 @@ static unsigned scancode_from_wx_key_code(int key_code)
 	return 0;
 }
 
-unsigned InputNativeScancodeFromKeyEvent(const wxKeyEvent &event)
+/*
+ * The key's physical position as an X11 keycode, or 0 if this platform will not
+ * say. Every platform has some way of reporting position; what differs is where
+ * wxWidgets puts it.
+ */
+static unsigned scancode_from_physical_key(const wxKeyEvent &event)
 {
-	// keyboard_map_key() is keyed by X11 hardware keycodes, so the raw-keycode
-	// paths are only meaningful under wxGTK/X11. On wxMSW the raw values are
-	// Windows scancodes/VK codes that the X11 table can't map (and GetRawKeyFlags
-	// is non-zero, which would wrongly short-circuit the portable fallback), so
-	// fall straight through to the wx-keycode mapping there.
 #if defined(__WXGTK__)
+	/* X11 hands us a hardware keycode already, which is what the rest of
+	   RPCEmu is keyed by, so there is nothing to translate. */
 	const unsigned hardware = static_cast<unsigned>(event.GetRawKeyFlags());
 	if (hardware != 0) {
 		return hardware;
@@ -197,8 +215,66 @@ unsigned InputNativeScancodeFromKeyEvent(const wxKeyEvent &event)
 	if (raw != 0 && keyboard_map_key(raw) != nullptr) {
 		return raw;
 	}
+	return 0;
+#elif defined(__WXMSW__)
+	/* GetRawKeyFlags() is the WM_KEY* lParam (wxWidgets src/msw/window.cpp),
+	   which carries the OEM scancode and so describes a position. The unpacking
+	   lives in keymap_platform.c so that tests/test_keymap.c can check it. */
+	return keymap_x11_from_windows_lparam(
+	    static_cast<unsigned>(event.GetRawKeyFlags()));
+#elif defined(__WXOSX__)
+	/* GetRawKeyCode() is [NSEvent keyCode] (wxWidgets src/osx/cocoa/window.mm),
+	   an ADB keycode, which is a position. */
+	return keymap_x11_from_macos_keycode(
+	    static_cast<unsigned>(event.GetRawKeyCode()));
+#else
+	(void) event;
+	return 0;
 #endif
+}
 
+/*
+ * What RPCEmu does with the two keys a Mac has and a RiscPC does not.
+ *
+ * Left Command becomes Ctrl. That is long-standing deliberate behaviour, not an
+ * accident of the old character mapping: RISC OS uses Ctrl for what macOS uses
+ * Command for, so Cmd+C copying is what a Mac user expects and issue #35 was
+ * about making those combinations work.
+ *
+ * Right Command becomes the menu key, which RPCEmu already offers as the third
+ * mouse button. A Mac keyboard has no menu key, so before this there was no way
+ * to reach a RISC OS menu button from the keyboard at all (issue #91). Left and
+ * right Command are only distinguishable now that positions are being read.
+ */
+static unsigned apply_macos_key_policy(unsigned scan_code)
+{
+#if defined(__WXOSX__)
+	if (scan_code == X11_LEFTWIN) {
+		return X11_LEFTCTRL;
+	}
+	if (scan_code == X11_RIGHTWIN) {
+		return X11_MENU;
+	}
+#endif
+	return scan_code;
+}
+
+unsigned InputNativeScancodeFromKeyEvent(const wxKeyEvent &event)
+{
+	const unsigned physical = scancode_from_physical_key(event);
+
+	if (physical != 0) {
+		return apply_macos_key_policy(physical);
+	}
+
+	/*
+	 * Nothing said where the key was, so fall back to mapping the character it
+	 * produced. This is the path that cannot cope with a non-UK layout (see
+	 * keymap_platform.h), kept only because a key we failed to place is better
+	 * sent to the guest approximately than dropped on the floor. Anything
+	 * arriving here on Windows or macOS is a gap in the position tables and
+	 * shows up in the RPCEMU_KEYBOARD_DEBUG log as such.
+	 */
 	int keycode = event.GetKeyCode();
 
 	/* A letter typed with Control held arrives as a control character (1-26)
@@ -223,4 +299,48 @@ bool InputIsReleaseMouseCaptureKey(const wxKeyEvent &event)
 	const int key_code = event.GetKeyCode();
 	return (key_code == WXK_RETURN || key_code == WXK_NUMPAD_ENTER) &&
 	       (event.GetModifiers() & wxMOD_ALT) != 0;
+}
+
+bool InputIsThirdMouseButtonKey(const wxKeyEvent &event)
+{
+	const int key_code = event.GetKeyCode();
+
+	if (key_code == WXK_MENU || key_code == WXK_WINDOWS_MENU) {
+		return true;
+	}
+
+	/* On macOS the test above can never pass - wxWidgets does not report
+	   WXK_MENU, because the keyboard has no such key - so right Command stands
+	   in for it. Asked of the position, since Command is indistinguishable from
+	   Control at the character level on that platform (issue #91). */
+	return apply_macos_key_policy(scancode_from_physical_key(event)) == X11_MENU;
+}
+
+void InputLogKeyEvent(const wxKeyEvent &event, unsigned scan_code, bool key_down)
+{
+	static int enabled = -1;
+
+	if (enabled < 0) {
+		enabled = getenv("RPCEMU_KEYBOARD_DEBUG") != nullptr;
+	}
+	if (!enabled) {
+		return;
+	}
+
+	const unsigned physical = scancode_from_physical_key(event);
+	const uint8_t *mapped = scan_code != 0 ? keyboard_map_key(scan_code) : nullptr;
+
+	/* "position" is what the platform said, "scancode" is what RPCEmu will send
+	   after any policy is applied, and "ps2" is what the guest actually receives.
+	   A position of 0 means the physical tables did not place the key and the
+	   character fallback was used, which is the shape of issues #88 and #91. */
+	rpclog("Keyboard: %s raw=0x%08x flags=0x%08x wxkey=%d position=0x%02x "
+	       "scancode=0x%02x ps2=%s\n",
+	       key_down ? "down" : "up  ",
+	       (unsigned) event.GetRawKeyCode(),
+	       (unsigned) event.GetRawKeyFlags(),
+	       event.GetKeyCode(),
+	       physical,
+	       scan_code,
+	       mapped != nullptr ? "yes" : "DROPPED");
 }

--- a/src/gui/input_helpers.h
+++ b/src/gui/input_helpers.h
@@ -27,7 +27,42 @@ extern "C" {
 #include "keyboard.h"
 }
 
+/**
+ * The X11 keycode ("native scancode") for the key this event came from.
+ *
+ * Derived from the key's PHYSICAL POSITION wherever the platform will say what
+ * that was, so that the host's keyboard layout is not applied on top of the one
+ * RISC OS is already applying. See keymap_platform.h for why that matters and
+ * which issues it fixes.
+ *
+ * @return X11 keycode, or 0 when the key has no RISC OS equivalent.
+ */
 unsigned InputNativeScancodeFromKeyEvent(const wxKeyEvent &event);
+
 bool InputIsReleaseMouseCaptureKey(const wxKeyEvent &event);
+
+/**
+ * Is this the key that stands in for the third (menu) mouse button?
+ *
+ * The menu key everywhere it exists, and additionally right Command on macOS,
+ * where there is no menu key at all and wxWidgets never reports WXK_MENU
+ * (issue #91).
+ */
+bool InputIsThirdMouseButtonKey(const wxKeyEvent &event);
+
+/**
+ * Log one key event to rpclog.txt when RPCEMU_KEYBOARD_DEBUG is set in the
+ * environment.
+ *
+ * Off by default and free when off. This is how a keyboard fault on a platform
+ * the developer cannot run gets diagnosed: it prints what the host reported
+ * (raw code, raw flags, wx keycode) beside what RPCEmu made of it, so a reporter
+ * can be asked for a log rather than for adjectives.
+ *
+ * @param event     The key event as it arrived.
+ * @param scan_code What InputNativeScancodeFromKeyEvent() returned for it.
+ * @param key_down  True for a press, false for a release.
+ */
+void InputLogKeyEvent(const wxKeyEvent &event, unsigned scan_code, bool key_down);
 
 #endif

--- a/src/gui/keyboard_x.c
+++ b/src/gui/keyboard_x.c
@@ -124,6 +124,12 @@ static const KeyMapInfo key_map[] = {
 	{ 0x68, { 0xe0, 0x5a } },	// Keypad Enter
 	{ 0x69, { 0xe0, 0x14 } },	// Right Ctrl
 	{ 0x6a, { 0xe0, 0x4a } },	// Keypad /
+	// Right Alt / AltGr. Absent until 2026-08-04, so the key was dropped on
+	// every platform: X11 reported keycode 0x6c and found nothing here, while
+	// Windows and macOS reported it as LEFT Alt because they were mapping
+	// characters rather than positions. A German keyboard needs AltGr for
+	// @ \ | ~ and the like - see issue #88.
+	{ 0x6c, { 0xe0, 0x11 } },	// Right Alt (AltGr)
 
 	{ 0x6e, { 0xe0, 0x6c } },	// Home
 	{ 0x6f, { 0xe0, 0x75 } },	// Up

--- a/src/gui/keymap_platform.c
+++ b/src/gui/keymap_platform.c
@@ -1,0 +1,435 @@
+/*
+  RPCEmu - An Acorn system emulator
+
+  Copyright (C) 2026 Andy Timmins
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+/*
+ * keymap_platform.c - Windows and macOS physical keys as X11 keycodes.
+ *
+ * The rationale is in keymap_platform.h. The contract worth stating here is
+ * that a NON-ZERO RETURN IS ALWAYS A KEYCODE keyboard_map_key() KNOWS. Callers
+ * are entitled to treat zero as "this key has no RISC OS equivalent" and a
+ * non-zero value as something that will reach the guest, and
+ * tests/test_keymap.c enforces exactly that by resolving every entry here
+ * through keyboard_map_key().
+ */
+
+#include "keymap_platform.h"
+
+#include <stddef.h>
+
+/*
+ * Apple's own constants, used to check the numbers below rather than to build
+ * them. The table has to hold literals so that it compiles and can be tested
+ * everywhere, which leaves the risk that a literal is simply wrong; asserting
+ * each one against <Carbon/HIToolbox/Events.h> turns that into a macOS build
+ * failure instead of a key that does the wrong thing on somebody's Mac.
+ *
+ * __has_include keeps it optional: where the header is absent the table is
+ * still built, merely unchecked, so this can never be the reason a port fails
+ * to compile.
+ */
+#if defined(__APPLE__) && defined(__has_include)
+#  if __has_include(<Carbon/HIToolbox/Events.h>)
+#    include <Carbon/HIToolbox/Events.h>
+#    define KEYMAP_CHECK_AGAINST_APPLE_HEADERS 1
+#  endif
+#endif
+
+/* X11 keycodes, named so the tables below read as positions. These are the
+   values keyboard_x.c is keyed by; the comments there name the same keys. */
+enum {
+	X11_ESCAPE = 0x09,
+	X11_1 = 0x0a, X11_2 = 0x0b, X11_3 = 0x0c, X11_4 = 0x0d, X11_5 = 0x0e,
+	X11_6 = 0x0f, X11_7 = 0x10, X11_8 = 0x11, X11_9 = 0x12, X11_0 = 0x13,
+	X11_MINUS = 0x14, X11_EQUAL = 0x15, X11_BACKSPACE = 0x16,
+	X11_TAB = 0x17,
+	X11_Q = 0x18, X11_W = 0x19, X11_E = 0x1a, X11_R = 0x1b, X11_T = 0x1c,
+	X11_Y = 0x1d, X11_U = 0x1e, X11_I = 0x1f, X11_O = 0x20, X11_P = 0x21,
+	X11_LEFTBRACKET = 0x22, X11_RIGHTBRACKET = 0x23, X11_RETURN = 0x24,
+	X11_LEFTCTRL = 0x25,
+	X11_A = 0x26, X11_S = 0x27, X11_D = 0x28, X11_F = 0x29, X11_G = 0x2a,
+	X11_H = 0x2b, X11_J = 0x2c, X11_K = 0x2d, X11_L = 0x2e,
+	X11_SEMICOLON = 0x2f, X11_QUOTE = 0x30, X11_GRAVE = 0x31,
+	X11_LEFTSHIFT = 0x32, X11_HASH = 0x33,
+	X11_Z = 0x34, X11_X = 0x35, X11_C = 0x36, X11_V = 0x37, X11_B = 0x38,
+	X11_N = 0x39, X11_M = 0x3a,
+	X11_COMMA = 0x3b, X11_PERIOD = 0x3c, X11_SLASH = 0x3d,
+	X11_RIGHTSHIFT = 0x3e, X11_KP_MULTIPLY = 0x3f,
+	X11_LEFTALT = 0x40, X11_SPACE = 0x41, X11_CAPSLOCK = 0x42,
+	X11_F1 = 0x43, X11_F2 = 0x44, X11_F3 = 0x45, X11_F4 = 0x46,
+	X11_F5 = 0x47, X11_F6 = 0x48, X11_F7 = 0x49, X11_F8 = 0x4a,
+	X11_F9 = 0x4b, X11_F10 = 0x4c,
+	X11_NUMLOCK = 0x4d, X11_SCROLLLOCK = 0x4e,
+	X11_KP_7 = 0x4f, X11_KP_8 = 0x50, X11_KP_9 = 0x51, X11_KP_MINUS = 0x52,
+	X11_KP_4 = 0x53, X11_KP_5 = 0x54, X11_KP_6 = 0x55, X11_KP_PLUS = 0x56,
+	X11_KP_1 = 0x57, X11_KP_2 = 0x58, X11_KP_3 = 0x59, X11_KP_0 = 0x5a,
+	X11_KP_DECIMAL = 0x5b,
+	X11_BACKSLASH = 0x5e, X11_F11 = 0x5f, X11_F12 = 0x60,
+	X11_KP_ENTER = 0x68, X11_RIGHTCTRL = 0x69, X11_KP_DIVIDE = 0x6a,
+	X11_RIGHTALT = 0x6c,
+	X11_HOME = 0x6e, X11_UP = 0x6f, X11_PAGEUP = 0x70, X11_LEFT = 0x71,
+	X11_RIGHT = 0x72, X11_END = 0x73, X11_DOWN = 0x74, X11_PAGEDOWN = 0x75,
+	X11_INSERT = 0x76, X11_DELETE = 0x77,
+	X11_BREAK = 0x7f,
+	X11_LEFTWIN = 0x85, X11_RIGHTWIN = 0x86, X11_MENU = 0x87
+};
+
+/*
+ * Windows, the non-extended block: X11 keycode = Set 1 scancode + 8.
+ *
+ * That is not a coincidence worth hiding behind a hand-typed table. Linux
+ * builds its evdev keycodes from the same AT scancode numbering with the same
+ * offset of 8, so every key from Escape (0x01 -> 0x09) through F12
+ * (0x58 -> 0x60) lines up, the two international keys included: 0x2b is the
+ * `#`/`\` key next to Return and 0x56 is the `\`/`<>|` key beside left Shift,
+ * which are exactly the two keyboard_x.c marks "International only". A table
+ * would be ninety chances to mistype a number that arithmetic gets right.
+ *
+ * Two scancodes inside the range have no X11 keycode: 0x54 is SysReq
+ * (Alt+PrintScreen) and 0x55 is unassigned, which is the gap at 0x5c/0x5d in
+ * keyboard_x.c. They are refused so that the "non-zero means mappable"
+ * contract holds.
+ */
+#define WINDOWS_SCANCODE_TO_X11_OFFSET 8
+#define WINDOWS_SCANCODE_SYSREQ 0x54
+#define WINDOWS_SCANCODE_UNASSIGNED 0x55
+
+/* Windows, the E0-prefixed block. Positions that duplicate a key in the block
+   above and so cannot be told apart by scancode alone. */
+static const struct {
+	uint32_t scancode;
+	uint32_t x11;
+} windows_extended[] = {
+	{ 0x1c, X11_KP_ENTER },
+	{ 0x1d, X11_RIGHTCTRL },
+	{ 0x35, X11_KP_DIVIDE },
+	/* AltGr. A German keyboard needs it for @ \ | ~ and the like, and until
+	   now it reached nothing: right Alt was being reported to the guest as
+	   left Alt on Windows and macOS, and on X11 it was dropped outright
+	   because keyboard_x.c had no 0x6c. See issue #88. */
+	{ 0x38, X11_RIGHTALT },
+	/* Ctrl+Pause arrives as E0 46 rather than as the E1 sequence. */
+	{ 0x46, X11_BREAK },
+	{ 0x47, X11_HOME },
+	{ 0x48, X11_UP },
+	{ 0x49, X11_PAGEUP },
+	{ 0x4b, X11_LEFT },
+	{ 0x4d, X11_RIGHT },
+	{ 0x4f, X11_END },
+	{ 0x50, X11_DOWN },
+	{ 0x51, X11_PAGEDOWN },
+	{ 0x52, X11_INSERT },
+	{ 0x53, X11_DELETE },
+	{ 0x5b, X11_LEFTWIN },
+	{ 0x5c, X11_RIGHTWIN },
+	{ 0x5d, X11_MENU },
+};
+
+/*
+ * macOS virtual keycodes. Sparse and in no useful order, because ADB numbered
+ * the keys by where they sat on the 1984 keyboard's matrix rather than by
+ * anything a layout cares about - which is precisely why they are the right
+ * thing to read. Every entry is checked against Apple's own kVK_ constant
+ * below when building on macOS.
+ *
+ * Deliberately absent: kVK_Function (0x3f) and kVK_ANSI_KeypadEquals (0x51),
+ * which no PC keyboard and therefore no RISC OS has, and kVK_F13 (0x69), whose
+ * PC equivalent is Print Screen and which keyboard_x.c does not map either.
+ */
+static const struct {
+	uint32_t keycode;
+	uint32_t x11;
+} macos_keys[] = {
+	{ 0x00, X11_A },
+	{ 0x01, X11_S },
+	{ 0x02, X11_D },
+	{ 0x03, X11_F },
+	{ 0x04, X11_H },
+	{ 0x05, X11_G },
+	{ 0x06, X11_Z },
+	{ 0x07, X11_X },
+	{ 0x08, X11_C },
+	{ 0x09, X11_V },
+	/* The extra key an ISO keyboard has and an ANSI one does not. On a UK Mac
+	   it is the section key; on a PC it is the one beside left Shift. */
+	{ 0x0a, X11_BACKSLASH },
+	{ 0x0b, X11_B },
+	{ 0x0c, X11_Q },
+	{ 0x0d, X11_W },
+	{ 0x0e, X11_E },
+	{ 0x0f, X11_R },
+	{ 0x10, X11_Y },
+	{ 0x11, X11_T },
+	{ 0x12, X11_1 },
+	{ 0x13, X11_2 },
+	{ 0x14, X11_3 },
+	{ 0x15, X11_4 },
+	{ 0x16, X11_6 },	/* 6 and 5 really are the other way round */
+	{ 0x17, X11_5 },
+	{ 0x18, X11_EQUAL },
+	{ 0x19, X11_9 },
+	{ 0x1a, X11_7 },
+	{ 0x1b, X11_MINUS },
+	{ 0x1c, X11_8 },
+	{ 0x1d, X11_0 },
+	{ 0x1e, X11_RIGHTBRACKET },
+	{ 0x1f, X11_O },
+	{ 0x20, X11_U },
+	{ 0x21, X11_LEFTBRACKET },
+	{ 0x22, X11_I },
+	{ 0x23, X11_P },
+	{ 0x24, X11_RETURN },
+	{ 0x25, X11_L },
+	{ 0x26, X11_J },
+	{ 0x27, X11_QUOTE },
+	{ 0x28, X11_K },
+	{ 0x29, X11_SEMICOLON },
+	{ 0x2a, X11_HASH },
+	{ 0x2b, X11_COMMA },
+	{ 0x2c, X11_SLASH },
+	{ 0x2d, X11_N },
+	{ 0x2e, X11_M },
+	{ 0x2f, X11_PERIOD },
+	{ 0x30, X11_TAB },
+	{ 0x31, X11_SPACE },
+	{ 0x32, X11_GRAVE },
+	{ 0x33, X11_BACKSPACE },	/* kVK_Delete is the one above Return */
+	{ 0x35, X11_ESCAPE },
+	/* Both Command keys map to their honest PC equivalent, the Windows keys.
+	   What RPCEmu then DOES with them is a policy decision and lives in
+	   input_helpers.cpp: left Command becomes Ctrl so that Cmd+C still copies
+	   in RISC OS, and right Command becomes the third mouse button because a
+	   Mac has no menu key (issue #91). Keeping that out of this table is what
+	   lets the table stay one-to-one and be checked for collisions. */
+	{ 0x36, X11_RIGHTWIN },
+	{ 0x37, X11_LEFTWIN },
+	{ 0x38, X11_LEFTSHIFT },
+	{ 0x39, X11_CAPSLOCK },
+	{ 0x3a, X11_LEFTALT },
+	{ 0x3b, X11_LEFTCTRL },
+	{ 0x3c, X11_RIGHTSHIFT },
+	{ 0x3d, X11_RIGHTALT },
+	{ 0x3e, X11_RIGHTCTRL },
+	{ 0x41, X11_KP_DECIMAL },
+	{ 0x43, X11_KP_MULTIPLY },
+	{ 0x45, X11_KP_PLUS },
+	{ 0x47, X11_NUMLOCK },		/* kVK_ANSI_KeypadClear */
+	{ 0x4b, X11_KP_DIVIDE },
+	{ 0x4c, X11_KP_ENTER },
+	{ 0x4e, X11_KP_MINUS },
+	{ 0x52, X11_KP_0 },
+	{ 0x53, X11_KP_1 },
+	{ 0x54, X11_KP_2 },
+	{ 0x55, X11_KP_3 },
+	{ 0x56, X11_KP_4 },
+	{ 0x57, X11_KP_5 },
+	{ 0x58, X11_KP_6 },
+	{ 0x59, X11_KP_7 },
+	{ 0x5b, X11_KP_8 },
+	{ 0x5c, X11_KP_9 },
+	{ 0x60, X11_F5 },
+	{ 0x61, X11_F6 },
+	{ 0x62, X11_F7 },
+	{ 0x63, X11_F3 },
+	{ 0x64, X11_F8 },
+	{ 0x65, X11_F9 },
+	{ 0x67, X11_F11 },
+	{ 0x6b, X11_SCROLLLOCK },	/* kVK_F14 */
+	{ 0x6d, X11_F10 },
+	{ 0x6f, X11_F12 },
+	{ 0x71, X11_BREAK },		/* kVK_F15 */
+	{ 0x72, X11_INSERT },		/* kVK_Help */
+	{ 0x73, X11_HOME },
+	{ 0x74, X11_PAGEUP },
+	{ 0x75, X11_DELETE },		/* kVK_ForwardDelete */
+	{ 0x76, X11_F4 },
+	{ 0x77, X11_END },
+	{ 0x78, X11_F2 },
+	{ 0x79, X11_PAGEDOWN },
+	{ 0x7a, X11_F1 },
+	{ 0x7b, X11_LEFT },
+	{ 0x7c, X11_RIGHT },
+	{ 0x7d, X11_DOWN },
+	{ 0x7e, X11_UP },
+};
+
+#ifdef KEYMAP_CHECK_AGAINST_APPLE_HEADERS
+/* Every literal in macos_keys[] against the constant it is meant to be. A
+   mistyped number becomes a compile error on macOS rather than a wrong key.
+   kVK_RightCommand is left out on purpose: unlike the rest it was only added to
+   the SDK in 10.12, so asserting it would make the check itself a portability
+   problem. */
+#define KEYMAP_ASSERT_KVK(literal, apple) \
+	_Static_assert((literal) == (apple), "macOS keycode " #apple " is not " #literal)
+
+KEYMAP_ASSERT_KVK(0x00, kVK_ANSI_A);
+KEYMAP_ASSERT_KVK(0x01, kVK_ANSI_S);
+KEYMAP_ASSERT_KVK(0x02, kVK_ANSI_D);
+KEYMAP_ASSERT_KVK(0x03, kVK_ANSI_F);
+KEYMAP_ASSERT_KVK(0x04, kVK_ANSI_H);
+KEYMAP_ASSERT_KVK(0x05, kVK_ANSI_G);
+KEYMAP_ASSERT_KVK(0x06, kVK_ANSI_Z);
+KEYMAP_ASSERT_KVK(0x07, kVK_ANSI_X);
+KEYMAP_ASSERT_KVK(0x08, kVK_ANSI_C);
+KEYMAP_ASSERT_KVK(0x09, kVK_ANSI_V);
+KEYMAP_ASSERT_KVK(0x0a, kVK_ISO_Section);
+KEYMAP_ASSERT_KVK(0x0b, kVK_ANSI_B);
+KEYMAP_ASSERT_KVK(0x0c, kVK_ANSI_Q);
+KEYMAP_ASSERT_KVK(0x0d, kVK_ANSI_W);
+KEYMAP_ASSERT_KVK(0x0e, kVK_ANSI_E);
+KEYMAP_ASSERT_KVK(0x0f, kVK_ANSI_R);
+KEYMAP_ASSERT_KVK(0x10, kVK_ANSI_Y);
+KEYMAP_ASSERT_KVK(0x11, kVK_ANSI_T);
+KEYMAP_ASSERT_KVK(0x12, kVK_ANSI_1);
+KEYMAP_ASSERT_KVK(0x13, kVK_ANSI_2);
+KEYMAP_ASSERT_KVK(0x14, kVK_ANSI_3);
+KEYMAP_ASSERT_KVK(0x15, kVK_ANSI_4);
+KEYMAP_ASSERT_KVK(0x16, kVK_ANSI_6);
+KEYMAP_ASSERT_KVK(0x17, kVK_ANSI_5);
+KEYMAP_ASSERT_KVK(0x18, kVK_ANSI_Equal);
+KEYMAP_ASSERT_KVK(0x19, kVK_ANSI_9);
+KEYMAP_ASSERT_KVK(0x1a, kVK_ANSI_7);
+KEYMAP_ASSERT_KVK(0x1b, kVK_ANSI_Minus);
+KEYMAP_ASSERT_KVK(0x1c, kVK_ANSI_8);
+KEYMAP_ASSERT_KVK(0x1d, kVK_ANSI_0);
+KEYMAP_ASSERT_KVK(0x1e, kVK_ANSI_RightBracket);
+KEYMAP_ASSERT_KVK(0x1f, kVK_ANSI_O);
+KEYMAP_ASSERT_KVK(0x20, kVK_ANSI_U);
+KEYMAP_ASSERT_KVK(0x21, kVK_ANSI_LeftBracket);
+KEYMAP_ASSERT_KVK(0x22, kVK_ANSI_I);
+KEYMAP_ASSERT_KVK(0x23, kVK_ANSI_P);
+KEYMAP_ASSERT_KVK(0x24, kVK_Return);
+KEYMAP_ASSERT_KVK(0x25, kVK_ANSI_L);
+KEYMAP_ASSERT_KVK(0x26, kVK_ANSI_J);
+KEYMAP_ASSERT_KVK(0x27, kVK_ANSI_Quote);
+KEYMAP_ASSERT_KVK(0x28, kVK_ANSI_K);
+KEYMAP_ASSERT_KVK(0x29, kVK_ANSI_Semicolon);
+KEYMAP_ASSERT_KVK(0x2a, kVK_ANSI_Backslash);
+KEYMAP_ASSERT_KVK(0x2b, kVK_ANSI_Comma);
+KEYMAP_ASSERT_KVK(0x2c, kVK_ANSI_Slash);
+KEYMAP_ASSERT_KVK(0x2d, kVK_ANSI_N);
+KEYMAP_ASSERT_KVK(0x2e, kVK_ANSI_M);
+KEYMAP_ASSERT_KVK(0x2f, kVK_ANSI_Period);
+KEYMAP_ASSERT_KVK(0x30, kVK_Tab);
+KEYMAP_ASSERT_KVK(0x31, kVK_Space);
+KEYMAP_ASSERT_KVK(0x32, kVK_ANSI_Grave);
+KEYMAP_ASSERT_KVK(0x33, kVK_Delete);
+KEYMAP_ASSERT_KVK(0x35, kVK_Escape);
+KEYMAP_ASSERT_KVK(0x37, kVK_Command);
+KEYMAP_ASSERT_KVK(0x38, kVK_Shift);
+KEYMAP_ASSERT_KVK(0x39, kVK_CapsLock);
+KEYMAP_ASSERT_KVK(0x3a, kVK_Option);
+KEYMAP_ASSERT_KVK(0x3b, kVK_Control);
+KEYMAP_ASSERT_KVK(0x3c, kVK_RightShift);
+KEYMAP_ASSERT_KVK(0x3d, kVK_RightOption);
+KEYMAP_ASSERT_KVK(0x3e, kVK_RightControl);
+KEYMAP_ASSERT_KVK(0x41, kVK_ANSI_KeypadDecimal);
+KEYMAP_ASSERT_KVK(0x43, kVK_ANSI_KeypadMultiply);
+KEYMAP_ASSERT_KVK(0x45, kVK_ANSI_KeypadPlus);
+KEYMAP_ASSERT_KVK(0x47, kVK_ANSI_KeypadClear);
+KEYMAP_ASSERT_KVK(0x4b, kVK_ANSI_KeypadDivide);
+KEYMAP_ASSERT_KVK(0x4c, kVK_ANSI_KeypadEnter);
+KEYMAP_ASSERT_KVK(0x4e, kVK_ANSI_KeypadMinus);
+KEYMAP_ASSERT_KVK(0x52, kVK_ANSI_Keypad0);
+KEYMAP_ASSERT_KVK(0x53, kVK_ANSI_Keypad1);
+KEYMAP_ASSERT_KVK(0x54, kVK_ANSI_Keypad2);
+KEYMAP_ASSERT_KVK(0x55, kVK_ANSI_Keypad3);
+KEYMAP_ASSERT_KVK(0x56, kVK_ANSI_Keypad4);
+KEYMAP_ASSERT_KVK(0x57, kVK_ANSI_Keypad5);
+KEYMAP_ASSERT_KVK(0x58, kVK_ANSI_Keypad6);
+KEYMAP_ASSERT_KVK(0x59, kVK_ANSI_Keypad7);
+KEYMAP_ASSERT_KVK(0x5b, kVK_ANSI_Keypad8);
+KEYMAP_ASSERT_KVK(0x5c, kVK_ANSI_Keypad9);
+KEYMAP_ASSERT_KVK(0x60, kVK_F5);
+KEYMAP_ASSERT_KVK(0x61, kVK_F6);
+KEYMAP_ASSERT_KVK(0x62, kVK_F7);
+KEYMAP_ASSERT_KVK(0x63, kVK_F3);
+KEYMAP_ASSERT_KVK(0x64, kVK_F8);
+KEYMAP_ASSERT_KVK(0x65, kVK_F9);
+KEYMAP_ASSERT_KVK(0x67, kVK_F11);
+KEYMAP_ASSERT_KVK(0x6b, kVK_F14);
+KEYMAP_ASSERT_KVK(0x6d, kVK_F10);
+KEYMAP_ASSERT_KVK(0x6f, kVK_F12);
+KEYMAP_ASSERT_KVK(0x71, kVK_F15);
+KEYMAP_ASSERT_KVK(0x72, kVK_Help);
+KEYMAP_ASSERT_KVK(0x73, kVK_Home);
+KEYMAP_ASSERT_KVK(0x74, kVK_PageUp);
+KEYMAP_ASSERT_KVK(0x75, kVK_ForwardDelete);
+KEYMAP_ASSERT_KVK(0x76, kVK_F4);
+KEYMAP_ASSERT_KVK(0x77, kVK_End);
+KEYMAP_ASSERT_KVK(0x78, kVK_F2);
+KEYMAP_ASSERT_KVK(0x79, kVK_PageDown);
+KEYMAP_ASSERT_KVK(0x7a, kVK_F1);
+KEYMAP_ASSERT_KVK(0x7b, kVK_LeftArrow);
+KEYMAP_ASSERT_KVK(0x7c, kVK_RightArrow);
+KEYMAP_ASSERT_KVK(0x7d, kVK_DownArrow);
+KEYMAP_ASSERT_KVK(0x7e, kVK_UpArrow);
+#endif /* KEYMAP_CHECK_AGAINST_APPLE_HEADERS */
+
+uint32_t
+keymap_x11_from_windows_scancode(uint32_t scancode, int extended)
+{
+	size_t i;
+
+	if (extended) {
+		for (i = 0; i < sizeof(windows_extended) / sizeof(windows_extended[0]); i++) {
+			if (windows_extended[i].scancode == scancode) {
+				return windows_extended[i].x11;
+			}
+		}
+		return 0;
+	}
+
+	if (scancode == 0 || scancode > KEYMAP_WINDOWS_SCANCODE_MAX) {
+		return 0;
+	}
+	if (scancode == WINDOWS_SCANCODE_SYSREQ ||
+	    scancode == WINDOWS_SCANCODE_UNASSIGNED) {
+		return 0;
+	}
+	return scancode + WINDOWS_SCANCODE_TO_X11_OFFSET;
+}
+
+/* Layout of the WM_KEY* lParam, as documented for WM_KEYDOWN. */
+#define WINDOWS_LPARAM_SCANCODE_SHIFT 16
+#define WINDOWS_LPARAM_SCANCODE_MASK 0xff
+#define WINDOWS_LPARAM_EXTENDED_BIT (1u << 24)
+
+uint32_t
+keymap_x11_from_windows_lparam(uint32_t lparam)
+{
+	const uint32_t scancode =
+	    (lparam >> WINDOWS_LPARAM_SCANCODE_SHIFT) & WINDOWS_LPARAM_SCANCODE_MASK;
+	const int extended = (lparam & WINDOWS_LPARAM_EXTENDED_BIT) != 0;
+
+	return keymap_x11_from_windows_scancode(scancode, extended);
+}
+
+uint32_t
+keymap_x11_from_macos_keycode(uint32_t keycode)
+{
+	size_t i;
+
+	for (i = 0; i < sizeof(macos_keys) / sizeof(macos_keys[0]); i++) {
+		if (macos_keys[i].keycode == keycode) {
+			return macos_keys[i].x11;
+		}
+	}
+	return 0;
+}

--- a/src/gui/keymap_platform.h
+++ b/src/gui/keymap_platform.h
@@ -1,0 +1,100 @@
+/*
+  RPCEmu - An Acorn system emulator
+
+  Copyright (C) 2026 Andy Timmins
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifndef KEYMAP_PLATFORM_H
+#define KEYMAP_PLATFORM_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Physical key position -> the X11 hardware keycode the rest of RPCEmu calls a
+ * "native scancode" and feeds to keyboard_map_key().
+ *
+ * WHY THIS EXISTS. A native scancode identifies a key by WHERE IT IS, not by
+ * what it types. keyboard_map_key() turns that position into PS/2 Set 2 codes
+ * and RISC OS applies its own keyboard layout on top. Under wxGTK the position
+ * arrives for free, because an X11 keycode is what X11 hands us. On Windows and
+ * macOS it does not: wxKeyEvent::GetKeyCode() has already been through the
+ * host's layout, so it describes a CHARACTER.
+ *
+ * Mapping that character back onto a position can only work if the host layout
+ * matches whatever layout the table was written against, and ours was written
+ * against UK. On any other layout it fails three ways at once, all of them
+ * reported: keys whose character is not in the table go dead (issue #88,
+ * umlauts), keys that moved get the position of whatever they now type so RISC
+ * OS translates a second time (issue #88, z and y swapping "the wrong way
+ * around"), and keys that differ only by position rather than by character
+ * cannot be told apart at all (issue #91, Command against Control on macOS;
+ * also left against right Shift and Ctrl everywhere).
+ *
+ * So both platforms are given their own position table instead. Neither is
+ * conditionally compiled: they are plain data, which means tests/test_keymap.c
+ * can check all three platforms' mappings from whichever one it happens to be
+ * running on. See docs/keyboard.md.
+ */
+
+/**
+ * Windows OEM (PS/2 Set 1) scancode -> X11 keycode.
+ *
+ * @param scancode Set 1 scancode, i.e. bits 16-23 of the WM_KEY* lParam that
+ *                 wxWidgets exposes as wxKeyEvent::GetRawKeyFlags().
+ * @param extended Non-zero when bit 24 of that lParam is set, marking the key
+ *                 as one of the E0-prefixed duplicates (keypad Enter, right
+ *                 Ctrl, the arrow cluster, AltGr and so on).
+ * @return X11 keycode, or 0 when the key has no RISC OS equivalent.
+ */
+uint32_t keymap_x11_from_windows_scancode(uint32_t scancode, int extended);
+
+/**
+ * Windows WM_KEY* lParam -> X11 keycode.
+ *
+ * Unpacks the message parameter and looks the result up, so that the shifts and
+ * masks live somewhere a test can reach rather than inline in the wxWidgets
+ * event handler. Bits 16-23 hold the scancode and bit 24 the extended flag;
+ * getting either wrong yields a plausible but wrong key, which is not the kind
+ * of mistake that announces itself.
+ *
+ * @param lparam Value of wxKeyEvent::GetRawKeyFlags() under wxMSW.
+ * @return X11 keycode, or 0 when the key has no RISC OS equivalent.
+ */
+uint32_t keymap_x11_from_windows_lparam(uint32_t lparam);
+
+/**
+ * macOS virtual keycode -> X11 keycode.
+ *
+ * @param keycode The value of [NSEvent keyCode], which wxWidgets exposes as
+ *                wxKeyEvent::GetRawKeyCode(). These are the original ADB
+ *                keycodes and describe a position, not a character.
+ * @return X11 keycode, or 0 when the key has no RISC OS equivalent.
+ */
+uint32_t keymap_x11_from_macos_keycode(uint32_t keycode);
+
+/** Highest Windows Set 1 scancode the non-extended arithmetic covers. */
+#define KEYMAP_WINDOWS_SCANCODE_MAX 0x58
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* KEYMAP_PLATFORM_H */

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -1734,7 +1734,18 @@ void MainFrame::ProcessEmulatorKeyEvent(wxKeyEvent &event, bool key_down)
 	 * / full-screen release key (Alt+Enter), handled below. */
 
 	const int key_code = event.GetKeyCode();
-	if (key_code == WXK_NONE || key_code == 0) {
+	const unsigned scan_code = InputNativeScancodeFromKeyEvent(event);
+
+	InputLogKeyEvent(event, scan_code, key_down);
+
+	/*
+	 * Both have to be unusable before the key is given up on. Testing the wx
+	 * keycode alone used to be enough, and was wrong: a key the host layout puts
+	 * somewhere wxWidgets has no name for reports WXK_NONE, so the keys that most
+	 * needed the physical-position lookup were thrown away before reaching it.
+	 * That is the German umlauts in issue #88.
+	 */
+	if (scan_code == 0 && (key_code == WXK_NONE || key_code == 0)) {
 		event.Skip();
 		return;
 	}
@@ -1752,7 +1763,7 @@ void MainFrame::ProcessEmulatorKeyEvent(wxKeyEvent &event, bool key_down)
 		/* Nothing to escape from, so the guest gets the key. */
 	}
 
-	if (key_code == WXK_MENU || key_code == WXK_WINDOWS_MENU) {
+	if (InputIsThirdMouseButtonKey(event)) {
 		if (emulator_) {
 			if (key_down) {
 				emulator_->MousePress(4);
@@ -1767,7 +1778,6 @@ void MainFrame::ProcessEmulatorKeyEvent(wxKeyEvent &event, bool key_down)
 		return;
 	}
 
-	const unsigned scan_code = InputNativeScancodeFromKeyEvent(event);
 	if (scan_code == 0) {
 		event.Skip();
 		return;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -136,6 +136,21 @@ add_executable(test_mode_fit test_mode_fit.c
 target_include_directories(test_mode_fit PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 rpcemu_add_test(test_mode_fit)
 
+# Host keys to RISC OS keys. Compiles the two units directly, which is the whole
+# point of them being separate: they are integer lookup tables with no wxWidgets
+# and no platform calls, so THE WINDOWS AND macOS MAPPINGS ARE BOTH TESTED FROM
+# WHICHEVER PLATFORM HAPPENS TO BE RUNNING. The keyboard had no test at all until
+# three faults arrived that all came from mapping characters instead of physical
+# key positions - #88 (German layout), #91 (third mouse button on macOS) and part
+# of #70 (left and right modifiers). See docs/keyboard.md.
+add_executable(test_keymap test_keymap.c
+               ${CMAKE_CURRENT_SOURCE_DIR}/../src/gui/keymap_platform.c
+               ${CMAKE_CURRENT_SOURCE_DIR}/../src/gui/keyboard_x.c)
+target_include_directories(test_keymap PRIVATE
+                           ${CMAKE_CURRENT_SOURCE_DIR}/../src
+                           ${CMAKE_CURRENT_SOURCE_DIR}/../src/gui)
+rpcemu_add_test(test_keymap)
+
 # Networking tests for the Access+/ShareFS path, where large copies drive IP
 # fragment reassembly. These compile the code under test directly rather than
 # linking rpcemu_core, because each replaces a symbol the core also defines: the
@@ -296,7 +311,7 @@ rpcemu_add_test(test_unzip)
 #
 # Raise RPCEMU_EXPECTED_TESTS when adding a test. If that feels like a chore, it
 # is the only line in the file that cannot go stale without being noticed.
-set(RPCEMU_EXPECTED_TESTS 16)	# tests that build on every platform
+set(RPCEMU_EXPECTED_TESTS 17)	# tests that build on every platform
 if(RPCEMU_JIT_TESTS)
     math(EXPR RPCEMU_EXPECTED_TESTS "${RPCEMU_EXPECTED_TESTS} + 8")	# JIT differential
 endif()

--- a/tests/test_keymap.c
+++ b/tests/test_keymap.c
@@ -1,0 +1,565 @@
+/*
+ * Physical keys to RISC OS keys, for all three platforms at once.
+ *
+ * WHY THIS TEST CAN EXIST AT ALL. The two things under test are pure lookup
+ * tables over integers, with no wxWidgets, no window and no platform calls
+ * anywhere near them. That is deliberate: it means the Windows table and the
+ * macOS table are both checkable from a Linux runner, and the keyboard stops
+ * being the one input path that could only be tested by a person sitting at
+ * three different machines. Before this there was no keyboard test of any kind.
+ *
+ * WHAT WENT WRONG WITHOUT IT. Windows and macOS used to identify a key by the
+ * CHARACTER the host layout produced and look that up in a table written for a
+ * UK keyboard. Three reported faults came out of that one decision:
+ *
+ *   #88  A German keyboard. Umlauts dead, because no table entry types 'u'
+ *        with an umlaut. z and y swapped "the wrong way around", because
+ *        Windows had already applied German and RISC OS then applied it again.
+ *   #91  The third mouse button on macOS, because Command and Control are
+ *        different POSITIONS producing the same character, and a character
+ *        cannot tell them apart.
+ *   #70  Partly. Left and right Shift were reported to the guest as the same
+ *        key for the same reason.
+ *
+ * So the cases below are not decoration. They assert the properties that were
+ * actually violated: that a position maps to the same RISC OS key whatever the
+ * host layout thinks it types, that keys differing only by position stay
+ * distinct, and that nothing in either table maps to a key keyboard_x.c cannot
+ * deliver.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "keyboard.h"
+#include "keymap_platform.h"
+
+static int failures;
+
+static void
+check(const char *what, int ok)
+{
+	printf("  %-62s %s\n", what, ok ? "ok" : "FAIL");
+	if (!ok) {
+		failures++;
+	}
+}
+
+/* Windows Set 1 scancodes, by position rather than by what they type. */
+#define WSC_ESCAPE	0x01
+#define WSC_1		0x02
+#define WSC_MINUS	0x0c
+#define WSC_BACKSPACE	0x0e
+#define WSC_TAB		0x0f
+#define WSC_Q		0x10
+#define WSC_Y		0x15	/* types 'z' on a German keyboard */
+#define WSC_LEFTBRACKET	0x1a	/* types 'u' umlaut on a German keyboard */
+#define WSC_RETURN	0x1c
+#define WSC_LEFTCTRL	0x1d
+#define WSC_A		0x1e
+#define WSC_SEMICOLON	0x27	/* types 'o' umlaut on a German keyboard */
+#define WSC_QUOTE	0x28	/* types 'a' umlaut on a German keyboard */
+#define WSC_HASH	0x2b	/* international, # on UK */
+#define WSC_LEFTSHIFT	0x2a
+#define WSC_Z		0x2c	/* types 'y' on a German keyboard */
+#define WSC_SLASH	0x35
+#define WSC_RIGHTSHIFT	0x36
+#define WSC_LEFTALT	0x38
+#define WSC_SPACE	0x39
+#define WSC_CAPSLOCK	0x3a
+#define WSC_F1		0x3b
+#define WSC_NUMLOCK	0x45
+#define WSC_KP_7	0x47
+#define WSC_SYSREQ	0x54
+#define WSC_UNASSIGNED	0x55
+#define WSC_BACKSLASH	0x56	/* international, <>| on German */
+#define WSC_F11		0x57
+#define WSC_F12		0x58
+
+/* macOS virtual keycodes, likewise. Names match Apple's kVK_ constants, which
+   keymap_platform.c asserts these numbers against when built on macOS. */
+#define MVK_A		0x00
+#define MVK_Z		0x06
+#define MVK_ISO_SECTION	0x0a
+#define MVK_Q		0x0c
+#define MVK_Y		0x10
+#define MVK_1		0x12
+#define MVK_5		0x17
+#define MVK_6		0x16
+#define MVK_RETURN	0x24
+#define MVK_TAB		0x30
+#define MVK_SPACE	0x31
+#define MVK_BACKSPACE	0x33
+#define MVK_ESCAPE	0x35
+#define MVK_RIGHTCOMMAND 0x36
+#define MVK_COMMAND	0x37
+#define MVK_SHIFT	0x38
+#define MVK_CAPSLOCK	0x39
+#define MVK_OPTION	0x3a
+#define MVK_CONTROL	0x3b
+#define MVK_RIGHTSHIFT	0x3c
+#define MVK_RIGHTOPTION	0x3d
+#define MVK_RIGHTCONTROL 0x3e
+#define MVK_FUNCTION	0x3f
+#define MVK_KEYPAD_EQUALS 0x51
+#define MVK_F1		0x7a
+#define MVK_LEFTARROW	0x7b
+#define MVK_UPARROW	0x7e
+
+/* X11 keycodes, the shared currency both tables produce. */
+#define X11_ESCAPE	0x09
+#define X11_1		0x0a
+#define X11_MINUS	0x14
+#define X11_BACKSPACE	0x16
+#define X11_TAB		0x17
+#define X11_Q		0x18
+#define X11_Y		0x1d
+#define X11_LEFTBRACKET	0x22
+#define X11_RETURN	0x24
+#define X11_LEFTCTRL	0x25
+#define X11_A		0x26
+#define X11_SEMICOLON	0x2f
+#define X11_QUOTE	0x30
+#define X11_LEFTSHIFT	0x32
+#define X11_HASH	0x33
+#define X11_Z		0x34
+#define X11_SLASH	0x3d
+#define X11_RIGHTSHIFT	0x3e
+#define X11_LEFTALT	0x40
+#define X11_SPACE	0x41
+#define X11_CAPSLOCK	0x42
+#define X11_F1		0x43
+#define X11_NUMLOCK	0x4d
+#define X11_KP_7	0x4f
+#define X11_BACKSLASH	0x5e
+#define X11_F11		0x5f
+#define X11_F12		0x60
+#define X11_KP_ENTER	0x68
+#define X11_RIGHTCTRL	0x69
+#define X11_KP_DIVIDE	0x6a
+#define X11_RIGHTALT	0x6c
+#define X11_UP		0x6f
+#define X11_LEFT	0x71
+#define X11_DELETE	0x77
+#define X11_LEFTWIN	0x85
+#define X11_RIGHTWIN	0x86
+#define X11_MENU	0x87
+
+/* PS/2 Set 2 make codes, so the chain can be followed all the way to the wire. */
+#define PS2_A		0x1c
+#define PS2_Q		0x15
+#define PS2_Y		0x35
+#define PS2_Z		0x1a
+#define PS2_LEFTSHIFT	0x12
+#define PS2_RIGHTSHIFT	0x59
+
+static void
+win(const char *what, uint32_t scancode, int extended, uint32_t expected)
+{
+	char label[128];
+	const uint32_t got = keymap_x11_from_windows_scancode(scancode, extended);
+
+	snprintf(label, sizeof(label), "windows %s0x%02x -> x11 0x%02x",
+	    extended ? "e0 " : "", scancode, expected);
+	if (got != expected) {
+		snprintf(label + strlen(label), sizeof(label) - strlen(label),
+		    " (got 0x%02x)", got);
+	}
+	check(label, got == expected);
+	(void) what;
+}
+
+static void
+mac(const char *what, uint32_t keycode, uint32_t expected)
+{
+	char label[128];
+	const uint32_t got = keymap_x11_from_macos_keycode(keycode);
+
+	snprintf(label, sizeof(label), "macos 0x%02x (%s) -> x11 0x%02x",
+	    keycode, what, expected);
+	if (got != expected) {
+		snprintf(label + strlen(label), sizeof(label) - strlen(label),
+		    " (got 0x%02x)", got);
+	}
+	check(label, got == expected);
+}
+
+/** First PS/2 make code for an X11 keycode, or 0 when it maps to nothing. */
+static uint8_t
+ps2_of(uint32_t x11)
+{
+	const uint8_t *codes = keyboard_map_key(x11);
+
+	return codes != NULL ? codes[0] : 0;
+}
+
+/*
+ * The contract keymap_platform.c documents: a non-zero return is always a
+ * keycode keyboard_map_key() knows. If that fails, a key silently reaches the
+ * guest as nothing at all, which is exactly the class of bug being fixed, so it
+ * is checked exhaustively rather than by sampling.
+ */
+static void
+test_no_dead_ends(void)
+{
+	uint32_t sc, vk;
+	int windows_mapped = 0, macos_mapped = 0;
+	int dead = 0;
+
+	puts("Every mapped position resolves to a real RISC OS key:");
+
+	for (sc = 1; sc <= KEYMAP_WINDOWS_SCANCODE_MAX; sc++) {
+		const uint32_t x11 = keymap_x11_from_windows_scancode(sc, 0);
+
+		if (x11 == 0) {
+			continue;
+		}
+		windows_mapped++;
+		if (ps2_of(x11) == 0) {
+			printf("    windows 0x%02x -> x11 0x%02x -> nothing\n", sc, x11);
+			dead++;
+		}
+	}
+	/* The E0 block is sparse, so sweep the whole byte rather than a range. */
+	for (sc = 0; sc <= 0xff; sc++) {
+		const uint32_t x11 = keymap_x11_from_windows_scancode(sc, 1);
+
+		if (x11 == 0) {
+			continue;
+		}
+		windows_mapped++;
+		if (ps2_of(x11) == 0) {
+			printf("    windows e0 0x%02x -> x11 0x%02x -> nothing\n", sc, x11);
+			dead++;
+		}
+	}
+	for (vk = 0; vk <= 0xff; vk++) {
+		const uint32_t x11 = keymap_x11_from_macos_keycode(vk);
+
+		if (x11 == 0) {
+			continue;
+		}
+		macos_mapped++;
+		if (ps2_of(x11) == 0) {
+			printf("    macos 0x%02x -> x11 0x%02x -> nothing\n", vk, x11);
+			dead++;
+		}
+	}
+
+	check("no windows or macos position maps to an unknown key", dead == 0);
+
+	/* A table that mapped almost nothing would pass the check above without
+	   being any use, so assert it is actually populated. A PC keyboard has
+	   about 100 keys and both tables should be within reach of that. */
+	printf("    windows positions mapped: %d, macos: %d\n",
+	    windows_mapped, macos_mapped);
+	check("windows table covers a whole keyboard", windows_mapped >= 100);
+	check("macos table covers a whole keyboard", macos_mapped >= 100);
+}
+
+/*
+ * Two physical keys must never become one RISC OS key. This is the property
+ * whose absence made issue #91 impossible to fix at the character level, and it
+ * is why the Command policy lives in input_helpers.cpp rather than in the table.
+ */
+static void
+test_no_collisions(void)
+{
+	int seen[0x100];
+	uint32_t sc, vk;
+	int collisions = 0;
+
+	puts("Distinct positions stay distinct:");
+
+	memset(seen, 0, sizeof(seen));
+	for (sc = 1; sc <= KEYMAP_WINDOWS_SCANCODE_MAX; sc++) {
+		const uint32_t x11 = keymap_x11_from_windows_scancode(sc, 0);
+
+		if (x11 != 0 && seen[x11]++) {
+			printf("    windows x11 0x%02x reached twice\n", x11);
+			collisions++;
+		}
+	}
+	for (sc = 0; sc <= 0xff; sc++) {
+		const uint32_t x11 = keymap_x11_from_windows_scancode(sc, 1);
+
+		if (x11 != 0 && seen[x11]++) {
+			printf("    windows e0 x11 0x%02x reached twice\n", x11);
+			collisions++;
+		}
+	}
+	check("no two windows positions share a RISC OS key", collisions == 0);
+
+	memset(seen, 0, sizeof(seen));
+	collisions = 0;
+	for (vk = 0; vk <= 0xff; vk++) {
+		const uint32_t x11 = keymap_x11_from_macos_keycode(vk);
+
+		if (x11 != 0 && seen[x11]++) {
+			printf("    macos x11 0x%02x reached twice\n", x11);
+			collisions++;
+		}
+	}
+	check("no two macos positions share a RISC OS key", collisions == 0);
+}
+
+/*
+ * Issue #88. The point is not that these particular keys work, it is that the
+ * answer does not depend on what the host layout says the key types. A German
+ * keyboard puts z where a UK one puts y; both are scancode 0x15 and both must
+ * arrive as RISC OS's Y key, leaving RISC OS to apply its own layout ONCE.
+ */
+static void
+test_layout_independence(void)
+{
+	puts("Issue #88 - a position means the same thing on any layout:");
+
+	win("Y position", WSC_Y, 0, X11_Y);
+	win("Z position", WSC_Z, 0, X11_Z);
+	check("windows Y position reaches the guest's Y",
+	    ps2_of(keymap_x11_from_windows_scancode(WSC_Y, 0)) == PS2_Y);
+	check("windows Z position reaches the guest's Z",
+	    ps2_of(keymap_x11_from_windows_scancode(WSC_Z, 0)) == PS2_Z);
+
+	/* The keys a German layout puts umlauts on. Each used to be dead, because
+	   the character it produced was in no table. */
+	win("umlaut u position", WSC_LEFTBRACKET, 0, X11_LEFTBRACKET);
+	win("umlaut o position", WSC_SEMICOLON, 0, X11_SEMICOLON);
+	win("umlaut a position", WSC_QUOTE, 0, X11_QUOTE);
+
+	/* The two keys that exist only on some layouts, and are the ones a German
+	   keyboard uses for <>| and #. */
+	win("international <>| beside left shift", WSC_BACKSLASH, 0, X11_BACKSLASH);
+	win("international # beside return", WSC_HASH, 0, X11_HASH);
+
+	/* AltGr, which a German keyboard cannot manage without, and which reached
+	   nothing at all before: right Alt was reported as left Alt. */
+	win("AltGr", 0x38, 1, X11_RIGHTALT);
+	check("AltGr is not left Alt",
+	    keymap_x11_from_windows_scancode(0x38, 1) !=
+	    keymap_x11_from_windows_scancode(WSC_LEFTALT, 0));
+	check("AltGr reaches the guest", ps2_of(X11_RIGHTALT) != 0);
+
+	mac("Y position", MVK_Y, X11_Y);
+	mac("Z position", MVK_Z, X11_Z);
+	mac("ISO extra key", MVK_ISO_SECTION, X11_BACKSLASH);
+	mac("right Option is AltGr", MVK_RIGHTOPTION, X11_RIGHTALT);
+}
+
+/*
+ * Issues #91 and #70. Keys that differ only by which side of the keyboard they
+ * are on had been collapsed onto one another.
+ */
+static void
+test_left_and_right_are_distinct(void)
+{
+	puts("Issues #91 and #70 - left and right are not the same key:");
+
+	win("left shift", WSC_LEFTSHIFT, 0, X11_LEFTSHIFT);
+	win("right shift", WSC_RIGHTSHIFT, 0, X11_RIGHTSHIFT);
+	check("windows shifts differ",
+	    keymap_x11_from_windows_scancode(WSC_LEFTSHIFT, 0) !=
+	    keymap_x11_from_windows_scancode(WSC_RIGHTSHIFT, 0));
+	check("the guest sees two different shifts",
+	    ps2_of(X11_LEFTSHIFT) == PS2_LEFTSHIFT &&
+	    ps2_of(X11_RIGHTSHIFT) == PS2_RIGHTSHIFT);
+
+	win("left ctrl", WSC_LEFTCTRL, 0, X11_LEFTCTRL);
+	win("right ctrl", 0x1d, 1, X11_RIGHTCTRL);
+	check("windows ctrls differ",
+	    keymap_x11_from_windows_scancode(WSC_LEFTCTRL, 0) !=
+	    keymap_x11_from_windows_scancode(0x1d, 1));
+
+	mac("left shift", MVK_SHIFT, X11_LEFTSHIFT);
+	mac("right shift", MVK_RIGHTSHIFT, X11_RIGHTSHIFT);
+	mac("left control", MVK_CONTROL, X11_LEFTCTRL);
+	mac("right control", MVK_RIGHTCONTROL, X11_RIGHTCTRL);
+
+	/* The heart of issue #91: wxWidgets reports Command as WXK_CONTROL, so at
+	   the character level Command and Control are one key and neither can be
+	   spared for the third mouse button. By position they are four keys. */
+	mac("left command", MVK_COMMAND, X11_LEFTWIN);
+	mac("right command", MVK_RIGHTCOMMAND, X11_RIGHTWIN);
+	check("command is distinguishable from control",
+	    keymap_x11_from_macos_keycode(MVK_COMMAND) !=
+	    keymap_x11_from_macos_keycode(MVK_CONTROL));
+	check("the two commands are distinguishable from each other",
+	    keymap_x11_from_macos_keycode(MVK_COMMAND) !=
+	    keymap_x11_from_macos_keycode(MVK_RIGHTCOMMAND));
+	/* input_helpers.cpp turns right Command into this. If the menu key stopped
+	   reaching the guest, the third mouse button would go with it. */
+	check("the menu key the third mouse button needs is deliverable",
+	    ps2_of(X11_MENU) != 0);
+}
+
+/*
+ * Known answers, end to end. Deliberately spelled out per platform rather than
+ * generated, so that a table edited wrongly on one platform cannot be excused by
+ * a matching edit to the other.
+ */
+static void
+test_known_answers(void)
+{
+	puts("Known answers, position to PS/2:");
+
+	win("escape", WSC_ESCAPE, 0, X11_ESCAPE);
+	win("1", WSC_1, 0, X11_1);
+	win("minus", WSC_MINUS, 0, X11_MINUS);
+	win("backspace", WSC_BACKSPACE, 0, X11_BACKSPACE);
+	win("tab", WSC_TAB, 0, X11_TAB);
+	win("Q", WSC_Q, 0, X11_Q);
+	win("return", WSC_RETURN, 0, X11_RETURN);
+	win("A", WSC_A, 0, X11_A);
+	win("slash", WSC_SLASH, 0, X11_SLASH);
+	win("space", WSC_SPACE, 0, X11_SPACE);
+	win("caps lock", WSC_CAPSLOCK, 0, X11_CAPSLOCK);
+	win("F1", WSC_F1, 0, X11_F1);
+	win("F11", WSC_F11, 0, X11_F11);
+	win("F12", WSC_F12, 0, X11_F12);
+	win("num lock", WSC_NUMLOCK, 0, X11_NUMLOCK);
+	win("keypad 7", WSC_KP_7, 0, X11_KP_7);
+	win("keypad enter", 0x1c, 1, X11_KP_ENTER);
+	win("keypad divide", 0x35, 1, X11_KP_DIVIDE);
+	win("up arrow", 0x48, 1, X11_UP);
+	win("left arrow", 0x4b, 1, X11_LEFT);
+	win("delete", 0x53, 1, X11_DELETE);
+	win("menu", 0x5d, 1, X11_MENU);
+
+	mac("A", MVK_A, X11_A);
+	mac("Q", MVK_Q, X11_Q);
+	mac("1", MVK_1, X11_1);
+	/* 5 and 6 are the wrong way round in ADB numbering, which is the sort of
+	   thing a hand-written table gets wrong in exactly one direction. */
+	mac("5", MVK_5, 0x0e);
+	mac("6", MVK_6, 0x0f);
+	mac("return", MVK_RETURN, X11_RETURN);
+	mac("tab", MVK_TAB, X11_TAB);
+	mac("space", MVK_SPACE, X11_SPACE);
+	mac("backspace", MVK_BACKSPACE, X11_BACKSPACE);
+	mac("escape", MVK_ESCAPE, X11_ESCAPE);
+	mac("caps lock", MVK_CAPSLOCK, X11_CAPSLOCK);
+	mac("left option is left alt", MVK_OPTION, X11_LEFTALT);
+	mac("F1", MVK_F1, X11_F1);
+	mac("left arrow", MVK_LEFTARROW, X11_LEFT);
+	mac("up arrow", MVK_UPARROW, X11_UP);
+
+	/* Both platforms must agree about where a key is, since both feed the same
+	   guest. A test per platform would let the two drift apart. */
+	check("windows and macos agree on A",
+	    keymap_x11_from_windows_scancode(WSC_A, 0) ==
+	    keymap_x11_from_macos_keycode(MVK_A));
+	check("windows and macos agree on Q",
+	    keymap_x11_from_windows_scancode(WSC_Q, 0) ==
+	    keymap_x11_from_macos_keycode(MVK_Q));
+	check("windows and macos agree on Y",
+	    keymap_x11_from_windows_scancode(WSC_Y, 0) ==
+	    keymap_x11_from_macos_keycode(MVK_Y));
+	check("A reaches PS/2 0x1c from both",
+	    ps2_of(keymap_x11_from_windows_scancode(WSC_A, 0)) == PS2_A &&
+	    ps2_of(keymap_x11_from_macos_keycode(MVK_A)) == PS2_A);
+	check("Q reaches PS/2 0x15 from both",
+	    ps2_of(keymap_x11_from_windows_scancode(WSC_Q, 0)) == PS2_Q &&
+	    ps2_of(keymap_x11_from_macos_keycode(MVK_Q)) == PS2_Q);
+}
+
+/*
+ * Keys with no RISC OS equivalent, and inputs that are simply not keys. These
+ * must answer zero rather than something plausible: the caller reads zero as
+ * "let the character fallback try", and a wrong non-zero answer would press a
+ * key nobody touched.
+ */
+static void
+test_refusals(void)
+{
+	puts("Positions with no RISC OS equivalent refuse to guess:");
+
+	win("scancode 0 is not a key", 0, 0, 0);
+	win("SysReq", WSC_SYSREQ, 0, 0);
+	win("unassigned", WSC_UNASSIGNED, 0, 0);
+	win("past the end of the block", KEYMAP_WINDOWS_SCANCODE_MAX + 1, 0, 0);
+	win("0xff", 0xff, 0, 0);
+	/* An unprefixed scancode is not an E0 one: 0x1e is A, but E0 1E is nothing. */
+	win("A is not an extended key", WSC_A, 1, 0);
+
+	mac("fn has no PC equivalent", MVK_FUNCTION, 0);
+	mac("keypad equals has no PC equivalent", MVK_KEYPAD_EQUALS, 0);
+	mac("0xff", 0xff, 0);
+}
+
+/*
+ * Unpacking the Windows message parameter. Worth its own cases because the
+ * failure mode is silent: a shift that is off by four still produces a
+ * scancode, just the wrong one, and the result is a key that does something
+ * unrelated rather than an obvious crash.
+ *
+ * The lParam values are built the way Windows builds them - repeat count in the
+ * low half, scancode at bit 16, extended at bit 24, and the transition and
+ * previous-state bits set as they would be on a real release - so the masking
+ * has to ignore everything it should ignore.
+ */
+static void
+test_windows_lparam(void)
+{
+	puts("Unpacking the Windows WM_KEY* lParam:");
+
+	/* A press of A: repeat count 1, scancode 0x1e, nothing else set. */
+	check("plain press of A",
+	    keymap_x11_from_windows_lparam(0x001e0001u) == X11_A);
+
+	/* The same key released: bits 30 and 31 set. Must not change the answer. */
+	check("release of A ignores the transition bits",
+	    keymap_x11_from_windows_lparam(0xc01e0001u) == X11_A);
+
+	/* Held down: a large repeat count in the low half must be masked off. */
+	check("autorepeat count is ignored",
+	    keymap_x11_from_windows_lparam(0x001effffu) == X11_A);
+
+	/* Right Ctrl: same scancode as left Ctrl, extended bit set. This pair is
+	   the reason the flag cannot be ignored. */
+	check("left ctrl without the extended bit",
+	    keymap_x11_from_windows_lparam(0x001d0001u) == X11_LEFTCTRL);
+	check("right ctrl with the extended bit",
+	    keymap_x11_from_windows_lparam(0x011d0001u) == X11_RIGHTCTRL);
+
+	/* AltGr, the key issue #88 needs and the reason bit 24 is read at all. */
+	check("AltGr with the extended bit",
+	    keymap_x11_from_windows_lparam(0x01380001u) == X11_RIGHTALT);
+	check("left alt without it",
+	    keymap_x11_from_windows_lparam(0x00380001u) == X11_LEFTALT);
+
+	/* The context-code bit (29) is set whenever Alt is held, so it rides along
+	   with every AltGr combination and must not disturb the lookup. */
+	check("the Alt context bit is ignored",
+	    keymap_x11_from_windows_lparam(0x21380001u) == X11_RIGHTALT);
+
+	/* Bits above the extended flag must not leak into the scancode. Note 0xff
+	   in the top byte would ALSO set bit 24 and legitimately give 0, so the
+	   reserved and state bits are set here without it - which is the only way
+	   this case tests the masking rather than the extended flag again. */
+	check("bits above the extended flag are ignored",
+	    keymap_x11_from_windows_lparam(0xfe1e0001u) == X11_A);
+	check("setting bit 24 does change the answer",
+	    keymap_x11_from_windows_lparam(0x011e0001u) == 0);
+	check("an empty lparam is not a key",
+	    keymap_x11_from_windows_lparam(0) == 0);
+}
+
+int
+main(void)
+{
+	test_no_dead_ends();
+	test_no_collisions();
+	test_layout_independence();
+	test_left_and_right_are_distinct();
+	test_known_answers();
+	test_windows_lparam();
+	test_refusals();
+
+	if (failures != 0) {
+		printf("\n%d check%s failed\n", failures, failures == 1 ? "" : "s");
+		return EXIT_FAILURE;
+	}
+	puts("\nall keymap checks passed");
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Three open issues, one cause. Each commit builds and passes the suite on its own, so this bisects.

## The cause

RISC OS applies its own keyboard layout, so RPCEmu has to tell it **which key** was pressed. The currency for that throughout the source is an X11 keycode, a physical position, which `keyboard_map_key()` turns into PS/2 codes.

Under wxGTK we were passing a position. On Windows and macOS we were not: `input_helpers.cpp` took `wxKeyEvent::GetKeyCode()`, which has already been through the host's layout and so names a **character**, and looked it up in a table written for a **UK** keyboard.

## What that produced

**#88, German keyboards.** Umlauts and `ß < > |` completely dead, because nothing in a UK table types those characters, so the lookup returned 0 and the key was skipped. `z` and `y` swapping "the wrong way around" when the RISC OS layout changed, because Windows had already applied German and RISC OS then applied it again. The digit row fine, being in the same place on both layouts. And a UK host layout with a German RISC OS layout working perfectly, which is the system working by accident and the clue that this was never about German in particular.

**#91, the third mouse button on macOS.** wx reports Command as `WXK_CONTROL` and physical Control as `WXK_RAW_CONTROL`, so at the character level Command and Control are one key. @Astro-mh concluded there was no simple fix and no other unique key available. By position they are four distinct keys, so there is one.

**#70, in part.** Left and right Shift, and left and right Ctrl, were both reported to the guest as the left-hand key.

Also found and fixed: **AltGr reached nothing at all, on every platform.** Windows and macOS reported it as left Alt; X11 reported keycode `0x6c`, which `keyboard_x.c` had no entry for, so it was dropped. A German keyboard cannot manage without it.

## The change

Both platforms get a position table in the new `src/gui/keymap_platform.c`. Windows keeps the position in `GetRawKeyFlags()` (the `WM_KEY*` lParam) and macOS in `GetRawKeyCode()` (`[NSEvent keyCode]`) — both confirmed against the wxWidgets source rather than assumed.

For Windows the mapping is arithmetic, not a table: X11 keycode = Set 1 scancode + 8, since Linux derives its evdev keycodes from the same numbering. That removes ninety chances to mistype a number. For macOS a table is unavoidable, so **every literal in it is asserted against Apple's own `kVK_` constant when built on macOS** — a wrong number becomes a build failure there rather than a key that misbehaves on someone else's Mac.

One subtle fix in `main_frame.cpp`: the wx keycode is no longer enough on its own to give up on a key. It used to be, and that was wrong in precisely the wrong place, because a key the host layout puts somewhere wx has no name for reports `WXK_NONE` — so the keys that most needed the position lookup were discarded before reaching it.

The macOS policy for the two keys a RiscPC lacks lives in `input_helpers.cpp`, not in the table, so the table stays one-to-one and can be checked for collisions. **Left Command stays mapped to Ctrl** (deliberate and long-standing, so Cmd+C copies, issue #35) and **right Command becomes the menu key**, which is what gives #91 its third mouse button. Say if you would rather that were right Option.

## Testing

`tests/test_keymap.c`, **99 checks**, `RPCEMU_EXPECTED_TESTS` 16 to 17. The keyboard had no test of any kind before this.

The tables are dependency-free integer lookups, which is the point of them being a separate unit: **the Windows and macOS mappings are both tested from whichever platform the suite runs on**, so a Linux runner covers all three. The cases assert the properties that were actually violated rather than restating the tables — no dead ends (swept exhaustively), no collisions, both tables agreeing with each other, a position meaning the same thing on any layout, left and right staying distinct, and the lParam unpacking ignoring the repeat count and transition bits while honouring bit 24.

The test was checked by breaking the code on purpose: reintroducing the #88 Y/Z swap, deleting the AltGr entry and collapsing right Command onto Control each make it fail. It also caught a wrong expectation of mine while being written, which is recorded in the case as a comment.

**Linux, verified end to end.** Booted a real machine under Xvfb with `RPCEMU_KEYBOARD_DEBUG=1`: every key resolved by position and reached PS/2, AltGr included, and left and right modifiers arrived as different keys.

**Windows**, compiles clean against real wxMSW headers with `-Wall -Wextra`. Runtime behaviour unverified — the cross-build environment here has no libusb, and a cross-compile is a compile check anyway.

**macOS**, unverified. It is the platform with the most behaviour riding on this and it wants a look before this is trusted.

## Diagnosis for the platforms we cannot sit in front of

`RPCEMU_KEYBOARD_DEBUG` in the environment logs every key event: what the host reported, the position we derived, what we will send, and whether the guest can receive it. A `position=0x00` means the tables did not place the key. This is how a reporter can be asked for a log rather than for adjectives, and it pairs with *Help → Save Support Files*.

## What this does NOT fix

**The letter-case behaviour in #70.** With Shift held, the reporter saw the first thirteen letters uppercase and the rest lowercase, fixed by toggling Caps Lock. Upper and lower case letters map to the *same* position, so the mapping provably cannot cause a case error: something is desynchronising the guest's Shift or Caps Lock state. The leading theory (macOS reporting Caps Lock as a toggle, and `NativeKeyPress()` dropping a press for a key already held, so the guest's caps state inverts) is written down in `docs/keyboard.md` as a theory. It needs a Mac. #70 should stay open on that basis even if the modifier half is confirmed fixed.

Also known and documented: Windows sends a phantom left Ctrl alongside AltGr, so the guest sees Ctrl+AltGr. Whether that stops German AltGr characters working is unconfirmed, and the debug log will show it.