### PR TITLE
HostFS folder from Settings, warn on an empty folder, and stop overrides being saved

### DIFF
--- a/src/app_settings.c
+++ b/src/app_settings.c
@@ -320,6 +320,25 @@ app_settings_relay_enabled(void)
 	return overrides.have_relay ? overrides.relay_enabled : 1;
 }
 
+int
+app_settings_is_overridden(AppSettingId which)
+{
+	switch (which) {
+	case APP_SETTING_VNC_PORT:		return overrides.have_vnc_port;
+	case APP_SETTING_VNC_ENABLED:		return overrides.have_vnc_enabled;
+	case APP_SETTING_HOSTCMD_SOCKET:	return overrides.have_hostcmd_socket;
+	case APP_SETTING_DEBUG_SOCKET:		return overrides.have_debug_socket;
+	case APP_SETTING_COUNT:			break;
+	}
+	return 0;
+}
+
+void
+app_settings_clear_overrides(void)
+{
+	memset(&overrides, 0, sizeof(overrides));
+}
+
 void
 app_settings_apply_overrides(Config *cfg)
 {

--- a/src/app_settings.h
+++ b/src/app_settings.h
@@ -123,6 +123,35 @@ extern void app_settings_apply_overrides(Config *cfg);
 /** Has the relay been turned off for this instance? */
 extern int app_settings_relay_enabled(void);
 
+/*
+ * Which settings a command-line option is overriding for this run.
+ *
+ * ★ WHY THIS HAS TO BE ASKED. An override is applied to the live Config so that
+ * everything downstream sees it, and config_save() then writes the Config out -
+ * so a per-run option was being baked into the machine's configuration file as
+ * though the user had chosen it. A --debug-socket used once left an absolute path
+ * behind that broke as soon as the data folder moved, and --vnc-port, --no-vnc
+ * and --hostcmd-socket did the same to their settings. This is exactly why
+ * --datadir is not remembered either: an option supplied afresh every run must
+ * not become a permanent preference.
+ *
+ * config_save() asks about each of these and leaves the file's own value alone
+ * where an override is in force.
+ */
+typedef enum {
+	APP_SETTING_VNC_PORT,
+	APP_SETTING_VNC_ENABLED,
+	APP_SETTING_HOSTCMD_SOCKET,
+	APP_SETTING_DEBUG_SOCKET,
+	APP_SETTING_COUNT
+} AppSettingId;
+
+/** Non-zero if a command-line option is overriding @which for this run. */
+extern int app_settings_is_overridden(AppSettingId which);
+
+/** Forget every override. For tests; nothing in the emulator needs it. */
+extern void app_settings_clear_overrides(void);
+
 /** Path of the settings file, for messages. Returns a pointer to a static buffer. */
 extern const char *app_settings_path(const char *datadir);
 

--- a/src/debugcmd.c
+++ b/src/debugcmd.c
@@ -38,6 +38,7 @@
 
 #include "socket-compat.h"
 #ifndef _WIN32
+#include <sys/stat.h>
 #include <sys/un.h>
 #endif
 
@@ -856,6 +857,37 @@ dc_set_nonblock(int fd)
 }
 
 #ifndef _WIN32
