### PR TITLE
HostFS: warn that a new folder will be empty, plus Wine-based Windows testing

### DIFF
--- a/build-windows.sh
+++ b/build-windows.sh
@@ -81,6 +81,24 @@ else
 	GCCDIR=$(dirname "$(${TARGET}-gcc -print-libgcc-file-name)")
 	SEARCH_DIRS=("$SYSROOT/bin" "$SYSROOT/lib" "$GCCDIR")
 	CMAKE_TC_ARGS=(-DCMAKE_TOOLCHAIN_FILE="$SCRIPT_DIR/cmake/mingw-w64-x86_64.cmake")
+	# Wine, if it is here, so ctest can run the cross-built tests. Looked for in
+	# the places Debian and Ubuntu put it: the `wine` wrapper is a separate
+	# package from the loader, so wine64 alone is a perfectly normal install and
+	# was what this machine had.
+	if [ -z "${WINE:-}" ]; then
+		for candidate in wine64 wine /usr/lib/wine/wine64; do
+			if command -v "$candidate" >/dev/null 2>&1; then
+				WINE=$(command -v "$candidate")
+				break
+			elif [ -x "$candidate" ]; then
+				WINE="$candidate"
+				break
+			fi
+		done
+	fi
+	if [ -n "${WINE:-}" ] && [ "${RPCEMU_SKIP_WINE_TESTS:-0}" != "1" ]; then
+		CMAKE_TC_ARGS+=(-DCMAKE_CROSSCOMPILING_EMULATOR="$WINE")
+	fi
 	command -v ${TARGET}-gcc >/dev/null || { echo "error: ${TARGET}-gcc not found (apt install mingw-w64)"; exit 1; }
 	if ! [ -x "$SYSROOT/bin/wx-config" ]; then
 		echo "error: cross wxWidgets not found in $SYSROOT. Run ./setup-cross-build-env.sh first."
@@ -102,13 +120,42 @@ cmake --build "$BUILD_DIR" -j"$(njobs)"
 
 [ -f "$BUILD_DIR/bin/$BIN" ] || { echo "error: $BIN not built"; exit 1; }
 
-# Run the test suite. Only possible on a native MSYS2 build, since a cross build
-# produces .exe files this host cannot execute. A failure is fatal: Windows spent
-# a long time as the one platform that built without ever being tested.
+# Run the test suite. A failure is fatal: Windows spent a long time as the one
+# platform that built without ever being tested.
+#
+# A cross build used to skip this entirely, on the grounds that a Linux host
+# cannot execute .exe files. It can, under Wine, and the whole suite passes there
+# - which turns "the Windows build is checked when CI gets to it" into something
+# checkable before pushing. CMAKE_CROSSCOMPILING_EMULATOR (set at configure time,
+# above) is what makes ctest run each test through it.
+#
+# WINEPATH is needed as well: the test executables link the same DLLs the emulator
+# does, and at this point they have not been staged next to anything. Without it
+# every test exits 53 - a Windows "DLL not found", with no message, which reads
+# like a crash.
+#
+# Set RPCEMU_SKIP_WINE_TESTS=1 to opt out.
 if [ "$NATIVE" = true ]; then
 	bash "$SCRIPT_DIR/tests/run-ctest.sh" "$BUILD_DIR"
+elif [ -n "${WINE:-}" ] && [ "${RPCEMU_SKIP_WINE_TESTS:-0}" != "1" ]; then
+	echo "==> Running the Windows test suite under Wine ($WINE)"
+	winepath=""
+	for d in "${SEARCH_DIRS[@]}"; do
+		[ -d "$d" ] || continue
+		# Z: is Wine's mapping of /, so an absolute Unix path converts by
+		# swapping the separators.
+		winepath="${winepath:+$winepath;}Z:${d//\//\\}"
+	done
+	WINEPATH="$winepath" WINEDEBUG="${WINEDEBUG:--all}" \
+	    bash "$SCRIPT_DIR/tests/run-ctest.sh" "$BUILD_DIR" wine
 else
-	echo "Note: skipping tests (cross-compiled binaries cannot run on this host)."
+	if [ "${RPCEMU_SKIP_WINE_TESTS:-0}" = "1" ]; then
+		echo "Note: skipping tests (RPCEMU_SKIP_WINE_TESTS=1)."
+	else
+		echo "Note: skipping tests - no wine found, so these .exe files cannot run"
+		echo "      on this host. Install wine to test a cross build before pushing"
+		echo "      (apt install wine64), or rely on the Windows CI job."
+	fi
 fi
 
 echo "==> Staging $WIN_RELEASE"

--- a/docs/hostfs.md
+++ b/docs/hostfs.md
@@ -150,6 +150,39 @@ this section rather than a bug that can be fixed.
 Measured by reading a hand-written file with `wxFileConfig`, not assumed; the
 results are pinned in `tests/test_hostfs_path.c`.
 
+## Moving the data folder
+
+The *relative* form travels: a machine with `hostfs_path=disc` resolves under
+wherever its machine directory now is, and boots exactly as before. Verified by
+moving a whole data folder and booting from the new location.
+
+An *absolute* path does not, and the way it fails is worth knowing. HostFS creates
+its root **and every missing level above it**, so a machine whose absolute path
+pointed inside the data folder that moved does not report an error: the old tree
+is recreated, empty, and the machine boots from a blank disc — the grey screen
+above. The resurrected tree also makes the old location look like it is still in
+use.
+
+That is reachable without moving anything by hand, because the one-time migration
+of `~/.local/share/rpcemu` to `~/RPCEmu` renames the tree without rewriting
+configurations.
+
+The log now says so when the root is absent **and its parent is absent too**,
+which is what distinguishes a stale path from somebody asking for a new folder on
+a drive that exists:
+
+    HostFS: '/old/machines/Box/hostfs' does not exist and neither does
+    '/old/machines/Box'. If this machine's data folder has moved, this is a stale
+    absolute hostfs_path: the folder will be created empty and the guest will see
+    a blank disc. Its own folder is '/new/machines/.../hostfs'.
+
+**Whether it should instead refuse and fall back** to the machine's own folder is
+an open question, not an oversight. In the moved-folder case falling back would be
+right — the files are there, under the new location — but it would also override
+somebody who deliberately named a folder on a drive that is not mounted yet, and
+that is a behaviour change rather than a bug fix. Prefer a relative path if you
+expect to move things.
+
 ## Known gaps
 
 - The sharing warning is given when you **choose** a folder, not when two

