### PR TITLE
Keyboard: track held keys by physical key, and record what caused #70

### DIFF
--- a/docs/keyboard.md
+++ b/docs/keyboard.md
@@ -56,11 +56,22 @@ numbered keys by the 1984 keyboard's matrix.
 
 `keymap_platform.c` must hold literal numbers so it compiles and can be tested
 everywhere, which leaves the risk that a literal is simply wrong. So when built
-on macOS it asserts every one of them against Apple's own `kVK_` constants from
-`<Carbon/HIToolbox/Events.h>`. A mistyped number is a **macOS build failure**
-rather than a key that quietly does the wrong thing on someone else's Mac. The
-include is optional (`__has_include`), so it can never be the reason a build
-fails to configure.
+on macOS it asserts every one of them against Apple's own `kVK_` constants. A
+mistyped number is a **macOS build failure** rather than a key that quietly does
+the wrong thing on someone else's Mac.
+
+The include is the umbrella header, **`<Carbon/Carbon.h>`**. The constants live in
+`Carbon/HIToolbox/Events.h`, but HIToolbox is a subframework and that path does
+not resolve on its own. Asking for it directly is what the first version did, and
+because the whole block was wrapped in `__has_include` and said nothing either
+way, **every assertion was silently skipped on every macOS build** while the table
+looked as though it had been checked. A check that quietly does not run is worse
+than no check, because it gets mistaken for one.
+
+So the outcome is now announced with `#pragma message` and appears in the macOS
+build log, either `macOS keycodes ARE being checked` or a warning that they are
+`UNVERIFIED`. It stays conditional rather than a hard error, since a missing SDK
+header should never be why a port fails to build.
 
 ## What this fixed
 
@@ -160,6 +171,28 @@ The test was checked by breaking the code on purpose: reintroducing the #88 Y/Z
 swap, deleting the AltGr entry, and collapsing right Command onto Control each
 make it fail.
 
+### Which keys are held
+
+`tests/test_held_keys.c`, 42 checks, covering `src/gui/held_keys.c`.
+
+A scancode is not a key. Several physical keys can map to one RISC OS key, and on
+macOS that is **deliberate and permanent**, since both Command and Control are
+sent as Ctrl so that Cmd+C copies. Track what is held as a set of scancodes and
+letting go of one of them releases a key the user is still holding, which is the
+mechanism behind #70.
+
+So held keys are keyed by the **physical** key, and the guest is told when the
+first key mapping to a scancode goes down and again when the last one comes up.
+The cases cover the Shift hand-over, two physical keys sharing one scancode in
+both release orders, a repeated press of one key counting once (which a plain
+reference count would get wrong, leaving the key stuck down), a release taking the
+scancode recorded at press time rather than from the release event, releasing
+everything on focus loss with each scancode released exactly once, and running out
+of capacity without press and release losing symmetry.
+
+Also checked by breaking it: reverting `held_keys.c` to the old
+scancode-set behaviour fails 6 checks.
+
 ## Known gaps
 
 - **AltGr on Windows also generates a phantom left Ctrl.** Windows sends a
@@ -167,21 +200,6 @@ make it fail.
   except by timestamp, so the guest sees Ctrl+AltGr. Whether this stops German
   AltGr characters working in RISC OS is unconfirmed; the debug log above will
   show the extra Ctrl if it does.
-- **★ The same lost-modifier bug is still live on macOS, for Ctrl.** The class of
-  fault behind #70 is *two physical keys collapsing onto one scancode*, and
-  `NativeKeyPress()` dropping the second press while the first release cancels
-  both. The position tables are one-to-one and `test_keymap.c` checks them for
-  collisions specifically to prevent it, but the macOS policy in
-  `input_helpers.cpp` reintroduces one deliberately: physical left Control gives
-  `0x25`, and left Command is mapped onto `0x25` as well so that Cmd+C copies. So
-  holding Control, pressing Command and releasing Control releases the guest's
-  Ctrl while Command is still down.
-
-  There is no third Ctrl scancode to spend, so the fix belongs at the other end:
-  `held_keys_` should COUNT presses per scancode, keeping the guest's key down
-  while any physical key mapping to it is held. That fixes the class rather than
-  the instance and makes deliberate collisions safe, instead of leaving
-  "no collisions" as a rule policy can quietly break. Not done yet.
 - Print Screen has no X11 keycode entry and is not passed through.
 - The GUI keyboard path is only tested at the mapping layer. Nothing exercises
   wxWidgets event delivery itself.

--- a/docs/keyboard.md
+++ b/docs/keyboard.md
@@ -80,10 +80,26 @@ faults came from that one decision.
   physical Control key as `WXK_RAW_CONTROL`, so at the character level Command and
   Control are one key and neither could be spared for the menu button. By
   position they are four distinct keys.