+/*
+ * Does the directory that would hold @path exist?
+ *
+ * bind() on a Unix socket needs its parent directory to be there, and answers a
+ * missing one with ENOENT - which reads as "the socket is missing" rather than
+ * "the folder is". Checked separately so the caller can say which.
+ */
+static int
+dc_parent_dir_exists(const char *path)
+{
+	char dir[512];
+	char *slash;
+	struct stat st;
+
+	if (snprintf(dir, sizeof(dir), "%s", path) < 0 ||
+	    strlen(path) >= sizeof(dir)) {
+		return 0;
+	}
+
+	slash = strrchr(dir, '/');
+	if (slash == NULL) {
+		return 1;	/* A bare name, so the current directory. */
+	}
+	if (slash == dir) {
+		return 1;	/* Directly in the root. */
+	}
+	*slash = '\0';
+
+	return stat(dir, &st) == 0 && S_ISDIR(st.st_mode);
+}
+
 static int
 dc_listen_unix(const char *path)
 {
@@ -972,6 +1004,28 @@ debugcmd_init(void)
 		if (config.debug_socket[0] == '/') {
 			strncpy(path, config.debug_socket, sizeof(path) - 1);
 			path[sizeof(path) - 1] = '\0';
+
+			/*
+			 * ★ Fall back to the default when the directory it names has
+			 * gone, rather than failing to bind and losing the debug
+			 * socket for the run.
+			 *
+			 * This heals configurations that already carry a stale
+			 * absolute path. Until now, one run with --debug-socket wrote
+			 * that path into the machine's configuration file, so moving
+			 * a data folder left it pointing at a directory that no
+			 * longer existed and every later run reported
+			 * "bind(...) failed: No such file or directory". The write is
+			 * fixed in settings.cpp, but existing files still hold the
+			 * bad value, and rewriting somebody's configuration on a
+			 * guess about what they meant is worse than quietly working.
+			 */
+			if (!dc_parent_dir_exists(path)) {
+				rpclog("DebugCmd: '%s' is not there any more, using the "
+				       "default socket instead\n", path);
+				snprintf(path, sizeof(path), "%srpcemu-debug.sock",
+				    rpcemu_get_datadir());
+			}
 		} else {
 			snprintf(path, sizeof(path), "%srpcemu-debug.sock",
 			    rpcemu_get_datadir());

--- a/src/gui/machine_edit_dialog.cpp
+++ b/src/gui/machine_edit_dialog.cpp
@@ -271,6 +271,24 @@ void MachineEditDialog::UpdateHostfsNote()
 		note = resolved;
 		if (!wxDirExists(resolved)) {
 			note += "  (does not exist yet, it will be created)";
+		} else if (!wxDirExists(resolved + wxFileName::GetPathSeparator() + "!Boot") &&
+		           !wxFileExists(resolved + wxFileName::GetPathSeparator() + "!Boot")) {
+			/*
+			 * ★ Said because the alternative is baffling. A machine that boots
+			 * from HostFS and finds no !Boot does not report a missing boot
+			 * sequence: RISC OS comes up and drops to the supervisor prompt with
+			 * "Error: Use *Desktop to start TaskManager", which tells you
+			 * nothing about the folder you just chose. Reported by David
+			 * Ramsden, who pointed a machine at a blank folder expecting the old
+			 * "No !Boot found" and got a part-started desktop instead.
+			 *
+			 * Only a warning. An empty folder is perfectly reasonable if this
+			 * machine does not boot from HostFS, or if you are about to put
+			 * something in it.
+			 */
+			note += "\nThere is no !Boot here. If this machine boots from "
+			        "HostFS it will stop at the supervisor prompt rather than "
+			        "reaching the desktop.";
 		}
 
 		const wxString other = MachineSharingHostfs(resolved,
@@ -1670,7 +1688,34 @@ void MachineEditDialog::SaveSettings()
 		network_type = "iptunnelling";
 	}
 
-	settings.Write("hostfs_path", hostfs_edit_->GetValue().Trim().Trim(false));
+	/*
+	 * ★ Written to the LIVE CONFIG as well as to the file, and not only to the
+	 * file, which is what it did at first and was wrong.
+	 *
+	 * Opened from the machine selector nothing else holds a Config, so writing
+	 * the file was enough and it appeared to work. Opened from a running
+	 * machine's Settings > Machine, the emulator is holding a Config that still
+	 * has the OLD value, and the next config_save() writes that back over the
+	 * file - so the setting silently reverted. Reported by David Ramsden.
+	 *
+	 * Updating it here also earns the restart prompt for nothing:
+	 * MachineNeedsRestart() memcmp()s the whole structure, so a changed
+	 * hostfs_path is now a change it can see, and the machine is offered a
+	 * restart exactly as it is for any other hardware-shaped setting.
+	 */
+	{
+		const wxString hostfs = hostfs_edit_->GetValue().Trim().Trim(false);
+
+		settings.Write("hostfs_path", hostfs);
+
+		if (snprintf(config.hostfs_path, sizeof(config.hostfs_path), "%s",
+		        hostfs.utf8_str().data()) >= (int) sizeof(config.hostfs_path)) {
+			/* Emptied rather than truncated, matching config_load(): a
+			   truncated path is a different directory, and HostFS would create
+			   it and put the guest's files there. */
+			config.hostfs_path[0] = '\0';
+		}
+	}
 	settings.Write("name", new_name_);
 	settings.Write("rom_dir", rom_dir);
 	settings.Write("model", wxString::FromUTF8(models[model_sel].name_config));

--- a/src/gui/settings.cpp
+++ b/src/gui/settings.cpp
@@ -782,6 +782,38 @@ extern "C" void config_save_to_path(Config *cfg, const char *path)
 	wxFileConfig settings(wxEmptyString, wxEmptyString,
 	                      wxString::FromUTF8(path), wxEmptyString,
 	                      wxCONFIG_USE_RELATIVE_PATH);
+
+	/*
+	 * ★ Captured BEFORE DeleteAll(), which wipes the file and writes it again.
+	 *
+	 * A setting a command-line option is overriding must come out of the file
+	 * unchanged, and simply not writing it does not achieve that - it deletes
+	 * the key, because of that DeleteAll(). Which is how the first attempt at
+	 * this silently discarded a deliberately configured socket instead of
+	 * preserving it. So the file's own value is read first and written back.
+	 *
+	 * Absence is preserved as absence: a key the file never had stays missing,
+	 * which config_load() reads as "use the default".
+	 */
+	struct PreservedEntry {
+		const char *key;
+		AppSettingId setting;
+		bool present;
+		wxString value;
+	} preserved[] = {
+		{ "vnc_enabled",    APP_SETTING_VNC_ENABLED,    false, wxEmptyString },
+		{ "vnc_port",       APP_SETTING_VNC_PORT,       false, wxEmptyString },
+		{ "hostcmd_socket", APP_SETTING_HOSTCMD_SOCKET, false, wxEmptyString },
+		{ "debug_socket",   APP_SETTING_DEBUG_SOCKET,   false, wxEmptyString },
+	};
+
+	ConfigFileUseGeneralGroup(settings);
+	for (PreservedEntry &e : preserved) {
+		if (app_settings_is_overridden(e.setting) && settings.HasEntry(e.key)) {
+			e.present = settings.Read(e.key, &e.value);
+		}
+	}
+
 	settings.DeleteAll();
 	ConfigFileUseGeneralGroup(settings);
 
@@ -847,15 +879,53 @@ extern "C" void config_save_to_path(Config *cfg, const char *path)
 	   without being told again on the command line every time. The app settings
 	   file supplies these before a machine is chosen, and as the default for a
 	   machine whose file has not got them yet. */
-	settings.Write("vnc_enabled", static_cast<long>(cfg->vnc_enabled));
-	settings.Write("vnc_port", static_cast<long>(cfg->vnc_port));
-	settings.Write("vnc_password", wxString(cfg->vnc_password, wxConvUTF8));
-	settings.Write("hostcmd_enabled", static_cast<long>(cfg->hostcmd_enabled));
-	settings.Write("hostcmd_socket", wxString(cfg->hostcmd_socket, wxConvUTF8));
-	settings.Write("clipboard_enabled", static_cast<long>(cfg->clipboard_enabled));
+	/*
+	 * ★ A SETTING A COMMAND-LINE OPTION IS OVERRIDING IS NOT WRITTEN, and the
+	 * file's own value is left exactly as it was.
+	 *
+	 * An override is applied to the live Config so everything downstream sees
+	 * it, and this function then writes the Config out - so a per-run option was
+	 * being recorded as though the user had chosen it. One run with
+	 * --debug-socket left an absolute path in the machine's configuration that
+	 * broke the moment the data folder moved, and --vnc-port did the same to the
+	 * port, which matters more than it sounds: running two instances with
+	 * different ports permanently rewrote both machines' configured port.
+	 *
+	 * Not writing is deliberately better than writing the pre-override value
+	 * back: there is nothing to remember, and wxFileConfig leaves an entry it is
+	 * not asked to change untouched.
+	 */
+	{
+		/* Overridden: put back exactly what the file said, or leave the key out
+		   if it never had one. Otherwise write the running value as usual. */
+		auto write_or_restore = [&](const char *key, const wxString &running) {
+			for (const PreservedEntry &e : preserved) {
+				if (strcmp(e.key, key) != 0) {
+					continue;
+				}
+				if (app_settings_is_overridden(e.setting)) {
+					if (e.present) {
+						settings.Write(key, e.value);
+					}
+					return;
+				}
+			}
+			settings.Write(key, running);
+		};
 
-	settings.Write("debug_enabled", static_cast<long>(cfg->debug_enabled));
-	settings.Write("debug_socket", wxString(cfg->debug_socket, wxConvUTF8));
+		write_or_restore("vnc_enabled",
+		    wxString::Format("%ld", static_cast<long>(cfg->vnc_enabled)));
+		write_or_restore("vnc_port",
+		    wxString::Format("%ld", static_cast<long>(cfg->vnc_port)));
+		settings.Write("vnc_password", wxString(cfg->vnc_password, wxConvUTF8));
+		settings.Write("hostcmd_enabled", static_cast<long>(cfg->hostcmd_enabled));
+		write_or_restore("hostcmd_socket",
+		    wxString(cfg->hostcmd_socket, wxConvUTF8));
+		settings.Write("clipboard_enabled",
+		    static_cast<long>(cfg->clipboard_enabled));
+		settings.Write("debug_enabled", static_cast<long>(cfg->debug_enabled));
+		write_or_restore("debug_socket", wxString(cfg->debug_socket, wxConvUTF8));
+	}
 	settings.Write("network_capture", cfg->network_capture ? wxString(cfg->network_capture, wxConvUTF8) : wxString());
 
 	config_nat_rules_save(settings);

--- a/tests/test_app_settings.c
+++ b/tests/test_app_settings.c
@@ -155,6 +155,82 @@ main(int argc, char *argv[])
 		    strcmp(back.hostcmd_socket, "/tmp/hc.sock") == 0);
 	}
 
