### PR TITLE
Show progress when a machine is deleted or cloned

### DIFF
--- a/src/gui/config_paths.cpp
+++ b/src/gui/config_paths.cpp
@@ -163,7 +163,8 @@ bool ConfigPathsCreateMachineDirectory(const wxString &machine_name)
  * Subdirectories are walked explicitly rather than asking for a recursive file
  * list, so an empty directory in the source is a directory in the copy.
  */
-static bool CopyTreeInto(const wxString &src, const wxString &dst)
+static bool CopyTreeInto(const wxString &src, const wxString &dst,
+                         const ConfigPathsCopyProgress &progress)
 {
 	const wxChar sep = wxFileName::GetPathSeparator();
 
@@ -183,6 +184,9 @@ static bool CopyTreeInto(const wxString &src, const wxString &dst)
 			if (!wxCopyFile(src + sep + name, dst + sep + name, true)) {
 				return false;
 			}
+			if (progress) {
+				progress(name);
+			}
 			more = dir.GetNext(&name);
 		}
 	}
@@ -194,7 +198,8 @@ static bool CopyTreeInto(const wxString &src, const wxString &dst)
 		}
 		bool more = dir.GetFirst(&name, wxEmptyString, wxDIR_DIRS | wxDIR_HIDDEN);
 		while (more) {
-			if (!CopyTreeInto(src + sep + name, dst + sep + name)) {
+			if (!CopyTreeInto(src + sep + name, dst + sep + name,
+			                  progress)) {
 				return false;
 			}
 			more = dir.GetNext(&name);
@@ -204,12 +209,13 @@ static bool CopyTreeInto(const wxString &src, const wxString &dst)
 	return true;
 }
 
-bool ConfigPathsCopyDirectory(const wxString &src, const wxString &dst)
+bool ConfigPathsCopyDirectory(const wxString &src, const wxString &dst,
+                              const ConfigPathsCopyProgress &progress)
 {
 	if (!wxDirExists(src)) {
 		return false;
 	}
-	return CopyTreeInto(src, dst);
+	return CopyTreeInto(src, dst, progress);
 }
 
 wxString ConfigPathsRenameMachine(const wxString &old_name, const wxString &new_name, const wxString &config_path)

--- a/src/gui/config_paths.h
+++ b/src/gui/config_paths.h
@@ -21,6 +21,7 @@
 #ifndef CONFIG_PATHS_H
 #define CONFIG_PATHS_H
 
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -46,7 +47,15 @@ wxString ConfigPathsSnapshotForConfig(const wxString &config_path);
 wxString ConfigPathsSanitizeName(const wxString &name);
 bool ConfigPathsIsNameUnique(const wxString &name);
 bool ConfigPathsCreateMachineDirectory(const wxString &machine_name);
-bool ConfigPathsCopyDirectory(const wxString &src, const wxString &dst);
+/*
+ * Called as each file is copied, for a caller that wants to say so. A machine's
+ * hard disc is thousands of files, and the window answers nothing while they
+ * are copied. Optional: the callers with no window to update pass nothing.
+ */
+using ConfigPathsCopyProgress = std::function<void(const wxString &file)>;
+
+bool ConfigPathsCopyDirectory(const wxString &src, const wxString &dst,
+                              const ConfigPathsCopyProgress &progress = nullptr);
 wxString ConfigPathsRenameMachine(const wxString &old_name, const wxString &new_name, const wxString &config_path);
 
 // QSettings-style machine configs store keys under [General]; wxFileConfig needs an explicit group.

--- a/src/gui/config_selector_dialog.cpp
+++ b/src/gui/config_selector_dialog.cpp
@@ -32,6 +32,7 @@
 #include <wx/fileconf.h>
 #include <wx/filedlg.h>
 #include <wx/filename.h>
+#include <wx/progdlg.h>
 #include <wx/textdlg.h>
 
 extern "C" {
@@ -455,15 +456,37 @@ void ConfigSelectorDialog::OnDelete(wxCommandEvent &)
 	const wxString machine_dir = ConfigPathsMachinesDir() + wxFileName::GetPathSeparator() + name;
 
 	/*
-	 * wx's own recursive remove, not a shell command. This was
-	 * system("rm -rf '<dir>'"), which had three problems: Windows has no rm, so
-	 * deleting a machine there removed its configuration and silently left every
-	 * byte of its data behind; a machine name is typed by the user and went into
-	 * a shell command inside single quotes, so a name containing one would have
-	 * been able to run whatever followed it; and the result was not looked at, so
-	 * a failure to delete reported success.
+	 * The files go one at a time rather than through a single recursive
+	 * remove, because a machine's hard disc is thousands of them and Rmdir()
+	 * offers nothing to report progress with: the window simply stopped
+	 * answering until it finished. What is left afterwards is empty
+	 * directories, which the recursive remove clears in one quick pass.
+	 *
+	 * wx rather than a shell command throughout: Windows has no rm, and the
+	 * name is the user's to type.
 	 */
 	if (wxFileName::DirExists(machine_dir)) {
+		wxArrayString files;
+
+		wxDir::GetAllFiles(machine_dir, &files);
+
+		{
+			wxProgressDialog progress("Delete Machine",
+			    wxString::Format("Deleting '%s'...", name),
+			    static_cast<int>(files.GetCount()), this,
+			    wxPD_APP_MODAL | wxPD_AUTO_HIDE | wxPD_ELAPSED_TIME);
+
+			for (size_t i = 0; i < files.GetCount(); i++) {
+				wxRemoveFile(files[i]);
+				/* Every so often rather than every file: the update costs
+				   more than the unlink, and a bar moving in steps of one is
+				   no more informative. */
+				if ((i & 0x1f) == 0) {
+					progress.Update(static_cast<int>(i));
+				}
+			}
+		}
+
 		if (!wxFileName::Rmdir(machine_dir, wxPATH_RMDIR_RECURSIVE)) {
 			wxMessageBox(wxString::Format(
 			                 "'%s' has been removed from the list, but its data "
@@ -507,12 +530,25 @@ void ConfigSelectorDialog::OnClone(wxCommandEvent &)
 
 	const wxString src_machine = ConfigPathsMachinesDir() + wxFileName::GetPathSeparator() + source_name;
 	const wxString dst_machine = ConfigPathsMachinesDir() + wxFileName::GetPathSeparator() + sanitized;
-	/* Copy the machine's own files (CMOS, HostFS, hard discs). This used to shell
-	   out to "cp -a", which does not exist on Windows: the clone was listed but
-	   its directory was never created, and nothing said so. */
+	/* The machine's own files: CMOS, HostFS, hard discs. wx rather than a shell
+	   command, which is what Windows has none of.
+
+	   Pulsed rather than counted: the copy walks the tree as it goes, and
+	   counting it first would mean walking the whole thing twice to tell
+	   somebody a number they are not waiting on. */
 	bool copied;
 	if (wxDirExists(src_machine)) {
-		copied = ConfigPathsCopyDirectory(src_machine, dst_machine);
+		wxProgressDialog progress("Clone Machine",
+		    wxString::Format("Copying '%s'...", source_name), 100, this,
+		    wxPD_APP_MODAL | wxPD_AUTO_HIDE | wxPD_ELAPSED_TIME);
+		int seen = 0;
+
+		copied = ConfigPathsCopyDirectory(src_machine, dst_machine,
+		    [&progress, &seen](const wxString &) {
+			    if ((++seen & 0x1f) == 0) {
+				    progress.Pulse();
+			    }
+		    });
 	} else {
 		copied = ConfigPathsCreateMachineDirectory(sanitized);
 	}


### PR DESCRIPTION
Deleting or cloning a machine froze the selector until it finished, with nothing on screen to say whether it was working or had hung. Both act on the machine's whole directory, which is thousands of files once RISC OS and some software are installed.

| | |
| --- | --- |
| `1a94265` | an optional per-file callback on `ConfigPathsCopyDirectory()` |
| `fd944e9` | the two dialogues in the selector |

## Delete gets a percentage

`Rmdir(wxPATH_RMDIR_RECURSIVE)` offers nothing to report progress with, so the files are removed one at a time and the empty directories left behind go in one quick recursive pass afterwards. The count is free: `GetAllFiles()` has to walk the tree either way.

## Clone pulses

The copy walks the tree as it goes, so a percentage would mean walking the whole thing twice to tell somebody a number they are not waiting on. `Pulse()` says "still working" for nothing.

## Neither can be cancelled

Deliberately. Stopping half way leaves a machine that is neither deleted nor whole, which is worse than waiting.

## Testing

Linux. Delete and clone exercised against a real 1,834-file machine: every file removed and all 475 directories swept, and the clone callback fired exactly 1,834 times with all files and directories present afterwards. The `nullptr` form was checked too, since three callers rely on it. Builds clean with no warnings from this project's own code, 29/29 tests, and both commits build on their own.

Updates are throttled to every 32 files: a `wxRemoveFile` is faster than a dialogue repaint, so updating per file would have made both operations slower than they were.