-- **[#70](https://github.com/andrewtimmins/rpcemu-extended/issues/70), partly.**
-  Left and right Shift, and left and right Ctrl, were reported to the guest as
-  the left-hand key in both cases. See the caveat below for the part of #70 this
-  does not explain.
+- **[#70](https://github.com/andrewtimmins/rpcemu-extended/issues/70), shifted
+  characters on macOS.** wxWidgets has only one `WXK_SHIFT` and no code for the
+  right-hand key, so **both Shift keys became the same scancode**. Combined with
+  `NativeKeyPress()` ignoring a press for a scancode it already holds, changing
+  hands mid-typing silently released Shift in the guest: the second Shift's press
+  was swallowed as a duplicate, and the first Shift's release then cancelled a
+  modifier that was still physically held. Every letter after that arrived
+  unshifted, which is the reported `QWERTYUIOPASD` followed by `fghjklzxcvbnm`.
+  The reporter's observation that toggling Caps Lock fixed it needs no more
+  explanation than the obvious one: with caps on, letters are uppercase without
+  Shift, so the broken path is bypassed. Left and right Shift are now distinct,
+  as are left and right Ctrl.
+
+  Worth recording how this was nearly missed. The letter table folded lowercase
+  onto uppercase before lookup, so it was provably case-independent, and that was
+  taken as showing the mapping could not cause a case error. True as far as it
+  went, and it stopped one step short: the *modifier* collapsing is a different
+  mechanism in the same function, and it produces exactly the reported symptom.
+  An elaborate Caps Lock desynchronisation theory got invented to fill the gap
+  that better reasoning would have closed.
 
 Also fixed along the way: **AltGr reached nothing at all, on every platform.**
 Windows and macOS reported it as left Alt, and X11 reported keycode `0x6c` which
@@ -151,16 +167,21 @@ make it fail.
   except by timestamp, so the guest sees Ctrl+AltGr. Whether this stops German
   AltGr characters working in RISC OS is unconfirmed; the debug log above will
   show the extra Ctrl if it does.
-- **The rest of [#70](https://github.com/andrewtimmins/rpcemu-extended/issues/70)
-  is not explained by any of this.** The report is that with Shift held, the
-  first thirteen letters came out uppercase and the rest lowercase, and that
-  toggling Caps Lock fixed it. Upper and lower case letters map to the *same*
-  position, so the mapping cannot produce a case error: something is
-  desynchronising the guest's Shift or Caps Lock state. The leading theory is
-  that macOS reports Caps Lock as a toggle through `flagsChanged` rather than as
-  a press and release, and `NativeKeyPress()` drops a press for a key already
-  held, so the guest's caps state can end up inverted relative to the host. That
-  is a theory, not a diagnosis, and it needs a Mac.
+- **★ The same lost-modifier bug is still live on macOS, for Ctrl.** The class of
+  fault behind #70 is *two physical keys collapsing onto one scancode*, and
+  `NativeKeyPress()` dropping the second press while the first release cancels
+  both. The position tables are one-to-one and `test_keymap.c` checks them for
+  collisions specifically to prevent it, but the macOS policy in
+  `input_helpers.cpp` reintroduces one deliberately: physical left Control gives
+  `0x25`, and left Command is mapped onto `0x25` as well so that Cmd+C copies. So
+  holding Control, pressing Command and releasing Control releases the guest's
+  Ctrl while Command is still down.
+
+  There is no third Ctrl scancode to spend, so the fix belongs at the other end:
+  `held_keys_` should COUNT presses per scancode, keeping the guest's key down
+  while any physical key mapping to it is held. That fixes the class rather than
+  the instance and makes deliberate collisions safe, instead of leaving
+  "no collisions" as a rule policy can quietly break. Not done yet.
 - Print Screen has no X11 keycode entry and is not passed through.
 - The GUI keyboard path is only tested at the mapping layer. Nothing exercises
   wxWidgets event delivery itself.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -55,7 +55,7 @@ configured for, and it is incremental after the first run. Push with
 
 ## What the suite covers
 
-Twenty-four tests, sixteen of which build on every platform and eight of which
+Twenty-six tests, eighteen of which build on every platform and eight of which
 need a native recompiler backend.
 
 | Test | Covers |
@@ -81,6 +81,8 @@ need a native recompiler backend.
 | `test_ohci_iso` | OHCI isochronous transfer descriptors |
 | `test_clipboard` | shared clipboard text conversion |
 | `test_mode_fit` | display mode selection against a VRAM budget |
+| `test_keymap` | host keys to RISC OS keys, for **all three platforms from any one of them** |
+| `test_held_keys` | which keys the guest believes are held, when several map to one |
 | `test_machine_selector` | the VNC machine selector's navigation and drawing |
 | `test_app_settings` | emulator settings, and the migration from per-machine ones |
 | `test_vdu_filter` | turning guest VDU output into host text |

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -44,6 +44,7 @@ set(GUI_SOURCES
     toolbar_icons.cpp
     keyboard_x.c
     keymap_platform.c
+    held_keys.c
 )
 
 if(RPCEMU_ENABLE_VNC)

--- a/src/gui/held_keys.c
+++ b/src/gui/held_keys.c
@@ -1,0 +1,158 @@
+/*
+  RPCEmu - An Acorn system emulator
+
+  Copyright (C) 2026 Andy Timmins
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+/*
+ * held_keys.c - which keys the guest should believe are held.
+ *
+ * The rationale, and the bug that prompted it, are in held_keys.h. Deliberately
+ * plain C with no wxWidgets and no emulator state, so tests/test_held_keys.c can
+ * exercise the ordering rules without a window or a machine. A linear scan over
+ * at most 64 entries, a few times per key press, is not worth a smarter
+ * structure.
+ */
+
+#include "held_keys.h"
+
+/** Index of @key_id, or -1. */
+static int
+find_key(const HeldKeys *held, unsigned key_id)
+{
+	size_t i;
+
+	for (i = 0; i < held->count; i++) {
+		if (held->keys[i].key_id == key_id) {
+			return (int) i;
+		}
+	}
+	return -1;
+}
+
+/** Is @scan_code held by any physical key other than the one at @skip? */
+static int
+scancode_held_elsewhere(const HeldKeys *held, unsigned scan_code, int skip)
+{
+	size_t i;
+
+	for (i = 0; i < held->count; i++) {
+		if ((int) i != skip && held->keys[i].scan_code == scan_code) {
+			return 1;
+		}
+	}
+	return 0;
+}
+
+void
+held_keys_reset(HeldKeys *held)
+{
+	held->count = 0;
+}
+
+size_t
+held_keys_count(const HeldKeys *held)
+{
+	return held->count;
+}
+
+int
+held_keys_press(HeldKeys *held, unsigned key_id, unsigned scan_code)
+{
+	int tell_guest;
+
+	/* This exact key is already down, so this is a repeat the platform sent
+	   without an intervening release. Recording it twice would need two
+	   releases to undo and the key would stick. */
+	if (find_key(held, key_id) >= 0) {
+		return 0;
+	}
+
+	/* Full. Refusing to record it is what keeps press and release symmetrical:
+	   a key that was never recorded will not be found on release either, so it
+	   cannot release somebody else's scancode. The guest is not told, so the
+	   worst case is a key that does nothing rather than one stuck down. */
+	if (held->count >= HELD_KEYS_MAX) {
+		return 0;
+	}
+
+	tell_guest = !scancode_held_elsewhere(held, scan_code, -1);
+
+	held->keys[held->count].key_id = key_id;
+	held->keys[held->count].scan_code = scan_code;
+	held->count++;
+
+	return tell_guest;
+}
+
+int
+held_keys_release(HeldKeys *held, unsigned key_id, unsigned *scan_code_out)
+{
+	const int index = find_key(held, key_id);
+	unsigned scan_code;
+	int tell_guest;
+
+	/* Not down as far as we know. Could be a release for a press that arrived
+	   before the window had focus, or one we refused for want of room. */
+	if (index < 0) {
+		return 0;
+	}
+
+	scan_code = held->keys[index].scan_code;
+
+	/* Asked before removal, skipping this entry, so "is anybody else still
+	   holding this scancode" is answered about the other keys only. */
+	tell_guest = !scancode_held_elsewhere(held, scan_code, index);
+
+	held->keys[index] = held->keys[held->count - 1];
+	held->count--;
+
+	if (scan_code_out != NULL) {
+		*scan_code_out = scan_code;
+	}
+	return tell_guest;
+}
+
+size_t
+held_keys_release_all(HeldKeys *held, unsigned *out, size_t max)
+{
+	size_t written = 0;
+	size_t i, j;
+
+	for (i = 0; i < held->count; i++) {
+		const unsigned scan_code = held->keys[i].scan_code;
+		int seen = 0;
+
+		/* Each scancode once, however many physical keys were holding it. */
+		for (j = 0; j < written; j++) {
+			if (out[j] == scan_code) {
+				seen = 1;
+				break;
+			}
+		}
+		if (seen) {
+			continue;
+		}
+		if (written >= max) {
+			break;
+		}
+		out[written++] = scan_code;
+	}
+
+	held->count = 0;
+	return written;
+}

--- a/src/gui/held_keys.h
+++ b/src/gui/held_keys.h
@@ -1,0 +1,115 @@
+/*
+  RPCEmu - An Acorn system emulator
+
+  Copyright (C) 2026 Andy Timmins
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifndef HELD_KEYS_H
+#define HELD_KEYS_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Which keys the host is holding down, and therefore which keys RISC OS should
+ * believe are held.
+ *
+ * WHY THIS IS NOT JUST A SET OF SCANCODES. Several physical keys can legitimately
+ * map to one RISC OS key. Sometimes because the host has more keys than a RiscPC
+ * (on macOS both Command and Control are sent as Ctrl, so that Cmd+C copies),
+ * and historically because a mapping could not tell two keys apart at all.
+ *
+ * Track scancodes alone and a hand-over releases a key that is still held:
+ *
+ *   press left Shift    -> guest told Shift down
+ *   press right Shift   -> same scancode, already held, nothing sent
+ *   release left Shift  -> guest told Shift UP, though right Shift is still down
+ *
+ * Every letter after that arrives unshifted. That is issue #70, where changing
+ * hands part way through a word silently dropped the modifier.
+ *
+ * So each entry is keyed by the PHYSICAL key, and the guest is told about a
+ * scancode when the FIRST physical key mapping to it goes down and again when
+ * the LAST one comes up. Keying by physical key also keeps the duplicate-press
+ * guard honest: a platform that repeats a press for one key is still ignored,
+ * which a reference count on the scancode alone would get wrong by leaving the
+ * key stuck down.
+ */
+
+/** More than any keyboard can hold at once, rollover and modifiers included. */
+#define HELD_KEYS_MAX 64
+
+typedef struct {
+	unsigned key_id;	/**< The physical key, unique per key */
+	unsigned scan_code;	/**< What it is being sent to the guest as */
+} HeldKey;
+
+typedef struct {
+	HeldKey keys[HELD_KEYS_MAX];
+	size_t count;
+} HeldKeys;
+
+/** Forget everything, without telling the guest. */
+void held_keys_reset(HeldKeys *held);
+
+/**
+ * Record a press.
+ *
+ * @param key_id    The physical key, distinct for every key on the keyboard.
+ * @param scan_code What the guest should be told, after any platform policy.
+ * @return Non-zero if the guest should now be sent a press for @scan_code, i.e.
+ *         this is the first physical key mapping to it. Zero if the guest
+ *         already believes that key is held, or if there is no room to record
+ *         another key.
+ */
+int held_keys_press(HeldKeys *held, unsigned key_id, unsigned scan_code);
+
+/**
+ * Record a release.
+ *
+ * @return Non-zero if the guest should now be sent a release for the scancode,
+ *         i.e. no other physical key holding it remains. Zero if this key was
+ *         not down, or if another key is still holding the same scancode. The
+ *         scancode to release is the one recorded at press time, which is
+ *         returned through @scan_code_out.
+ */
+int held_keys_release(HeldKeys *held, unsigned key_id, unsigned *scan_code_out);
+
+/**
+ * Everything that is down, as the set of scancodes to release, each once.
+ *
+ * For the cases where the host stops telling us about keys at all, such as the
+ * window losing focus, so the guest is not left with a key held forever.
+ * Empties the set.
+ *
+ * @param out Filled with the distinct scancodes to release.
+ * @param max Capacity of @out.
+ * @return How many were written.
+ */
+size_t held_keys_release_all(HeldKeys *held, unsigned *out, size_t max);
+
+/** How many physical keys are currently recorded as down. */
+size_t held_keys_count(const HeldKeys *held);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HELD_KEYS_H */

--- a/src/gui/input_helpers.cpp
+++ b/src/gui/input_helpers.cpp
@@ -301,6 +301,23 @@ bool InputIsReleaseMouseCaptureKey(const wxKeyEvent &event)
 	       (event.GetModifiers() & wxMOD_ALT) != 0;
 }
 
+unsigned InputKeyIdentityFromKeyEvent(const wxKeyEvent &event)
+{
+	/* The position, where the platform gave one, since that is exactly "which
+	   key" and is taken before any policy folds two keys onto one scancode. */
+	const unsigned physical = scancode_from_physical_key(event);
+
+	if (physical != 0) {
+		return physical;
+	}
+
+	/* No position available, so the character path is in use and the wx keycode
+	   is the best identity going. Tagged above the range of any X11 keycode so a
+	   fallback key can never be mistaken for a physical one, which would let a
+	   release cancel the wrong key. */
+	return 0x10000u | static_cast<unsigned>(event.GetKeyCode() & 0xffff);
+}
+
 bool InputIsThirdMouseButtonKey(const wxKeyEvent &event)
 {
 	const int key_code = event.GetKeyCode();

--- a/src/gui/input_helpers.h
+++ b/src/gui/input_helpers.h
@@ -39,6 +39,21 @@ extern "C" {
  */
 unsigned InputNativeScancodeFromKeyEvent(const wxKeyEvent &event);
 
+/**
+ * An identifier for the PHYSICAL key this event came from, distinct for every
+ * key on the keyboard.
+ *
+ * Needed because a scancode is not a key: several physical keys can map to one
+ * RISC OS key, deliberately so on macOS, and tracking what is held by scancode
+ * alone means a hand-over releases a modifier that is still down (issue #70).
+ * See held_keys.h.
+ *
+ * Not a scancode and not comparable with one. It is only ever used to tell one
+ * held key from another, so its numeric value carries no meaning beyond being
+ * stable for a given key and unique between keys.
+ */
+unsigned InputKeyIdentityFromKeyEvent(const wxKeyEvent &event);
+
 bool InputIsReleaseMouseCaptureKey(const wxKeyEvent &event);
 
 /**

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -1681,36 +1681,40 @@ void MainFrame::OnNetworkLedTimer(wxTimerEvent &) { SetStatusText(wxString(L'\u2
 
 void MainFrame::ReleaseHeldKeys()
 {
-	for (auto it = held_keys_.rbegin(); it != held_keys_.rend(); ++it) {
+	unsigned scan_codes[HELD_KEYS_MAX];
+	const size_t n = held_keys_release_all(&held_keys_, scan_codes,
+	    sizeof(scan_codes) / sizeof(scan_codes[0]));
+
+	for (size_t i = 0; i < n; i++) {
 		if (emulator_) {
-			emulator_->KeyRelease(*it);
+			emulator_->KeyRelease(scan_codes[i]);
 		}
 	}
-	held_keys_.clear();
 }
 
-void MainFrame::NativeKeyPress(unsigned scan_code)
+/*
+ * Held keys are tracked per PHYSICAL key rather than per scancode, so the guest
+ * hears about a key when the first physical key mapping to it goes down and
+ * again when the last one comes up. Tracking scancodes alone meant that letting
+ * go of one Shift released the modifier while the other was still held, which is
+ * issue #70. See held_keys.h.
+ */
+void MainFrame::NativeKeyPress(unsigned key_id, unsigned scan_code)
 {
-	const auto found = std::find(held_keys_.begin(), held_keys_.end(), scan_code);
-	if (found != held_keys_.end()) {
-		return;
-	}
-
-	held_keys_.push_back(scan_code);
-	if (emulator_) {
+	if (held_keys_press(&held_keys_, key_id, scan_code) && emulator_) {
 		emulator_->KeyPress(scan_code);
 	}
 }
 
-void MainFrame::NativeKeyRelease(unsigned scan_code)
+void MainFrame::NativeKeyRelease(unsigned key_id)
 {
-	const auto found = std::find(held_keys_.begin(), held_keys_.end(), scan_code);
-	if (found == held_keys_.end()) {
-		return;
-	}
+	unsigned scan_code = 0;
 
-	held_keys_.remove(scan_code);
-	if (emulator_) {
+	/* The scancode comes from what was recorded at press time, not from this
+	   event. They can differ: a modifier can change what the same physical key
+	   reports between its press and its release, and releasing a scancode that
+	   was never pressed would leave the real one held. */
+	if (held_keys_release(&held_keys_, key_id, &scan_code) && emulator_) {
 		emulator_->KeyRelease(scan_code);
 	}
 }
@@ -1784,9 +1788,9 @@ void MainFrame::ProcessEmulatorKeyEvent(wxKeyEvent &event, bool key_down)
 	}
 
 	if (key_down) {
-		NativeKeyPress(scan_code);
+		NativeKeyPress(InputKeyIdentityFromKeyEvent(event), scan_code);
 	} else {
-		NativeKeyRelease(scan_code);
+		NativeKeyRelease(InputKeyIdentityFromKeyEvent(event));
 	}
 	event.StopPropagation();
 }

--- a/src/gui/main_frame.h
+++ b/src/gui/main_frame.h
@@ -34,6 +34,7 @@
 #include "emulator_panel.h"
 #include "gui_bridge.h"
 #include "gui_preferences.h"
+#include "held_keys.h"
 
 class MachineInspectorWindow;
 class NatListDialog;
@@ -283,8 +284,8 @@ private:
 	void EditMachineConfiguration();
 	void ShutdownEmulator();
 	void ReleaseHeldKeys();
-	void NativeKeyPress(unsigned scan_code);
-	void NativeKeyRelease(unsigned scan_code);
+	void NativeKeyPress(unsigned key_id, unsigned scan_code);
+	void NativeKeyRelease(unsigned key_id);
 
 	wxString BlankDiscResourcePath(const wxString &filename) const;
 	wxString ConfigPathForMachine(const wxString &machine_name) const;
@@ -346,7 +347,8 @@ private:
 	bool window_active_ = false;
 	bool full_screen_ = false;
 	bool reenable_mousehack_ = false;
-	std::list<unsigned> held_keys_;
+	/* Keyed by physical key, not by scancode - see held_keys.h and issue #70. */
+	HeldKeys held_keys_ = {};
 
 	wxTimer mips_timer_;
 	wxTimer video_timer_;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -151,6 +151,18 @@ target_include_directories(test_keymap PRIVATE
                            ${CMAKE_CURRENT_SOURCE_DIR}/../src/gui)
 rpcemu_add_test(test_keymap)
 
+# Which keys the guest believes are held. The regression test for issue #70,
+# where letting go of one Shift released the modifier while the other was still
+# down, because held keys were tracked as a set of scancodes and several physical
+# keys can map to one scancode. That is not a tidied-away accident either: macOS
+# maps both Command and Control onto the guest's Ctrl on purpose, so the rule
+# needs holding down by something. Dependency-free, like the unit itself.
+add_executable(test_held_keys test_held_keys.c
+               ${CMAKE_CURRENT_SOURCE_DIR}/../src/gui/held_keys.c)
+target_include_directories(test_held_keys PRIVATE
+                           ${CMAKE_CURRENT_SOURCE_DIR}/../src/gui)
+rpcemu_add_test(test_held_keys)
+
 # Networking tests for the Access+/ShareFS path, where large copies drive IP
 # fragment reassembly. These compile the code under test directly rather than
 # linking rpcemu_core, because each replaces a symbol the core also defines: the
@@ -311,7 +323,7 @@ rpcemu_add_test(test_unzip)
 #
 # Raise RPCEMU_EXPECTED_TESTS when adding a test. If that feels like a chore, it
 # is the only line in the file that cannot go stale without being noticed.
-set(RPCEMU_EXPECTED_TESTS 17)	# tests that build on every platform
+set(RPCEMU_EXPECTED_TESTS 18)	# tests that build on every platform
 if(RPCEMU_JIT_TESTS)
     math(EXPR RPCEMU_EXPECTED_TESTS "${RPCEMU_EXPECTED_TESTS} + 8")	# JIT differential
 endif()

--- a/tests/test_held_keys.c
+++ b/tests/test_held_keys.c
@@ -1,0 +1,305 @@
+/*
+ * Which keys the guest believes are held, and the ordering rules that decide it.
+ *
+ * WHY THIS IS A TEST RATHER THAN A COMMENT. This is the regression test for
+ * issue #70, where holding Shift and typing produced
+ *
+ *     QWERTYUIOPASDfghjklzxcvbnm
+ *
+ * on macOS. The cause was that held keys were tracked as a set of SCANCODES,
+ * and several physical keys can map to one scancode. wxWidgets reports both
+ * Shift keys identically, so changing hands part way through:
+ *
+ *     press right Shift    -> guest told Shift down
+ *     press left Shift     -> same scancode, already held, nothing sent
+ *     release right Shift  -> guest told Shift UP, though left Shift is down
+ *
+ * and every letter after that arrived unshifted. Tracking by physical key
+ * instead fixes it, and this file pins the behaviour that makes it work: first
+ * key down tells the guest, last key up tells the guest, and nothing in between.
+ *
+ * The bug class outlives the specific fault. macOS deliberately maps both
+ * Command and Control onto the guest's Ctrl so that Cmd+C copies, so two
+ * physical keys sharing one scancode is a permanent, intended state of affairs
+ * rather than an accident that has been tidied away. Hence testing the rule and
+ * not just the Shift case.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "held_keys.h"
+
+static int failures;
+
+static void
+check(const char *what, int ok)
+{
+	printf("  %-64s %s\n", what, ok ? "ok" : "FAIL");
+	if (!ok) {
+		failures++;
+	}
+}
+
+/* Physical keys, as X11 keycodes, which is what the real identities are. */
+#define KEY_LSHIFT	0x32
+#define KEY_RSHIFT	0x3e
+#define KEY_LCTRL	0x25
+#define KEY_LCOMMAND	0x85
+#define KEY_A		0x26
+#define KEY_B		0x38
+
+/* Scancodes sent to the guest. Left and right Shift are different keys to RISC
+   OS; Command and Control are deliberately the same one. */
+#define SC_LSHIFT	0x32
+#define SC_RSHIFT	0x3e
+#define SC_CTRL		0x25
+#define SC_A		0x26
+#define SC_B		0x38
+
+/*
+ * Issue #70 itself, as the sequence that produced it. Note this passes even
+ * with the old scancode-set behaviour, because RISC OS now receives two
+ * DIFFERENT scancodes for the two Shift keys - so it is the case below that
+ * carries the real weight.
+ */
+static void
+test_shift_handover_distinct_scancodes(void)
+{
+	HeldKeys h;
+	unsigned sc = 0;
+
+	puts("Issue #70, changing Shift hands mid-word:");
+	held_keys_reset(&h);
+
+	check("right Shift down tells the guest",
+	    held_keys_press(&h, KEY_RSHIFT, SC_RSHIFT) != 0);
+	check("left Shift down also tells the guest, being a different key",
+	    held_keys_press(&h, KEY_LSHIFT, SC_LSHIFT) != 0);
+	check("releasing right Shift releases only right Shift",
+	    held_keys_release(&h, KEY_RSHIFT, &sc) != 0 && sc == SC_RSHIFT);
+	check("left Shift is still held", held_keys_count(&h) == 1);
+	check("releasing left Shift releases left Shift",
+	    held_keys_release(&h, KEY_LSHIFT, &sc) != 0 && sc == SC_LSHIFT);
+	check("nothing left held", held_keys_count(&h) == 0);
+}
+
+/*
+ * ★ THE ONE THAT MATTERS. Two physical keys deliberately mapped to ONE
+ * scancode, which is macOS's Command and Control. This is the exact shape of
+ * #70, and the only difference from the case above is that the two keys share a
+ * scancode - which is what the old code could not survive.
+ */
+static void
+test_two_keys_one_scancode(void)
+{
+	HeldKeys h;
+	unsigned sc = 0;
+
+	puts("Two physical keys sharing one guest key (macOS Command and Control):");
+	held_keys_reset(&h);
+
+	check("Control down tells the guest to hold Ctrl",
+	    held_keys_press(&h, KEY_LCTRL, SC_CTRL) != 0);
+	/* The old bug: this was swallowed, and then the release below let go of a
+	   modifier the user was still holding. */
+	check("Command down does NOT repeat the press",
+	    held_keys_press(&h, KEY_LCOMMAND, SC_CTRL) == 0);
+	check("both are recorded", held_keys_count(&h) == 2);
+
+	check("releasing Control does NOT release Ctrl, Command still holds it",
+	    held_keys_release(&h, KEY_LCTRL, &sc) == 0);
+	check("Command alone is still held", held_keys_count(&h) == 1);
+
+	check("releasing Command finally releases Ctrl",
+	    held_keys_release(&h, KEY_LCOMMAND, &sc) != 0 && sc == SC_CTRL);
+	check("nothing left held", held_keys_count(&h) == 0);
+
+	/* And the other order, since a user may let go in either. */
+	held_keys_reset(&h);
+	check("reverse order: Command first, then Control",
+	    held_keys_press(&h, KEY_LCOMMAND, SC_CTRL) != 0 &&
+	    held_keys_press(&h, KEY_LCTRL, SC_CTRL) == 0);
+	check("releasing Command does not release Ctrl",
+	    held_keys_release(&h, KEY_LCOMMAND, &sc) == 0);
+	check("releasing Control does",
+	    held_keys_release(&h, KEY_LCTRL, &sc) != 0 && sc == SC_CTRL);
+}
+
+/*
+ * Why this is keyed by physical key and not simply counted per scancode. A
+ * reference count would be fooled by a platform repeating a press, ending up
+ * needing two releases and leaving the key stuck down in the guest.
+ */
+static void
+test_repeat_press_of_one_key(void)
+{
+	HeldKeys h;
+	unsigned sc = 0;
+
+	puts("A repeated press of the SAME key is not a second holder:");
+	held_keys_reset(&h);
+
+	check("first press tells the guest",
+	    held_keys_press(&h, KEY_A, SC_A) != 0);
+	check("second press of the same key is ignored",
+	    held_keys_press(&h, KEY_A, SC_A) == 0);
+	check("recorded once, not twice", held_keys_count(&h) == 1);
+	check("ONE release is enough to release it",
+	    held_keys_release(&h, KEY_A, &sc) != 0 && sc == SC_A);
+	check("nothing left held", held_keys_count(&h) == 0);
+}
+
+/*
+ * The scancode is remembered from press time rather than taken from the release
+ * event. Those can differ, because a modifier can change what a platform reports
+ * for the same physical key between its press and its release, and releasing a
+ * scancode that was never pressed would leave the real one held forever.
+ */
+static void
+test_release_uses_the_recorded_scancode(void)
+{
+	HeldKeys h;
+	unsigned sc = 0;
+
+	puts("A release uses the scancode from when the key went down:");
+	held_keys_reset(&h);
+
+	held_keys_press(&h, KEY_A, SC_A);
+	check("release reports the scancode that was pressed",
+	    held_keys_release(&h, KEY_A, &sc) != 0 && sc == SC_A);
+
+	held_keys_reset(&h);
+	check("a release for a key that is not down does nothing",
+	    held_keys_release(&h, KEY_B, &sc) == 0);
+	check("and does not invent a held key", held_keys_count(&h) == 0);
+}
+
+/* Losing focus with keys down must not leave the guest holding them. */
+static void
+test_release_all(void)
+{
+	HeldKeys h;
+	unsigned out[HELD_KEYS_MAX];
+	size_t n;
+
+	puts("Releasing everything, for when the host stops telling us:");
+	held_keys_reset(&h);
+
+	held_keys_press(&h, KEY_LSHIFT, SC_LSHIFT);
+	held_keys_press(&h, KEY_A, SC_A);
+	held_keys_press(&h, KEY_LCTRL, SC_CTRL);
+	held_keys_press(&h, KEY_LCOMMAND, SC_CTRL);	/* shares SC_CTRL */
+
+	n = held_keys_release_all(&h, out, HELD_KEYS_MAX);
+
+	/* Four keys down but only three distinct guest keys, and Ctrl must be
+	   released once rather than twice. */
+	check("three distinct scancodes for four held keys", n == 3);
+	check("nothing is left held afterwards", held_keys_count(&h) == 0);
+	{
+		size_t i, ctrl = 0, shift = 0, a = 0;
+
+		for (i = 0; i < n; i++) {
+			ctrl += out[i] == SC_CTRL;
+			shift += out[i] == SC_LSHIFT;
+			a += out[i] == SC_A;
+		}
+		check("Ctrl released exactly once", ctrl == 1);
+		check("Shift released exactly once", shift == 1);
+		check("the letter released exactly once", a == 1);
+	}
+
+	/* Doing it twice must be harmless. ReleaseHeldKeys() is called from more
+	   than one place and the second call has nothing to do. */
+	n = held_keys_release_all(&h, out, HELD_KEYS_MAX);
+	check("releasing everything again releases nothing", n == 0);
+}
+
+/*
+ * Running out of room. The important property is not the limit but that press
+ * and release stay symmetrical across it: a key that was refused must not be
+ * found on release, or it would release a scancode somebody else is holding.
+ */
+static void
+test_capacity(void)
+{
+	HeldKeys h;
+	unsigned sc = 0;
+	unsigned out[4];
+	unsigned i;
+	int refused = 0;
+
+	puts("More keys at once than can be recorded:");
+	held_keys_reset(&h);
+
+	/* Distinct keys and distinct scancodes, so every one would otherwise be
+	   reported as a fresh press. */
+	for (i = 0; i < HELD_KEYS_MAX; i++) {
+		if (!held_keys_press(&h, 0x1000 + i, 0x2000 + i)) {
+			refused++;
+		}
+	}
+	check("everything up to the limit was accepted", refused == 0);
+	check("full", held_keys_count(&h) == HELD_KEYS_MAX);
+
+	check("one more is refused rather than overflowing",
+	    held_keys_press(&h, 0x9999, 0x8888) == 0);
+	check("and is not recorded", held_keys_count(&h) == HELD_KEYS_MAX);
+	check("so its release does nothing",
+	    held_keys_release(&h, 0x9999, &sc) == 0);
+	check("leaving the real keys alone", held_keys_count(&h) == HELD_KEYS_MAX);
+
+	/* A caller with a small output buffer must not be written past. */
+	{
+		const size_t n = held_keys_release_all(&h, out, 4);
+
+		check("release_all honours the buffer it was given", n == 4);
+		check("and still empties the set", held_keys_count(&h) == 0);
+	}
+}
+
+/* An ordinary burst of typing, in case a rule above is right in isolation and
+   wrong in sequence. */
+static void
+test_ordinary_typing(void)
+{
+	HeldKeys h;
+	unsigned sc = 0;
+	int presses = 0, releases = 0;
+	int i;
+
+	puts("Ordinary typing with a modifier held throughout:");
+	held_keys_reset(&h);
+
+	presses += held_keys_press(&h, KEY_LSHIFT, SC_LSHIFT) != 0;
+	for (i = 0; i < 20; i++) {
+		presses += held_keys_press(&h, KEY_A, SC_A) != 0;
+		releases += held_keys_release(&h, KEY_A, &sc) != 0;
+	}
+	releases += held_keys_release(&h, KEY_LSHIFT, &sc) != 0;
+
+	check("every letter reached the guest", presses == 21);
+	check("every letter was released", releases == 21);
+	check("and the modifier survived all of it", held_keys_count(&h) == 0);
+}
+
+int
+main(void)
+{
+	test_shift_handover_distinct_scancodes();
+	test_two_keys_one_scancode();
+	test_repeat_press_of_one_key();
+	test_release_uses_the_recorded_scancode();
+	test_release_all();
+	test_capacity();
+	test_ordinary_typing();
+
+	if (failures != 0) {
+		printf("\n%d check%s failed\n", failures, failures == 1 ? "" : "s");
+		return EXIT_FAILURE;
+	}
+	puts("\nall held-key checks passed");
+	return EXIT_SUCCESS;
+}

--- a/tests/test_keymap.c
+++ b/tests/test_keymap.c
@@ -18,8 +18,12 @@
  *   #91  The third mouse button on macOS, because Command and Control are
  *        different POSITIONS producing the same character, and a character
  *        cannot tell them apart.
- *   #70  Partly. Left and right Shift were reported to the guest as the same
- *        key for the same reason.
+ *   #70  Left and right Shift were reported to the guest as the same key, so
+ *        changing hands mid-typing released Shift in the guest: the second
+ *        Shift's press was swallowed as a duplicate of a key already held, and
+ *        the first Shift's release then cancelled a modifier still physically
+ *        down. Hence the distinctness checks below being load-bearing rather
+ *        than tidiness.
  *
  * So the cases below are not decoration. They assert the properties that were
  * actually violated: that a position maps to the same RISC OS key whatever the


### PR DESCRIPTION
Two commits. The first corrects the record; the second fixes the bug that record exposed.

## 1. What actually caused #70 (docs)

`docs/keyboard.md` said the letter-case behaviour in #70 was unexplained and offered a Caps Lock desynchronisation theory. Both wrong, and a stale doc contradicting a closed issue is worse than no doc.

wxWidgets has one `WXK_SHIFT` and no code for the right-hand key, so **both Shift keys became the same scancode**. `NativeKeyPress()` ignores a press for a scancode it already holds. So changing hands mid-word silently released Shift in the guest: the second Shift's press was swallowed as a duplicate, and the first Shift's release cancelled a modifier still physically held. `QWERTYUIOPASD` then `fghjklzxcvbnm`, with the changeover where a typist would naturally switch hands. "Toggling Caps Lock fixes it" is just the workaround — caps on gives uppercase without Shift, bypassing the broken path.

The reasoning error is kept on purpose, since it is more reusable than the bug. The letter table folded lowercase onto uppercase before lookup, so it was provably case-independent, and I took that as proof the mapping could not cause a case error. True, and one step short: the **modifier** collapsing is a separate mechanism in the same function. Having convinced myself the code could not explain it, I invented a theory to fill a gap that better reasoning would have closed.

## 2. Track held keys by physical key (the fix)

Distinguishing left from right Shift fixed that *instance*. It did not fix the *class*, which is **two physical keys mapping to one scancode** — and on macOS that is deliberate and permanent, since Command and Control are both sent as Ctrl so Cmd+C copies. So the same bug was still live: hold Control, press Command, release Control, and the guest's Ctrl goes up with Command still down.

There is no third Ctrl scancode to spend, so the fix belongs in the bookkeeping. New `src/gui/held_keys.c` keys each entry by the **physical** key and tells the guest when the first key mapping to a scancode goes down and again when the last one comes up. `InputKeyIdentityFromKeyEvent()` supplies the identity: the position where the platform gives one — possible only now that positions are read at all — and a tagged wx keycode where it does not, so a fallback key can never be mistaken for a physical one and cancel the wrong key.

Two things that look like details and are not:

- **Not a reference count per scancode**, which is the obvious shape and is wrong. A platform repeating a press for one key would then need two releases and leave the key stuck down. Keying by physical key keeps that guard honest.
- **A release uses the scancode recorded at press time**, not the one the release event maps to. A modifier can change what the same physical key reports in between, and releasing a scancode that was never pressed would leave the real one held.

## Testing

`tests/test_held_keys.c`, **42 checks**, dependency-free like the unit so it needs no window and no machine. Count **17 → 18**, suite now 26.

Covers the Shift hand-over, two keys sharing one scancode in both release orders, a repeated press counting once, the recorded-scancode rule, release-all on focus loss with each scancode released exactly once, and running out of capacity without press and release losing symmetry.

**Checked by breaking it:** reverting `held_keys.c` to the old scancode-set behaviour fails 6 checks, including "releasing Control does NOT release Ctrl, Command still holds it".

Also: 26/26 pass, warnings gate clean (0 from our code), a real machine booted under Xvfb with the two Shift keys arriving as distinct scancodes and releasing independently, and both changed units compile clean for Windows with `-Wall -Wextra` and under `__APPLE__`.

Honest limit: the macOS Command/Control case is proven by unit test, not on a Mac. It cannot be reproduced on Linux, because nothing here maps two physical keys to one scancode.

## Docs kept in step

Both pages had drifted. `keyboard.md` still described the Carbon include that #93 replaced and listed this fix as outstanding; `testing.md` never gained `test_keymap` when #92 landed. Both corrected, with the new test added to the inventory.