+	/*
+	 * ★ A COMMAND-LINE OVERRIDE MUST NOT BECOME A SAVED SETTING.
+	 *
+	 * An override is applied to the live Config so everything downstream sees
+	 * it, and config_save() then writes the Config out - so a per-run option was
+	 * being recorded as though the user had chosen it. One run with
+	 * --debug-socket left an absolute path in the machine's configuration that
+	 * broke as soon as the data folder moved, and --vnc-port did the same to the
+	 * port, which is worse than it sounds: two instances started on different
+	 * ports permanently rewrote both machines' configured port.
+	 *
+	 * config_save() asks app_settings_is_overridden() before writing each of
+	 * these, so this checks the question is answered correctly. It cannot check
+	 * config_save() itself from here, since that needs wxWidgets.
+	 */
+	printf("\nan override is applied but never recorded as a setting\n");
+	{
+		Config cfg;
+
+		app_settings_clear_overrides();
+
+		check("nothing is overridden to begin with",
+		    !app_settings_is_overridden(APP_SETTING_VNC_PORT) &&
+		    !app_settings_is_overridden(APP_SETTING_VNC_ENABLED) &&
+		    !app_settings_is_overridden(APP_SETTING_HOSTCMD_SOCKET) &&
+		    !app_settings_is_overridden(APP_SETTING_DEBUG_SOCKET));
+
+		memset(&cfg, 0, sizeof(cfg));
+		cfg.vnc_port = 5900;
+		snprintf(cfg.debug_socket, sizeof(cfg.debug_socket), "%s", "keep-me");
+
+		/* Only --debug-socket given. */
+		app_settings_override_debug_socket("/run/one-off.sock");
+		app_settings_apply_overrides(&cfg);
+
+		check("the override reaches the live config",
+		    strcmp(cfg.debug_socket, "/run/one-off.sock") == 0);
+		check("and is reported as overridden, so it will not be written",
+		    app_settings_is_overridden(APP_SETTING_DEBUG_SOCKET));
+		check("while the settings nobody overrode are still writable",
+		    !app_settings_is_overridden(APP_SETTING_VNC_PORT) &&
+		    !app_settings_is_overridden(APP_SETTING_VNC_ENABLED) &&
+		    !app_settings_is_overridden(APP_SETTING_HOSTCMD_SOCKET));
+
+		/* --vnc-port, the one that bit two instances at once. */
+		app_settings_override_vnc_port(5911);
+		app_settings_apply_overrides(&cfg);
+		check("a port override reaches the config", cfg.vnc_port == 5911);
+		check("and is reported as overridden",
+		    app_settings_is_overridden(APP_SETTING_VNC_PORT));
+
+		app_settings_override_vnc_enabled(0);
+		app_settings_override_hostcmd_socket("/run/hc.sock");
+		app_settings_apply_overrides(&cfg);
+		check("every override is reported",
+		    app_settings_is_overridden(APP_SETTING_VNC_ENABLED) &&
+		    app_settings_is_overridden(APP_SETTING_HOSTCMD_SOCKET));
+
+		/* The count is not an id and must answer no rather than run off the
+		   end of the switch. */
+		check("APP_SETTING_COUNT is not a setting",
+		    !app_settings_is_overridden(APP_SETTING_COUNT));
+
+		app_settings_clear_overrides();
+		check("clearing forgets them all",
+		    !app_settings_is_overridden(APP_SETTING_VNC_PORT) &&
+		    !app_settings_is_overridden(APP_SETTING_DEBUG_SOCKET));
+
+		/* Cleared overrides must not still be applied, or a later save would
+		   write the value after all. */
+		memset(&cfg, 0, sizeof(cfg));
+		cfg.vnc_port = 5900;
+		app_settings_apply_overrides(&cfg);
+		check("and stops applying them", cfg.vnc_port == 5900);
+	}
+
 	printf("\nthe path is built sensibly\n");
 	check("a trailing slash is not doubled",
 	    strstr(app_settings_path("/tmp/"), "//") == NULL);