--- a/docs/hostfs.md
+++ b/docs/hostfs.md
@@ -95,6 +95,61 @@ Writing those found a real bug: a machine directory ending in `//` produced a
 doubled separator, which would also have made two identical shared folders compare
 as different and suppressed the warning.
 
+## An empty folder is an empty hard disc
+
+Pointing HostFS at a new folder gives the machine a **blank disc**. That is the
+setting working, not failing, but it does not look like it, because RISC OS does
+not say so. What you get depends on the version:
+
+| RISC OS | What an empty boot drive looks like |
+| --- | --- |
+| 5.31 | A bare grey screen with a mouse pointer. No icon bar, no banner, nothing to click. |
+| 5.30 | The supervisor prompt, with `Error: Use *Desktop to start TaskManager`. |
+
+Neither mentions a folder, so neither tells you what you just did. Nothing is
+lost: the old folder is untouched, and pointing the setting back at it brings the
+machine straight back.
+
+Both screens were reproduced deliberately, on Linux and on the Windows build under
+Wine, which is how the machine editor came to warn about it before you save rather
+than after you reboot. The warning is decided in `src/hostfs_advice.c` and checked
+by `tests/test_hostfs_advice.c` — separated from the dialog because the decision
+had been wrong: the warning lived in the branch for a folder that already existed,
+so a folder about to be **created**, which is necessarily empty, was the one case
+that never got it. Reported by David Ramsden.
+
+## Editing a config by hand on Windows
+
+Use the machine editor if you can, and **write forward slashes if you edit the
+file by hand**. `wxFileConfig` escapes backslashes when it writes a value and
+unescapes them when it reads one, so a file the emulator wrote round-trips
+correctly and a hand-edited one does not. What you get back depends on the letter
+after the backslash:
+
+| Typed by hand | Read back as | |
+| --- | --- | --- |
+| `C:\temp` | `C:<tab>emp` | refused, falls back to the machine's own folder with a line in the log |
+| `C:\new` | `C:<newline>ew` | refused |
+| `C:\run` | `C:<CR>un` | refused |
+| `C:\foo` | `C:oo` | **used as given** — see below |
+| `C:\bar` | `C:ar` | used as given |
+| `C:\\foo` | `C:\foo` | correct; this is what the editor writes |
+| `C:/foo` | `C:/foo` | correct, and needs no escaping at all |
+
+The first three become control characters, which name directories Windows will not
+create: HostFS then served a folder that was not there and the guest's disc
+appeared empty, with nothing to connect it to the file that had been edited. Those
+are now refused.
+
+The next two cannot be caught. An escape wx does not recognise loses **both**
+characters, and `C:oo` is a perfectly well-formed drive-relative path — nothing
+can tell it from one somebody meant to type. So it is used, and the machine
+quietly runs from the wrong folder. This is the reason for the advice at the top of
+this section rather than a bug that can be fixed.
+
+Measured by reading a hand-written file with `wxFileConfig`, not assumed; the
+results are pinned in `tests/test_hostfs_path.c`.
+
 ## Known gaps
 
 - The sharing warning is given when you **choose** a folder, not when two
@@ -102,4 +157,6 @@ as different and suppressed the warning.
   outside the folder itself, since anything written inside it would appear to the
   guest as a file.
 - Nothing migrates an existing `hostfs` folder when you change the setting. The
-  new folder is created empty and the old one is left alone.
+  new folder is created empty and the old one is left alone. The editor now warns
+  that it will be empty, but offering to copy or move the old contents would be
+  friendlier still.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -53,6 +53,35 @@ It builds in `build-prepush/` so it cannot disturb whatever `build/` is
 configured for, and it is incremental after the first run. Push with
 `--no-verify`, or set `RPCEMU_SKIP_PRE_PUSH=1`, when you have a reason.
 
+## Testing the Windows build on Linux, with Wine
+
+`./build-windows.sh` now runs the whole suite against the cross-built `.exe`
+files under Wine, so the Windows build can be checked before pushing instead of
+when CI gets to it. Nothing to pass: it looks for `wine64`, then `wine`, then
+`/usr/lib/wine/wine64`, and runs the tests if it finds one.
+
+```
+apt install wine64          # the loader; the `wine` wrapper is a separate package
+./build-windows.sh
+==> Running the Windows test suite under Wine (/usr/lib/wine/wine64)
+==> [wine] all 32 tests passed
+```
+
+Set `RPCEMU_SKIP_WINE_TESTS=1` to opt out.
+
+Two things are worth knowing:
+
+- **`WINEPATH` is set for the run**, pointing at the mingw sysroot. The test
+  executables link the same DLLs the emulator does, and at that point nothing has
+  been staged beside them. Without it every test exits **53** — a Windows "DLL not
+  found", with no message at all, which reads exactly like a crash.
+- **Wine is not Windows.** It is enough to catch what it catches; the
+  `windows-amd64` CI job on a real MSYS2 toolchain is still the authority.
+
+The emulator itself runs under Wine too, which is how `tests/cli_smoke.sh` can be
+pointed at the Windows binary, and how the RISC OS 5.31 empty-HostFS screen in
+[hostfs.md](hostfs.md) was reproduced on a Linux desktop.
+
 ## What the suite covers
 
 Thirty tests, twenty-two of which build on every platform and eight of which
@@ -85,6 +114,7 @@ need a native recompiler backend.
 | `test_openbus` | the second processor bus: window, bus mastering, nPIRQ, reset, timeslice |
 | `test_openbus_decode` | that the machine's own memory decode reaches a fitted card, which an unhooked window would hide |
 | `test_hostfs_path` | where a machine's HostFS drive resolves to, on all three platforms |
+| `test_hostfs_advice` | what the machine editor warns about when a HostFS folder is chosen |
 | `test_data_dir` | which data directory is used, and above all when the user is asked |
 | `test_held_keys` | which keys the guest believes are held, when several map to one |
 | `test_machine_selector` | the VNC machine selector's navigation and drawing |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ set(RPCEMU_CORE_SOURCES
     keyboard.c
     openbus.c
     openbus_stub.c
+    hostfs_advice.c
     hostfs_path.c
     mem.c
     perfprof.c

