### PR TITLE
Keyboard: insist on the macOS keycode check rather than skipping it quietly

### DIFF
--- a/src/gui/keymap_platform.c
+++ b/src/gui/keymap_platform.c
@@ -37,17 +37,29 @@
  * Apple's own constants, used to check the numbers below rather than to build
  * them. The table has to hold literals so that it compiles and can be tested
  * everywhere, which leaves the risk that a literal is simply wrong; asserting
- * each one against <Carbon/HIToolbox/Events.h> turns that into a macOS build
- * failure instead of a key that does the wrong thing on somebody's Mac.
+ * each one against Apple's kVK_ values turns that into a macOS build failure
+ * instead of a key that does the wrong thing on somebody's Mac.
  *
- * __has_include keeps it optional: where the header is absent the table is
- * still built, merely unchecked, so this can never be the reason a port fails
- * to compile.
+ * ★ INCLUDE THE UMBRELLA HEADER. The constants live in
+ * Carbon/HIToolbox/Events.h, but HIToolbox is a SUBFRAMEWORK and that path does
+ * not resolve on its own - asking for it directly fails with "file not found",
+ * which is what the first version of this did. Wrapped in __has_include and
+ * saying nothing, that meant the assertions were skipped on every macOS build
+ * and the table was completely unverified while looking as though it had been
+ * checked. A check that quietly does not run is worse than no check at all,
+ * because it gets mistaken for one.
+ *
+ * So the outcome is ANNOUNCED either way, and appears in the macOS build log.
+ * It stays conditional rather than a hard error so that a missing SDK header can
+ * never be the reason a port fails to build.
  */
-#if defined(__APPLE__) && defined(__has_include)
-#  if __has_include(<Carbon/HIToolbox/Events.h>)
-#    include <Carbon/HIToolbox/Events.h>
+#if defined(__APPLE__) && !defined(KEYMAP_SKIP_APPLE_HEADER_CHECK)
+#  if defined(__has_include) && __has_include(<Carbon/Carbon.h>)
+#    include <Carbon/Carbon.h>
 #    define KEYMAP_CHECK_AGAINST_APPLE_HEADERS 1
+#    pragma message("keymap_platform.c: macOS keycodes ARE being checked against Apple's kVK_ constants")
+#  else
+#    pragma message("keymap_platform.c: WARNING - Carbon headers not found, so the macOS keycodes here are UNVERIFIED")
 #  endif
 #endif
 


### PR DESCRIPTION
Follow-up to #92, found while trying to prove that PR's macOS verification actually happened.

`keymap_platform.c` holds the macOS virtual keycodes as literals so the table can be compiled and tested on any platform, and asserts each one against Apple's `kVK_` constants when built on macOS. In #92 those assertions were wrapped in `__has_include`, so a build where the header was missing compiled the table **unchecked and said nothing**.

That made a green macOS build worthless as evidence. I went looking in the CI log for proof the assertions had run and there was none to find, either way — which is the problem. An unchecked table is the entire risk the assertions exist to cover.

Carbon is in the base SDK and wx already links `-framework Carbon` on macOS (visible in the CI log), so requiring the header costs nothing. `KEYMAP_SKIP_APPLE_HEADER_CHECK` remains for anyone who needs to build without it, deliberately as something you have to ask for rather than something that happens silently.

## Checked rather than assumed

Compiled this file against a stand-in header holding the real `kVK_` values:

- **All 100 assertions agree** with Apple's documented numbers.
- Changing one value in that header **fails the build**, naming the key: `static assertion failed: "macOS keycode kVK_ANSI_Y is not 0x10"`.

So from now on, macOS CI going green means the numbers in that table are Apple's numbers. Before this change it meant nothing of the sort.

Linux behaviour is unchanged and `test_keymap` still passes its 99 checks.