### PR DESCRIPTION
@david-ramsden's three HostFS points, plus the `debug_socket` problem that turned out to have the same shape.

---

## 1. Changing the HostFS folder from Settings → Machine did nothing

Your diagnosis was right. `SaveSettings()` wrote `hostfs_path` to the **file only**. From the machine selector that is enough, because nothing else holds a `Config` — which is why it appeared to work there. From a **running** machine, the emulator holds a `Config` with the old value, and the next `config_save()` writes it back over the file. Hence the silent revert.

Fixed by also writing the live config, alongside `config.model`, which that function has always done for the same reason.

## 2. No "configuration has changed — restart?" prompt

Right that it should behave like every other setting, and it now does, **with no code of its own**: `MachineNeedsRestart()` `memcmp()`s the whole `Config`, so once the live config carries the new value it is a change it already sees.

## 3. Pointing at a blank folder half-started

Reproduced, and **not a fault in this code**. With no `!Boot` on the drive it boots from, RISC OS reaches the supervisor prompt:

```
RISC OS 514MB / SA-110 Processor / RPCEmu Host Filing System
Error: Use *Desktop to start TaskManager (Error number &81F403)
*
```

The same machine on its own folder reaches a full desktop with an iconbar, so the empty folder is the only variable. Your description was a part-started desktop *with a pointer*, which is not quite what I saw — possibly a partly-populated folder — but the cause is the same.