--- a/src/gui/machine_edit_dialog.cpp
+++ b/src/gui/machine_edit_dialog.cpp
@@ -27,6 +27,7 @@
 #include "config_paths.h"
 
 extern "C" {
+#include "hostfs_advice.h"
 #include "hostfs_path.h"
 }
 #include "gui_preferences.h"
@@ -269,26 +270,33 @@ void MachineEditDialog::UpdateHostfsNote()
 		note = "This machine's own folder: " + resolved;
 	} else {
 		note = resolved;
-		if (!wxDirExists(resolved)) {
-			note += "  (does not exist yet, it will be created)";
-		} else if (!wxDirExists(resolved + wxFileName::GetPathSeparator() + "!Boot") &&
-		           !wxFileExists(resolved + wxFileName::GetPathSeparator() + "!Boot")) {
-			/*
-			 * ★ Said because the alternative is baffling. A machine that boots
-			 * from HostFS and finds no !Boot does not report a missing boot
-			 * sequence: RISC OS comes up and drops to the supervisor prompt with
-			 * "Error: Use *Desktop to start TaskManager", which tells you
-			 * nothing about the folder you just chose. Reported by David
-			 * Ramsden, who pointed a machine at a blank folder expecting the old
-			 * "No !Boot found" and got a part-started desktop instead.
-			 *
-			 * Only a warning. An empty folder is perfectly reasonable if this
-			 * machine does not boot from HostFS, or if you are about to put
-			 * something in it.
-			 */
-			note += "\nThere is no !Boot here. If this machine boots from "
-			        "HostFS it will stop at the supervisor prompt rather than "
-			        "reaching the desktop.";
+
+		/*
+		 * Both warnings come from hostfs_advice(), which is where the decision
+		 * lives and where it is tested. It used to be decided here, in two
+		 * branches, and the branch for a folder that does not exist yet said only
+		 * that it would be created - never that it would be empty, which is the
+		 * case that most needs saying. See src/hostfs_advice.h.
+		 *
+		 * Only ever warnings. An empty folder is perfectly reasonable if this
+		 * machine does not boot from HostFS, or if you are about to put
+		 * something in it.
+		 */
+		const bool exists = wxDirExists(resolved);
+		const bool has_boot = exists &&
+		    (wxDirExists(resolved + wxFileName::GetPathSeparator() + "!Boot") ||
+		     wxFileExists(resolved + wxFileName::GetPathSeparator() + "!Boot"));
+		const unsigned advice = hostfs_advice(exists ? 1 : 0, has_boot ? 1 : 0);
+
+		static const unsigned bits[] = {
+			HOSTFS_ADVICE_WILL_CREATE,
+			HOSTFS_ADVICE_NO_BOOT,
+		};
+		for (size_t i = 0; i < sizeof(bits) / sizeof(bits[0]); i++) {
+			if (advice & bits[i]) {
+				note += "\n";
+				note += hostfs_advice_text(bits[i]);
+			}
 		}
 
 		const wxString other = MachineSharingHostfs(resolved,

--- a/src/hostfs.c
+++ b/src/hostfs.c
@@ -2444,13 +2444,53 @@ hostfs_init(void)
    */
   if (!hostfs_path_resolve(config.hostfs_path, rpcemu_get_machine_datadir(),
                            HOSTFS_ROOT, sizeof(HOSTFS_ROOT))) {
-    /* Only reachable with a configured path too long to resolve, which
-       config_load already refuses; belt and braces, since the alternative is a
-       truncated path that HostFS would happily create. */
+    /*
+     * Two ways in. A configured path too long to resolve, which config_load
+     * already refuses, so that one is belt and braces - the alternative being a
+     * truncated path that HostFS would happily create. And a path containing
+     * control characters, which is what a hand-edited Windows path becomes once
+     * wxFileConfig has unescaped it: "C:\temp" arrives as "C:<tab>emp". See
+     * hostfs_path.c.
+     */
     rpclog("HostFS: could not resolve hostfs_path '%s', using the default\n",
            config.hostfs_path);
     (void) hostfs_path_resolve("", rpcemu_get_machine_datadir(),
                                HOSTFS_ROOT, sizeof(HOSTFS_ROOT));
+  }
+
+  /*
+   * ★ SAY SO WHEN AN ABSOLUTE PATH LOOKS STALE, because the symptom explains
+   * nothing. rpcemu_ensure_dir() below creates the root and every missing level
+   * above it, so a machine whose absolute hostfs_path pointed inside a data
+   * folder that has since MOVED does not fail: the old tree is recreated empty,
+   * the guest boots from a blank disc, and RISC OS 5.31 shows a bare grey screen
+   * with no icon bar while 5.30 stops at the supervisor prompt. Neither mentions
+   * a folder, and the recreated tree makes the old location look like it is in
+   * use.
+   *
+   * That is reachable without anybody moving anything by hand: the one-time
+   * migration of ~/.local/share/rpcemu to ~/RPCEmu renames the tree without
+   * rewriting configurations.
+   *
+   * A missing PARENT is what separates this from somebody legitimately asking
+   * for a new folder on a drive that exists. Only logged - whether to create the
+   * lineage or fall back to the machine's own folder is a policy question, and
+   * quietly changing it here would surprise anyone relying on it.
+   */
+  if (config.hostfs_path[0] != '\0' &&
+      hostfs_path_is_absolute(config.hostfs_path)) {
+    struct stat st;
+    char parent[1024];
+
+    if (stat(HOSTFS_ROOT, &st) != 0 &&
+        hostfs_path_parent(HOSTFS_ROOT, parent, sizeof(parent)) &&
+        stat(parent, &st) != 0) {
+      rpclog("HostFS: '%s' does not exist and neither does '%s'. If this "
+             "machine's data folder has moved, this is a stale absolute "
+             "hostfs_path: the folder will be created empty and the guest will "
+             "see a blank disc. Its own folder is '%smachines/.../hostfs'.\n",
+             HOSTFS_ROOT, parent, rpcemu_get_datadir());
+    }
   }
   /*
    * Make sure it exists. ensure_machine_dirs() only ever creates

--- a/src/hostfs_advice.c
+++ b/src/hostfs_advice.c
@@ -1,0 +1,71 @@
+/*
+  RPCEmu - An Acorn system emulator
+
+  Copyright (C) 2026 Andy Timmins
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+/*
+ * hostfs_advice.c - what to say about a chosen HostFS folder.
+ *
+ * The reasoning is in hostfs_advice.h.
+ */
+
+#include "hostfs_advice.h"
+
+unsigned
+hostfs_advice(int folder_exists, int has_boot)
+{
+	unsigned flags = 0;
+
+	if (!folder_exists) {
+		flags |= HOSTFS_ADVICE_WILL_CREATE;
+		/* A folder that does not exist yet cannot hold a !Boot, whatever the
+		   caller passed. Deciding it here rather than trusting the caller is the
+		   whole point: the dialog only tested for !Boot in the branch where the
+		   folder already existed, so the case that always needs the warning was
+		   the one case that never got it. */
+		flags |= HOSTFS_ADVICE_NO_BOOT;
+		return flags;
+	}
+
+	if (!has_boot) {
+		flags |= HOSTFS_ADVICE_NO_BOOT;
+	}
+	return flags;
+}
+
+const char *
+hostfs_advice_text(unsigned bit)
+{
+	switch (bit) {
+	case HOSTFS_ADVICE_WILL_CREATE:
+		return "This folder does not exist yet. It will be created, empty.";
+
+	case HOSTFS_ADVICE_NO_BOOT:
+		/* Both symptoms, because they look nothing like each other and neither
+		   mentions a folder. See the header. */
+		return "There is no !Boot here, so this is an empty hard disc. If this "
+		       "machine boots from HostFS it will not reach its desktop: RISC OS "
+		       "5.31 comes up to a bare grey screen with no icon bar, and 5.30 "
+		       "stops at the supervisor prompt. Nothing is lost - point this "
+		       "back at the old folder to get the machine back.";
+
+	default:
+		/* Zero, a combination, or a bit that does not exist. Nothing invented. */
+		return NULL;
+	}
+}

--- a/src/hostfs_advice.h
+++ b/src/hostfs_advice.h
@@ -1,0 +1,82 @@
+/*
+  RPCEmu - An Acorn system emulator
+
+  Copyright (C) 2026 Andy Timmins
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifndef HOSTFS_ADVICE_H
+#define HOSTFS_ADVICE_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * What the machine editor should say about a chosen HostFS folder.
+ *
+ * Extracted from the dialog so the decision can be tested, because the decision
+ * is where it went wrong. The editor had the "there is no !Boot here" warning in
+ * the branch for a folder that already exists, and a separate branch for one
+ * that does not - which said only that it would be created. A folder that is
+ * about to be created is guaranteed to be empty, so that is precisely the case
+ * where the warning matters most, and precisely the case that did not get it.
+ *
+ * Reported by David Ramsden, who pointed a new machine's HostFS at C:\foo,
+ * accepted the restart, and got a machine that would not reach its desktop with
+ * nothing on screen to say why. Nothing was broken and nothing was lost: an
+ * empty folder is an empty hard disc, and a RISC OS with no !Boot does not
+ * announce the fact. See docs/hostfs.md.
+ */
+
+/** The folder is not there yet and will be created. */
+#define HOSTFS_ADVICE_WILL_CREATE	0x1u
+
+/** There is no !Boot, so a machine that boots from HostFS will not get far. */
+#define HOSTFS_ADVICE_NO_BOOT		0x2u
+
+/**
+ * Decide what to warn about.
+ *
+ * @param folder_exists Does the resolved folder exist?
+ * @param has_boot      Does it contain a !Boot? Meaningless, and ignored, when
+ *                      the folder does not exist: it cannot contain anything.
+ * @return A combination of HOSTFS_ADVICE_*, zero when there is nothing to say.
+ */
+unsigned hostfs_advice(int folder_exists, int has_boot);
+
+/**
+ * The wording for one HOSTFS_ADVICE_* bit.
+ *
+ * One bit at a time, so a caller decides the order and the punctuation between
+ * them. Returns NULL for zero, for a combination, or for an unknown bit rather
+ * than inventing something to display.
+ *
+ * The no-!Boot wording names BOTH symptoms on purpose. RISC OS 5.31 comes up to
+ * a bare grey screen with no icon bar; 5.30 stops at the supervisor prompt. An
+ * earlier version of this warning promised the supervisor prompt, so on 5.31 -
+ * the version people are downloading from ROOL - it described something the user
+ * would never see.
+ */
+const char *hostfs_advice_text(unsigned bit);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HOSTFS_ADVICE_H */

--- a/src/hostfs_path.c
+++ b/src/hostfs_path.c
@@ -212,6 +212,67 @@ hostfs_path_resolve(const char *configured, const char *machine_dir,
 }
 
 int
+hostfs_path_parent(const char *path, char *out, size_t len)
+{
+	char tidied[1024];
+	size_t i;
+	size_t cut = 0;
+	int found = 0;
+
+	if (out == NULL || len == 0) {
+		return 0;
+	}
+	out[0] = '\0';
+
+	if (path == NULL || path[0] == '\0' || strlen(path) >= sizeof(tidied)) {
+		return 0;
+	}
+	snprintf(tidied, sizeof(tidied), "%s", path);
+	tidy(tidied);
+
+	for (i = 0; tidied[i] != '\0'; i++) {
+		if (tidied[i] == '/') {
+			cut = i;
+			found = 1;
+		}
+	}
+	if (!found) {
+		/* A bare leaf has no parent to speak of: "hostfs" says nothing about
+		   where it sits. The caller wants a directory it can test for, and "" is
+		   not one, so say so rather than answering "." and having the caller test
+		   the working directory by accident. */
+		return 0;
+	}
+	if (cut == 0) {
+		/* "/foo": the parent is the root itself, and its slash is the whole of
+		   it. */
+		if (len < 2) {
+			return 0;
+		}
+		out[0] = '/';
+		out[1] = '\0';
+		return 1;
+	}
+	if (cut + 1 > len) {
+		return 0;
+	}
+	memcpy(out, tidied, cut);
+	out[cut] = '\0';
+	/* "C:/foo" leaves "C:", which on Windows means the current directory of that
+	   drive rather than its root - not what a caller testing for a directory
+	   wants. Give it the root. */
+	if (cut == 2 && out[1] == ':') {
+		if (len < 4) {
+			out[0] = '\0';
+			return 0;
+		}
+		out[2] = '/';
+		out[3] = '\0';
+	}
+	return 1;
+}
+
+int
 hostfs_path_same_root(const char *a, const char *b)
 {
 	char ta[1024];

--- a/src/hostfs_path.c
+++ b/src/hostfs_path.c
@@ -118,6 +118,56 @@ tidy(char *path)
 	}
 }
 
+/*
+ * Is this setting unusable as a path?
+ *
+ * ★ WHY A CONTROL CHARACTER CAN EVEN GET IN HERE. wxFileConfig escapes
+ * backslashes when it writes a value and unescapes them when it reads one, so a
+ * config file the emulator wrote round-trips fine. A config file edited BY HAND
+ * on Windows does not, and what comes back depends on the letter that follows the
+ * backslash. Measured, not guessed (see tests/test_hostfs_path.c):
+ *
+ *     hostfs_path=C:\temp   ->  "C:<09>emp"   \t became a tab
+ *     hostfs_path=C:\new    ->  "C:<0a>ew"    \n became a newline
+ *     hostfs_path=C:\run    ->  "C:<0d>un"    \r became a carriage return
+ *     hostfs_path=C:\foo    ->  "C:oo"        unknown escape, BOTH characters gone
+ *     hostfs_path=C:\bar    ->  "C:ar"        likewise
+ *
+ * The first three name directories Windows will not create, so HostFS served a
+ * folder that was not there and the guest came up with a hard disc that appeared
+ * empty - with nothing anywhere to connect it to the file that was edited. Those
+ * are refused here, so the caller falls back to the machine's own folder and logs
+ * that it did. A boot from the wrong folder with a line in the log beats a boot
+ * from nowhere in silence.
+ *
+ * ★ THE LAST TWO CANNOT BE CAUGHT, and pretending otherwise would be worse than
+ * saying so. "C:oo" is a perfectly well-formed drive-relative path; nothing here
+ * can tell it from one somebody meant to type. docs/hostfs.md says so, and says
+ * to use forward slashes when editing by hand, which need no escaping at all.
+ *
+ * Found while testing the Windows build under Wine, by writing a config by hand
+ * and watching the log say C:oo.
+ */
+static int
+has_control_char(const char *path)
+{
+	size_t i;
+
+	if (path == NULL) {
+		return 0;
+	}
+	for (i = 0; path[i] != '\0'; i++) {
+		const unsigned char c = (unsigned char) path[i];
+
+		/* Below space only. Anything at or above it may be part of a perfectly
+		   good name in some encoding, and this is not the place to police that. */
+		if (c < 0x20 || c == 0x7f) {
+			return 1;
+		}
+	}
+	return 0;
+}
+
 int
 hostfs_path_resolve(const char *configured, const char *machine_dir,
                     char *out, size_t len)
@@ -128,6 +178,10 @@ hostfs_path_resolve(const char *configured, const char *machine_dir,
 		return 0;
 	}
 	out[0] = '\0';
+
+	if (has_control_char(configured)) {
+		return 0;
+	}
 
 	if (configured != NULL && hostfs_path_is_absolute(configured)) {
 		written = snprintf(out, len, "%s", configured);

--- a/src/hostfs_path.h
+++ b/src/hostfs_path.h
@@ -84,6 +84,27 @@ int hostfs_path_resolve(const char *configured, const char *machine_dir,
                         char *out, size_t len);
 
 /**
+ * The directory one level above @path.
+ *
+ * For telling "you asked for a folder that is not there yet" apart from "this
+ * whole path is stale". A machine whose absolute hostfs_path pointed inside its
+ * data folder, after that folder has moved, names a directory whose PARENT has
+ * gone too - and HostFS creates the lot, so the old tree reappears empty and the
+ * guest boots to a blank disc with nothing to explain it. Only the parent test
+ * separates that from somebody legitimately asking for a new folder on a drive
+ * that does exist.
+ *
+ * Pure, like the rest of this file: the caller does the asking-the-filesystem.
+ *
+ * @return Non-zero on success. Zero when @path has no parent worth testing - a
+ *         bare leaf such as "hostfs", an empty path, or one too long to handle.
+ *         A drive-relative parent ("C:") is returned as that drive's root
+ *         ("C:/"), since "C:" on Windows means the current directory of the
+ *         drive and a caller testing for a directory would get the wrong answer.
+ */
+int hostfs_path_parent(const char *path, char *out, size_t len);
+
+/**
  * Would two machines be sharing one HostFS folder?
  *
  * Compares resolved roots, ignoring trailing separators and separator style, so

--- a/src/hostfs_path.h
+++ b/src/hostfs_path.h
@@ -75,7 +75,10 @@ int hostfs_path_is_absolute(const char *path);
  * @return Non-zero on success. Zero if the result would not fit, in which case
  *         @out is left empty rather than truncated: a truncated path is a
  *         different directory, and for HostFS that means writing the guest's
- *         files somewhere nobody asked for.
+ *         files somewhere nobody asked for. Also zero when @configured contains a
+ *         control character, which is what a hand-edited Windows path turns into
+ *         once wxFileConfig has unescaped it - see has_control_char() in
+ *         hostfs_path.c for how "C:\foo" becomes "C:<form feed>oo".
  */
 int hostfs_path_resolve(const char *configured, const char *machine_dir,
                         char *out, size_t len);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -202,6 +202,17 @@ target_include_directories(test_hostfs_path PRIVATE
                            ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 rpcemu_add_test(test_hostfs_path)
 
+# What the machine editor warns about when a HostFS folder is chosen. Split out of
+# the dialog because the decision was wrong in a way that read correctly: the
+# "no !Boot" warning lived in the branch for a folder that already existed, so a
+# folder about to be created - necessarily empty - was the one case that never got
+# it. Reported by David Ramsden. See src/hostfs_advice.h.
+add_executable(test_hostfs_advice test_hostfs_advice.c
+               ${CMAKE_CURRENT_SOURCE_DIR}/../src/hostfs_advice.c)
+target_include_directories(test_hostfs_advice PRIVATE
+                           ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+rpcemu_add_test(test_hostfs_advice)
+
 # The Risc PC second processor bus (OPEN Bus), and the stub card that proves it.
 # Built before any real card on purpose: a second CPU is the least testable thing
 # in the machine, so the bus takes its host services through a struct of function
@@ -388,7 +399,7 @@ rpcemu_add_test(test_unzip)
 #
 # Raise RPCEMU_EXPECTED_TESTS when adding a test. If that feels like a chore, it
 # is the only line in the file that cannot go stale without being noticed.
-set(RPCEMU_EXPECTED_TESTS 23)	# tests that build on every platform
+set(RPCEMU_EXPECTED_TESTS 24)	# tests that build on every platform
 if(RPCEMU_JIT_TESTS)
     math(EXPR RPCEMU_EXPECTED_TESTS "${RPCEMU_EXPECTED_TESTS} + 8")	# JIT differential
 endif()

--- a/tests/boot_smoke.py
+++ b/tests/boot_smoke.py
@@ -423,16 +423,42 @@ def seed_boot_file(hostfs: str) -> None:
         f.write("Desktop\n")
 
 
-def port_is_free(host: str, port: int) -> bool:
-    """Is `port` bindable on both IP families the emulator listens on?
+def ipv6_loopback_available() -> bool:
+    """Can anything bind ::1 at all on this host?
+
+    Asked once, about a port nobody uses, so the answer is about the host and not
+    about that port. Containers and sandboxes are routinely built with IPv6
+    disabled, where every ::1 bind fails with EADDRNOTAVAIL no matter which port
+    is tried - and port_is_free() used to read that as "every port is taken" and
+    give up after scanning all 64 of them. The message was "no free port found",
+    which sent the reader looking for a stray listener that was never there.
+    """
+    try:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind(("::1", 0))
+        return True
+    except OSError:
+        return False
+
+
+def port_is_free(host: str, port: int, want_ipv6: bool = True) -> bool:
+    """Is `port` bindable on the IP families the emulator can listen on?
 
     VncServer sets rfb_screen_->port and ->ipv6port to the same number and only
     gives up when *both* fail, so a port where just one family is taken would
     start a server that is half-reachable. Probing both keeps the port we hand
     over honest. SO_REUSEADDR matches what the server does, so a socket left in
     TIME_WAIT is not mistaken for a live listener.
+
+    IPv4 is required because that is what this script's own client connects on.
+    IPv6 is only required when the host has IPv6 loopback at all - see
+    ipv6_loopback_available().
     """
-    for family, addr in ((socket.AF_INET, host), (socket.AF_INET6, "::1")):
+    families = [(socket.AF_INET, host)]
+    if want_ipv6:
+        families.append((socket.AF_INET6, "::1"))
+    for family, addr in families:
         try:
             with socket.socket(family, socket.SOCK_STREAM) as s:
                 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -456,8 +482,12 @@ def pick_free_port(host: str, preferred: int) -> int:
     check and the emulator binding it. That is also why binding to port 0 is not
     used: it returns an ephemeral port with exactly that race.
     """
+    want_ipv6 = ipv6_loopback_available()
+    if not want_ipv6:
+        print("boot_smoke: no IPv6 loopback on this host, checking IPv4 only",
+              flush=True)
     for port in range(preferred, preferred + 64):
-        if port_is_free(host, port):
+        if port_is_free(host, port, want_ipv6):
             return port
     raise SmokeError(
         f"no free port found in {preferred}-{preferred + 63} for the VNC server"

--- a/tests/test_hostfs_advice.c
+++ b/tests/test_hostfs_advice.c
@@ -1,0 +1,129 @@
+/*
+ * What the machine editor says about a chosen HostFS folder.
+ *
+ * ★ THIS TEST EXISTS BECAUSE THE DECISION WAS WRONG IN A WAY THAT LOOKED RIGHT.
+ * The editor warned "there is no !Boot here" when the chosen folder existed and
+ * was empty, and in a separate branch said "does not exist yet, it will be
+ * created" when it did not. Both branches read sensibly. Together they left the
+ * one case that ALWAYS needs the warning - a folder about to be created, which is
+ * necessarily empty - as the only case that never got it.
+ *
+ * David Ramsden hit exactly that: a new machine, HostFS pointed at C:\foo, accept
+ * the restart, and a machine that will not reach its desktop with nothing on
+ * screen to say why. Reproduced here on Linux and under Wine on the Windows
+ * build, on RISC OS 5.31 (a bare grey screen with no icon bar) and 5.30 (the
+ * supervisor prompt). Nothing was broken and nothing was lost - an empty folder
+ * is an empty hard disc, and RISC OS does not announce a missing !Boot.
+ *
+ * The decision is therefore kept out of the dialog, where a wx build is needed to
+ * exercise it, and checked here on every platform instead.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "hostfs_advice.h"
+
+static int failures;
+
+static void
+check(const char *what, int ok)
+{
+	printf("  %-66s %s\n", what, ok ? "ok" : "FAIL");
+	if (!ok) {
+		failures++;
+	}
+}
+
+/* The regression. Everything else here is the surrounding behaviour. */
+static void
+test_folder_that_does_not_exist_yet(void)
+{
+	puts("A folder that does not exist yet gets BOTH warnings:");
+
+	check("it says the folder will be created",
+	    (hostfs_advice(0, 0) & HOSTFS_ADVICE_WILL_CREATE) != 0);
+	check("and it says there will be no !Boot - the case that was missed",
+	    (hostfs_advice(0, 0) & HOSTFS_ADVICE_NO_BOOT) != 0);
+
+	/*
+	 * A caller claiming a !Boot in a folder that does not exist is contradicting
+	 * itself. The answer is decided here rather than taken on trust, because the
+	 * dialog works it out from two separate filesystem calls and a wrong answer
+	 * would silence the warning again.
+	 */
+	check("a claimed !Boot in a folder that is not there is not believed",
+	    (hostfs_advice(0, 1) & HOSTFS_ADVICE_NO_BOOT) != 0);
+}
+
+static void
+test_folder_that_exists(void)
+{
+	puts("A folder that exists is judged on what is in it:");
+
+	check("empty: warned about the missing !Boot",
+	    hostfs_advice(1, 0) == HOSTFS_ADVICE_NO_BOOT);
+	check("empty: not told it will be created, because it is already there",
+	    (hostfs_advice(1, 0) & HOSTFS_ADVICE_WILL_CREATE) == 0);
+	check("with a !Boot: nothing to say at all",
+	    hostfs_advice(1, 1) == 0);
+}
+
+/*
+ * The wording is checked for the two things that would actually mislead: naming
+ * only one of the two symptoms, and claiming the machine is broken when it is
+ * not. Not checked word for word - that would fail on every edit and teach us to
+ * stop reading it.
+ */
+static void
+test_wording(void)
+{
+	const char *no_boot = hostfs_advice_text(HOSTFS_ADVICE_NO_BOOT);
+	const char *create = hostfs_advice_text(HOSTFS_ADVICE_WILL_CREATE);
+
+	puts("The wording covers both symptoms and does not overstate:");
+
+	check("there is wording for the missing !Boot", no_boot != NULL);
+	check("and for the folder being created", create != NULL);
+
+	if (no_boot != NULL) {
+		/* An earlier version promised the supervisor prompt, so on 5.31 - the
+		   version ROOL are shipping - it described something the user would
+		   never see. Both, or the warning misleads half its readers. */
+		check("it mentions the grey screen (what 5.31 does)",
+		    strstr(no_boot, "grey") != NULL);
+		check("it mentions the supervisor prompt (what 5.30 does)",
+		    strstr(no_boot, "supervisor") != NULL);
+		check("and it says nothing is lost, because nothing is",
+		    strstr(no_boot, "Nothing is lost") != NULL);
+	}
+	if (create != NULL) {
+		check("the create wording says the folder will be empty",
+		    strstr(create, "empty") != NULL);
+	}
+
+	check("a bit that does not exist gets no invented text",
+	    hostfs_advice_text(0x80u) == NULL);
+	check("nor does zero", hostfs_advice_text(0) == NULL);
+	/* A combination is a caller mistake: it would have to pick an order and
+	   punctuation, which is the caller's job. */
+	check("nor a combination of bits",
+	    hostfs_advice_text(HOSTFS_ADVICE_WILL_CREATE |
+	        HOSTFS_ADVICE_NO_BOOT) == NULL);
+}
+
+int
+main(void)
+{
+	test_folder_that_does_not_exist_yet();
+	test_folder_that_exists();
+	test_wording();
+
+	if (failures != 0) {
+		printf("\n%d check%s failed\n", failures, failures == 1 ? "" : "s");
+		return EXIT_FAILURE;
+	}
+	puts("\nall HostFS advice checks passed");
+	return EXIT_SUCCESS;
+}

--- a/tests/test_hostfs_path.c
+++ b/tests/test_hostfs_path.c
@@ -301,10 +301,58 @@ test_control_characters_refused(void)
 	    strcmp(out, "C:/my folder") == 0);
 }
 
+/*
+ * The parent of a resolved root, used to tell "not there yet" from "stale".
+ *
+ * ★ WHY THE DIFFERENCE MATTERS. HostFS creates its root and every missing level
+ * above it, so a machine whose absolute hostfs_path pointed inside a data folder
+ * that has since moved does not fail: the old tree is recreated empty and the
+ * guest boots from a blank disc. Confirmed by moving a data folder and watching
+ * the old tree reappear. The parent test is what separates that from somebody
+ * asking for a new folder on a drive that does exist, so it decides whether the
+ * log says anything useful.
+ */
+static void
+test_parent(void)
+{
+	char out[1024];
+
+	puts("The parent of a path, for spotting a stale absolute path:");
+
+	check("a Unix path gives the directory above",
+	    hostfs_path_parent("/data/machines/Box/hostfs", out, sizeof(out)) &&
+	    strcmp(out, "/data/machines/Box") == 0);
+	check("backslashes are understood the same way",
+	    hostfs_path_parent("D:\\data\\Box\\hostfs", out, sizeof(out)) &&
+	    strcmp(out, "D:/data/Box") == 0);
+	check("a trailing separator does not shift the answer",
+	    hostfs_path_parent("/data/Box/hostfs/", out, sizeof(out)) &&
+	    strcmp(out, "/data/Box") == 0);
+
+	/* The two cases where the obvious answer is the wrong one. */
+	check("under the root, the parent is the root",
+	    hostfs_path_parent("/hostfs", out, sizeof(out)) &&
+	    strcmp(out, "/") == 0);
+	check("on a drive, the parent is that drive's ROOT and not 'C:'",
+	    hostfs_path_parent("C:/foo", out, sizeof(out)) &&
+	    strcmp(out, "C:/") == 0);
+
+	/* And where there is no useful answer, say so rather than invent one: "."
+	   would send the caller to test the working directory by accident. */
+	check("a bare leaf has no parent to test",
+	    hostfs_path_parent("hostfs", out, sizeof(out)) == 0);
+	check("nor does an empty path",
+	    hostfs_path_parent("", out, sizeof(out)) == 0);
+	check("nor NULL", hostfs_path_parent(NULL, out, sizeof(out)) == 0);
+	check("a buffer too small is refused, not truncated",
+	    hostfs_path_parent("/data/machines/Box/hostfs", out, 4) == 0);
+}
+
 int
 main(void)
 {
 	test_default();
+	test_parent();
 	test_relative();
 	test_absolute();
 	test_truncation_is_refused();

--- a/tests/test_hostfs_path.c
+++ b/tests/test_hostfs_path.c
@@ -231,6 +231,76 @@ test_same_root(void)
 	}
 }
 
+/*
+ * A hand-edited Windows path, after wxFileConfig has unescaped it.
+ *
+ * ★ WHERE THIS CAME FROM. Testing the Windows build under Wine, a config file
+ * written by hand with
+ *
+ *     hostfs_path=C:\foo
+ *
+ * produced the log line "HostFS: root is 'C:oo'". wx escapes backslashes when it
+ * writes a value and unescapes them when it reads one, so a file the emulator
+ * wrote is fine and a hand-edited one is not. What comes back depends on the
+ * letter, and these are the measured results, from reading a hand-written file
+ * with wxFileConfig:
+ *
+ *     C:\temp -> "C:<09>emp"    C:\foo -> "C:oo"
+ *     C:\new  -> "C:<0a>ew"     C:\bar -> "C:ar"
+ *     C:\run  -> "C:<0d>un"
+ *
+ * The left column names directories Windows will not create, so HostFS served a
+ * folder that was not there and the guest's disc looked empty with nothing to
+ * connect it to the file that had been edited. Those are refused.
+ *
+ * ★ THE RIGHT COLUMN IS NOT DETECTABLE, and this test says so out loud rather
+ * than leaving a reader to assume the whole class is handled. "C:oo" is a
+ * well-formed drive-relative path and nothing here can tell it from one somebody
+ * meant.
+ */
+static void
+test_control_characters_refused(void)
+{
+	char out[1024];
+
+	puts("A setting with control characters in it is refused:");
+
+	/* The three escapes wx actually translates. */
+	check("a tab, from an unescaped \\t in C:\\temp, is refused",
+	    hostfs_path_resolve("C:\temp", "/data/machines/Box/", out,
+	        sizeof(out)) == 0);
+	check("and nothing is left in the buffer to be used by mistake",
+	    out[0] == '\0');
+	check("a newline, from \\n in C:\\new, is refused",
+	    hostfs_path_resolve("C:\new", "/data/machines/Box/", out,
+	        sizeof(out)) == 0);
+	check("a carriage return, from \\r in C:\\run, is refused",
+	    hostfs_path_resolve("C:\run", "/data/machines/Box/", out,
+	        sizeof(out)) == 0);
+	/* Not one wx produces, but it is in the same class and free to cover. */
+	check("a form feed is refused too",
+	    hostfs_path_resolve("C:\f" "oo", "/data/machines/Box/", out,
+	        sizeof(out)) == 0);
+
+	puts("What cannot be caught is recorded rather than implied:");
+	/* C:\foo loses the backslash AND the f. The result is indistinguishable
+	   from a path somebody meant to type, so it is used - deliberately, and
+	   documented in docs/hostfs.md, which says to use forward slashes by hand. */
+	check("C:\\foo arriving as 'C:oo' is used as given, undetectable",
+	    hostfs_path_resolve("C:oo", "/data/machines/Box/", out,
+	        sizeof(out)) != 0);
+	check("and it resolves to exactly that, not to the default",
+	    strcmp(out, "C:oo") == 0);
+
+	/* The boundary, so the check cannot creep upwards into real names. A space
+	   is not a control character and is legal in a folder name everywhere. */
+	check("a space is still allowed",
+	    hostfs_path_resolve("C:\\my folder", "/data/machines/Box/", out,
+	        sizeof(out)) != 0);
+	check("and resolves to the folder that was asked for",
+	    strcmp(out, "C:/my folder") == 0);
+}
+
 int
 main(void)
 {
@@ -238,6 +308,7 @@ main(void)
 	test_relative();
 	test_absolute();
 	test_truncation_is_refused();
+	test_control_characters_refused();
 	test_same_root();
 
 	if (failures != 0) {


### PR DESCRIPTION
Chasing David Ramsden's report that a new machine with HostFS pointed at `C:\foo` boots to a grey screen with no icon bar.

## What is actually happening

**Nothing is broken and nothing is lost.** An empty folder is an empty hard disc, and RISC OS does not announce a missing `!Boot`. Reproduced on Linux *and* on the Windows build under Wine:

| RISC OS | Empty boot drive looks like |
| --- | --- |
| 5.31 | bare grey screen, mouse pointer, no icon bar, no banner |
| 5.30 | supervisor prompt, `Error: Use *Desktop to start TaskManager` |

So it is not Windows-specific and not a HostFS fault — it is the RISC OS version. David was on 5.31; a 5.30 machine shows something completely different. Pointing the setting back at the old folder restores the machine, as he found.

I also ran every Windows path form he might plausibly have typed (backslash, forward slash, trailing separator, `C:\a\b\c` needing recursive creation, spaces, relative, default). All seven resolve and create correctly. The path handling is sound.

## The real defect

The editor already warned "there is no !Boot here", but only in the branch where the chosen folder **already existed**. A folder that is about to be created is necessarily empty, so that was the one case that always needed the warning and never got it. Both branches read correctly in isolation, which is why it survived review.

- The decision moves out of the dialog into `src/hostfs_advice.c`, so it is testable on every platform without a wx build: `tests/test_hostfs_advice.c`.
- Confirmed the test catches it by restoring the old decision and watching exactly the two relevant checks fail.
- The wording now names **both** symptoms. The old text promised the supervisor prompt, so on 5.31 — the version ROOL are shipping — it described something the user would never see.

## A second bug, found only because of Wine

A hand-edited config is silently mangled. `wxFileConfig` escapes backslashes on write and unescapes on read, so a file the emulator wrote round-trips and one edited by hand does not. Measured, not assumed:

```
C:\temp -> "C:<tab>emp"      C:\foo -> "C:oo"
C:\new  -> "C:<newline>ew"   C:\bar -> "C:ar"
C:\run  -> "C:<CR>un"
```

The control characters name directories Windows will not create, so HostFS served a folder that was not there and the guest's disc appeared empty — with nothing to connect it to the file that had been edited. Those are now **refused**, falling back to the machine's own folder with a line in the log. Verified end to end on the Windows binary: it now reaches the desktop where it previously came up blank.

The other two **cannot be caught** — an unrecognised escape loses both characters, and `C:oo` is a well-formed drive-relative path. Said plainly in the code, the test and the docs rather than left looking handled. Guidance is to use forward slashes by hand.

## Testing the Windows build on Linux

`build-windows.sh` skipped the suite on a cross build because a Linux host "cannot execute .exe files". It can, under Wine, and **all 32 pass**. It finds `wine64`/`wine`/`/usr/lib/wine/wine64` by itself and sets `CMAKE_CROSSCOMPILING_EMULATOR`; `RPCEMU_SKIP_WINE_TESTS=1` opts out. `WINEPATH` is set for the run, without which every test exits 53 (a Windows "DLL not found" with no message, which reads like a crash).

Wine is not Windows; the `windows-amd64` CI job remains the authority. It is enough to catch what it catches, which today was a real bug.

Also fixed: `boot_smoke.py` could not run here at all. `port_is_free()` demanded both IPv4 and IPv6, and this host has no IPv6 loopback, so all 64 candidates "failed" and it reported "no free port found" — sending you after a stray listener that never existed. IPv6 is now required only where it exists, and the reason is printed.

## Verification

- 32 tests on Linux, 32 on the Windows build under Wine
- warnings gate clean (none from code we maintain)
- `cli_smoke.sh` passes against both the Linux binary and the Windows one under Wine
- boot screens captured for 5.30 and 5.31, empty and normal, on both builds
- macOS not exercised locally; covered by CI and by the platform-independent tests

## Not done, for you to judge

Nothing offers to **copy or move** the existing disc contents when you change the folder. The editor now warns it will be empty, which addresses the confusion, but "move my files there" is the friendlier answer and is a bigger change than this.