We made it easy to walk into and the error names nothing useful, so the editor now warns live as you type:

> There is no !Boot here. If this machine boots from HostFS it will stop at the supervisor prompt rather than reaching the desktop.

A warning, not a refusal.

---

## 4. A command-line option must not become a saved setting

The stale absolute `debug_socket` that broke when a data folder moved was **not** written by the editor — there is no field for it. It came from **`--debug-socket`**. An override is applied to the live `Config` so everything downstream sees it, and `config_save()` writes the `Config` out. One run with a path, and that path is in the machine's configuration for good.

**And it is not only `debug_socket`.** The same mechanism covers `--vnc-port`, `--no-vnc` and `--hostcmd-socket`, so all four were being baked in. `--vnc-port` is arguably the worst: running two instances on different ports, which is what the option is *for*, permanently rewrote both machines' configured port.

Same rule `--datadir` already follows: an option supplied afresh every run must not become a permanent preference.

### The first attempt at this was wrong, and only testing found it

Skipping the `Write()` does **not** leave the file's value alone — it **deletes** the key, because `config_save_to_path()` calls `DeleteAll()` and rewrites the file. So my first version silently discarded a deliberately configured socket instead of preserving it: a different bug, in the same place, with the same shape as the one I was fixing. The file's own value is now read *before* the `DeleteAll()` and written back, and an absent key stays absent.

### Existing configurations heal themselves

They still hold the bad value, and rewriting somebody's file on a guess about what they meant is worse than quietly working. So `debugcmd.c` falls back at runtime: an absolute socket path whose directory has gone uses the default instead, with a line in the log, rather than failing to bind and losing the debug socket for the run.

```
DebugCmd: '/gone/machines/OS-530/debug.sock' is not there any more, using the default socket instead
DebugCmd: listening on AF_UNIX /tmp/rpcds/rpcemu-debug.sock
```

The config file is left untouched.

---

## Verification

**Through the GUI under Xvfb**, checking the process was alive at each step — an earlier attempt proved nothing because the emulator had already exited from its timeout and the OK click never landed. The real sequence: Settings → Machine → System, typed a path, saw the no-`!Boot` warning appear as it was typed, OK → **restart prompt** → Restart → the restarted machine logged the new root, the file held the value, and **it was still there after a clean SIGTERM**. That last check is the original symptom.

**End to end for the overrides:** a run with `--debug-socket` and `--vnc-port` leaves both keys in the file exactly as they were. A config naming a directory that no longer exists logs the fallback, binds the default, and is left alone.

Ten new checks in `test_app_settings`, including that a *cleared* override stops being applied — otherwise a later save would write the value after all.

29/29 tests, warnings gate clean (0 from our code), `cli_smoke` green, and `debugcmd.c`, `app_settings.c` and the editor all compile for Windows.

## Still open

- A stored data-folder choice pointing at a folder since deleted is used as given and re-seeded, which can look like lost machines.
- Nothing migrates an existing HostFS folder when the setting changes.
- The HostFS sharing warning fires when you choose a folder, not when two machines are actually running on one.