### PR TITLE
Offer to move the files when a HostFS or data folder is pointed somewhere new

### DIFF
--- a/docs/hostfs.md
+++ b/docs/hostfs.md
@@ -150,6 +150,67 @@ this section rather than a bug that can be fixed.
 Measured by reading a hand-written file with `wxFileConfig`, not assumed; the
 results are pinned in `tests/test_hostfs_path.c`.
 
+## Taking your files with you
+
+Point HostFS somewhere new and RPCEmu offers to bring the files across:
+
+    Your files are in:
+        /home/you/RPCEmu/machines/Box/hostfs
+    The new folder is:
+        /mnt/data/riscos
+
+    There is 412 MB to bring across.
+
+    Move - the files are copied and checked, and only then removed from the old
+    folder.
+    Copy - the old folder is left exactly as it is, so it doubles as a backup.
+    Needs room for both.
+
+    Either way, please make sure you have a backup first: this is your hard disc.
+    Nothing is deleted until every file has been copied and checked, but an
+    automatic move is not a substitute for a backup.
+
+      [ Move my files ]  [ Copy my files ]  [ I'll do it myself ]  [ Cancel ]
+
+"I'll do it myself" is the old behaviour: the setting changes, the files stay put,
+and the warning above about an empty disc applies until you move them.
+
+A progress window names each file with a running count and a remaining time, and
+its Cancel leaves everything as it was.
+
+### What makes it safe
+
+- **The setting is only changed after the transfer has succeeded.** If anything
+  fails part way, both copies are still on disc and the machine still boots from the
+  folder it was booting from before. A failed move is then an inconvenience rather
+  than a lost hard disc, which matters more than any wording, because people click
+  through warnings.
+- **Nothing is deleted until every file has been copied *and verified*** — MD5 on
+  both sides, not a size comparison. A copy truncated by a disc filling up has the
+  wrong content and the right length often enough to matter.
+- **A move within one filesystem is a rename**, so it is instant whatever the size
+  and cannot half-happen.
+- **A destination with files in it is refused, never merged.** Deciding which copy
+  of a clashing file wins is not a choice RPCEmu should make silently. Checked
+  twice: once when deciding what to offer, and again inside the transfer itself,
+  because the cleanup-on-failure step deletes everything at the destination and is
+  only safe if everything there is ours.
+- **It is refused outright while a machine is running from either folder.** HostFS
+  opens files as the guest asks for them, so moving them under a live machine would
+  damage whatever it read next.
+- **Free space is checked first**, with a margin, since a copy that exactly fills
+  the disc leaves nothing for the machine to write afterwards.
+
+The decision is `src/folder_move.c` (pure, `tests/test_folder_move.c`); the doing
+is `src/gui/folder_transfer.cpp` (`tests/test_folder_transfer.cpp`, which runs the
+real copy, verify and delete on real files, including a transfer that fails half
+way).
+
+The same offer is made for the **data folder**, from Options > Data Folder in the
+machine selector, where it moves the machines, ROMs and settings together. That one
+takes effect on restart, and closes the log file first because it lives in the
+folder being moved and Windows will not move an open file.
+
 ## Moving the data folder
 
 The *relative* form travels: a machine with `hostfs_path=disc` resolves under

--- a/docs/paths.md
+++ b/docs/paths.md
@@ -89,16 +89,34 @@ Exactly one of the 512 possible input combinations produces a dialogue, and
 
 On the machine selector, *Options ▾ → **Data Folder…***, then restart.
 
-It lives there and not on a running machine's Settings menu on purpose: the data
-folder is where *every* machine lives, so it is not a property of whichever one
-happens to be loaded, and the moment you want to change it is before choosing a
-machine rather than after.
+**You are offered a move or a copy**, and can still decline both:
 
-**Nothing is copied or moved.** Only the pointer changes. Relocating machines,
-discs and ROMs that may be gigabytes and may be open is how data gets lost, so the
-offer is the honest one, and the dialogue says what it means before doing it: if
-the new folder is empty you will start with no machines and a freshly seeded
-folder, the old folder is untouched, and you can point back at any time.
+| | |
+| --- | --- |
+| **Move my files** | The machines, ROMs and settings are brought across and the old folder emptied. Within one filesystem this is a rename, so it is instant. |
+| **Copy my files** | The same, but the old folder is left exactly as it is, so it doubles as a backup. Needs room for both. |
+| **I'll do it myself** | Only the pointer changes, which is what this used to do unconditionally. If the new folder is empty you start with no machines and a freshly seeded folder; the old one is untouched and you can point back at any time. |
+| **Cancel** | Nothing changes at all. |
+
+Either transfer takes effect on **restart**, like every other change to this
+setting. The rules that keep it safe — verified before anything is deleted, the
+pointer only changed once the files have arrived, a destination with files in it
+refused rather than merged — are in [hostfs.md](hostfs.md#what-makes-it-safe),
+since the same machinery does both folders.
+
+Two things specific to the data folder:
+
+- **The log file is closed first.** `rpclog.txt` lives in the folder being moved
+  and RPCEmu is holding it open; Windows will not move an open file. It reopens at
+  the new location on the next message.
+- **It is refused while any machine in either folder is running**, including one
+  belonging to a second copy of RPCEmu. Asked by trying to take each machine's
+  lock rather than by looking for a lock *file*, because the file outlives a crash
+  and would refuse the move for a machine that stopped running last week.
+
+It lives on the selector and not on a running machine's Settings menu on purpose:
+the data folder is where *every* machine lives, so it is not a property of
+whichever one happens to be loaded.
 
 ## The payload is a separate question
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,7 +64,7 @@ when CI gets to it. Nothing to pass: it looks for `wine64`, then `wine`, then
 apt install wine64          # the loader; the `wine` wrapper is a separate package
 ./build-windows.sh
 ==> Running the Windows test suite under Wine (/usr/lib/wine/wine64)
-==> [wine] all 32 tests passed
+==> [wine] all 34 tests passed
 ```
 
 Set `RPCEMU_SKIP_WINE_TESTS=1` to opt out.
@@ -84,8 +84,8 @@ pointed at the Windows binary, and how the RISC OS 5.31 empty-HostFS screen in
 
 ## What the suite covers
 
-Thirty tests, twenty-two of which build on every platform and eight of which
-need a native recompiler backend.
+Thirty-four tests, twenty-six of which build on every platform and eight of
+which need a native recompiler backend.
 
 | Test | Covers |
 | --- | --- |
@@ -115,6 +115,8 @@ need a native recompiler backend.
 | `test_openbus_decode` | that the machine's own memory decode reaches a fitted card, which an unhooked window would hide |
 | `test_hostfs_path` | where a machine's HostFS drive resolves to, on all three platforms |
 | `test_hostfs_advice` | what the machine editor warns about when a HostFS folder is chosen |
+| `test_folder_move` | whether moving somebody's files can be offered: empty destination, free space, in use |
+| `test_folder_transfer` | the transfer itself on real files, including one that fails half way through |
 | `test_data_dir` | which data directory is used, and above all when the user is asked |
 | `test_held_keys` | which keys the guest believes are held, when several map to one |
 | `test_machine_selector` | the VNC machine selector's navigation and drawing |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ set(RPCEMU_CORE_SOURCES
     keyboard.c
     openbus.c
     openbus_stub.c
+    folder_move.c
     hostfs_advice.c
     hostfs_path.c
     mem.c

--- a/src/folder_move.c
+++ b/src/folder_move.c
@@ -1,0 +1,172 @@
+/*
+  RPCEmu - An Acorn system emulator
+
+  Copyright (C) 2026 Andy Timmins
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+/*
+ * folder_move.c - whether moving somebody's files can be offered.
+ *
+ * The reasoning is in folder_move.h.
+ */
+
+#include "folder_move.h"
+
+#include <stddef.h>
+
+/*
+ * Spare room to leave behind, as a fraction of what is being copied plus a
+ * fixed floor.
+ *
+ * A copy that exactly fits leaves the destination completely full, which breaks
+ * the next thing to write there - quite possibly the guest, a moment later,
+ * having just been pointed at it. The floor matters for small discs, where a
+ * percentage of a few megabytes is no margin at all.
+ */
+#define SPACE_MARGIN_DIVISOR	20		/* 5% */
+#define SPACE_MARGIN_FLOOR	(16u * 1024u * 1024u)	/* 16 MB */
+
+int
+folder_move_space_is_enough(unsigned long long bytes_needed,
+                            unsigned long long bytes_free)
+{
+	unsigned long long margin;
+	unsigned long long required;
+
+	/* Nothing known: the caller could not measure, so this is not the place to
+	   refuse. Said in the header so nobody reads it as an oversight. */
+	if (bytes_needed == 0 && bytes_free == 0) {
+		return 1;
+	}
+
+	margin = bytes_needed / SPACE_MARGIN_DIVISOR;
+	if (margin < SPACE_MARGIN_FLOOR) {
+		margin = SPACE_MARGIN_FLOOR;
+	}
+
+	required = bytes_needed + margin;
+	/* Overflow would wrap and turn "far too big" into "plenty of room". */
+	if (required < bytes_needed) {
+		return 0;
+	}
+	return bytes_free >= required;
+}
+
+folder_move_offer
+folder_move_decide(const folder_move_facts *facts, folder_move_reason *why)
+{
+	folder_move_reason reason = FOLDER_MOVE_OK;
+	folder_move_offer offer = FOLDER_MOVE_OFFER_NOTHING;
+
+	if (facts == NULL) {
+		if (why != NULL) {
+			*why = FOLDER_MOVE_SOURCE_MISSING;
+		}
+		return FOLDER_MOVE_OFFER_NOTHING;
+	}
+
+	/*
+	 * Order matters, because the first thing that is true is what the user gets
+	 * told. In use comes first: it is the only one that could destroy a running
+	 * machine's files, and it is worth saying even when something else is also
+	 * wrong.
+	 */
+	if (facts->in_use) {
+		reason = FOLDER_MOVE_IN_USE;
+	} else if (facts->same_place) {
+		reason = FOLDER_MOVE_SAME_PLACE;
+	} else if (!facts->source_exists || !facts->source_is_dir) {
+		reason = FOLDER_MOVE_SOURCE_MISSING;
+	} else if (facts->source_empty) {
+		/* Nothing to bring across. Not a failure - this is the ordinary case of
+		   somebody pointing a brand new machine somewhere. */
+		reason = FOLDER_MOVE_SOURCE_EMPTY;
+	} else if (facts->dest_exists && !facts->dest_is_dir) {
+		reason = FOLDER_MOVE_DEST_NOT_A_DIR;
+	} else if (facts->dest_exists && !facts->dest_empty) {
+		reason = FOLDER_MOVE_DEST_NOT_EMPTY;
+	} else if (!facts->dest_parent_writable) {
+		reason = FOLDER_MOVE_DEST_READ_ONLY;
+	} else if (!folder_move_space_is_enough(facts->bytes_needed,
+	                                       facts->bytes_free)) {
+		reason = FOLDER_MOVE_NO_SPACE;
+	} else if (!facts->source_writable) {
+		/*
+		 * The files can be copied but the originals cannot be removed. Offering
+		 * the copy is still worth it: the machine ends up working, which is what
+		 * was wanted, and the leftovers are visible rather than lost.
+		 */
+		reason = FOLDER_MOVE_SOURCE_READ_ONLY;
+		offer = FOLDER_MOVE_OFFER_COPY_ONLY;
+	} else {
+		offer = FOLDER_MOVE_OFFER_BOTH;
+	}
+
+	if (why != NULL) {
+		*why = reason;
+	}
+	return offer;
+}
+
+const char *
+folder_move_reason_text(folder_move_reason why)
+{
+	switch (why) {
+	case FOLDER_MOVE_OK:
+		return "The files can be moved or copied.";
+
+	case FOLDER_MOVE_SAME_PLACE:
+		return "That is the folder already in use, so there is nothing to move.";
+
+	case FOLDER_MOVE_SOURCE_EMPTY:
+		return "The current folder is empty, so there is nothing to move.";
+
+	case FOLDER_MOVE_SOURCE_MISSING:
+		return "The current folder is not there, so there is nothing to move.";
+
+	case FOLDER_MOVE_DEST_NOT_EMPTY:
+		return "The new folder already has files in it. RPCEmu will not mix two "
+		       "sets of files together, because deciding which copy of a clashing "
+		       "file wins is not a choice it should make for you. Either empty "
+		       "the new folder or move the files across yourself.";
+
+	case FOLDER_MOVE_DEST_NOT_A_DIR:
+		return "The new location is a file, not a folder.";
+
+	case FOLDER_MOVE_NO_SPACE:
+		return "There is not enough free space where the files are going, once a "
+		       "small margin is allowed for. A copy that exactly fills the disc "
+		       "leaves nothing for the machine to write afterwards.";
+
+	case FOLDER_MOVE_IN_USE:
+		return "A machine is still running from one of these folders. Close it "
+		       "first: RPCEmu opens files as the guest asks for them, so moving "
+		       "them now would damage whatever it reads next.";
+
+	case FOLDER_MOVE_DEST_READ_ONLY:
+		return "The new folder cannot be written to.";
+
+	case FOLDER_MOVE_SOURCE_READ_ONLY:
+		return "The files can be copied, but the originals cannot be removed "
+		       "afterwards, so they will be left where they are.";
+	}
+
+	/* Not reachable for a value from the enumeration, and deliberately not a
+	   NULL: a caller showing this to somebody should never end up showing
+	   nothing at all. */
+	return "The files cannot be moved automatically.";
+}

--- a/src/folder_move.h
+++ b/src/folder_move.h
@@ -1,0 +1,153 @@
+/*
+  RPCEmu - An Acorn system emulator
+
+  Copyright (C) 2026 Andy Timmins
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifndef FOLDER_MOVE_H
+#define FOLDER_MOVE_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Should we offer to move somebody's files for them, and if not, why not?
+ *
+ * Choosing a new HostFS folder, or a new data folder, used to leave the files
+ * where they were: the new folder was created empty and the machine booted from a
+ * blank disc. The editor warns about that now, but a warning is a poor substitute
+ * for doing the thing the user obviously wanted, so this decides whether the
+ * offer can be made safely.
+ *
+ * ★ THE DECISION IS SEPARATED FROM THE DOING ON PURPOSE. Copying a hard disc is
+ * the most destructive thing this program does on the host's filesystem, and the
+ * conditions that make it unsafe - a destination with files already in it, not
+ * enough room, a machine still running from the folder - are exactly the things
+ * that are awkward to arrange in a test. So the rules live here, pure, with the
+ * filesystem answers passed in, and tests/test_folder_move.c can put any
+ * combination to them.
+ *
+ * The transfer itself is src/gui/folder_transfer.cpp, which asks this first.
+ */
+
+/** What the caller may offer. */
+typedef enum {
+	/** Both a move and a copy are safe to offer. */
+	FOLDER_MOVE_OFFER_BOTH,
+	/**
+	 * A copy is safe but a move is not, because the source cannot be removed
+	 * afterwards. Offered rather than refused: getting the files there is the
+	 * point, and tidying up afterwards is the user's business.
+	 */
+	FOLDER_MOVE_OFFER_COPY_ONLY,
+	/** Nothing can be offered. There is a reason, below. */
+	FOLDER_MOVE_OFFER_NOTHING
+} folder_move_offer;
+
+/** Why nothing can be offered, or why only a copy can be. */
+typedef enum {
+	FOLDER_MOVE_OK,
+	/** The two paths resolve to the same place, so there is nothing to do. */
+	FOLDER_MOVE_SAME_PLACE,
+	/** Nothing in the old folder to bring across. */
+	FOLDER_MOVE_SOURCE_EMPTY,
+	/** The old folder is not there at all. */
+	FOLDER_MOVE_SOURCE_MISSING,
+	/**
+	 * The new folder already has files in it. Never merged: two hard discs
+	 * interleaved is not something anybody asked for, and picking which copy of
+	 * a clashing file wins is not a decision this program should make silently.
+	 */
+	FOLDER_MOVE_DEST_NOT_EMPTY,
+	/** The new folder is a file, or otherwise cannot hold anything. */
+	FOLDER_MOVE_DEST_NOT_A_DIR,
+	/** Not enough free space at the destination for what is being copied. */
+	FOLDER_MOVE_NO_SPACE,
+	/**
+	 * A machine is running from one of these folders. Refused outright: HostFS
+	 * opens files as the guest asks for them, so moving them underneath a live
+	 * machine would corrupt whatever it touches next.
+	 */
+	FOLDER_MOVE_IN_USE,
+	/** The destination cannot be written to. */
+	FOLDER_MOVE_DEST_READ_ONLY,
+	/** The source cannot be removed, so only a copy can be offered. */
+	FOLDER_MOVE_SOURCE_READ_ONLY
+} folder_move_reason;
+
+/** What the filesystem says about the two folders. Gathered by the caller. */
+typedef struct {
+	int same_place;		/**< The two paths are the same directory. */
+	int source_exists;
+	int source_is_dir;
+	int source_writable;	/**< Can its contents be removed afterwards? */
+	int source_empty;
+	int dest_exists;
+	int dest_is_dir;	/**< Meaningless when dest_exists is zero. */
+	int dest_empty;
+	int dest_parent_writable; /**< Can the destination be created or written? */
+	int in_use;		/**< A machine is running from either folder. */
+
+	/**
+	 * Bytes to bring across, and bytes free where they are going.
+	 *
+	 * Both zero means "not known" and the space check is skipped: a caller that
+	 * cannot measure should not be forced to guess, and refusing on an unknown
+	 * would stop the feature working on any filesystem we cannot size.
+	 */
+	unsigned long long bytes_needed;
+	unsigned long long bytes_free;
+} folder_move_facts;
+
+/**
+ * Decide what to offer.
+ *
+ * @param facts What the filesystem says.
+ * @param why   Filled in with the reason. FOLDER_MOVE_OK when both are offered.
+ *              May be NULL.
+ * @return What may be offered.
+ */
+folder_move_offer folder_move_decide(const folder_move_facts *facts,
+                                     folder_move_reason *why);
+
+/**
+ * A sentence explaining a reason, for putting in front of the user.
+ *
+ * Never NULL, so a caller cannot accidentally show nothing. Phrased as the reason
+ * the offer is not being made, since that is the only time it is shown.
+ */
+const char *folder_move_reason_text(folder_move_reason why);
+
+/**
+ * Is there enough room, allowing for the margin?
+ *
+ * Exposed for the tests, and because the margin is a judgement rather than a
+ * fact: filling a disc completely is its own kind of failure, so a copy that
+ * would leave nothing spare is refused before it starts rather than half way
+ * through.
+ */
+int folder_move_space_is_enough(unsigned long long bytes_needed,
+                                unsigned long long bytes_free);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FOLDER_MOVE_H */

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -20,6 +20,7 @@ set(GUI_SOURCES
     input_helpers.cpp
     config_selector_dialog.cpp
     config_paths.cpp
+    folder_transfer.cpp
     machine_edit_dialog.cpp
     new_machine_dialog.cpp
     guest_command.cpp

--- a/src/gui/config_selector_dialog.cpp
+++ b/src/gui/config_selector_dialog.cpp
@@ -35,7 +35,10 @@
 #include <wx/progdlg.h>
 #include <wx/textdlg.h>
 
+#include "folder_transfer.h"
+
 extern "C" {
+#include "machine_lock.h"
 #include "rpcemu.h"
 #include "savestate.h"
 }
@@ -589,14 +592,62 @@ void ConfigSelectorDialog::OnOptions(wxCommandEvent &)
 }
 
 /*
- * Point RPCEmu at a different data folder.
+ * Is any machine in this data folder being used by a running RPCEmu?
  *
- * Only the pointer changes: nothing is copied or moved. Relocating machines,
- * discs and ROMs that may be gigabytes and may be open is how data gets lost, so
- * the honest offer is "look somewhere else", and the dialogue says what that
- * means before doing it. An empty folder means an empty machine list, which to
- * somebody expecting their machines to follow is indistinguishable from having
- * lost them, so it is spelled out.
+ * Asked by trying to take each machine's lock, not by looking for a lock FILE.
+ * The file is only a hint - it survives a crash, so its presence would refuse the
+ * move for a machine that stopped running last Tuesday. The lock underneath it is
+ * an flock, which the kernel drops when the holder dies, so acquiring it is an
+ * accurate answer. Anything taken here is given straight back.
+ *
+ * Nothing of ours is running: this dialogue is the machine selector, shown before
+ * a machine starts. The point is the OTHER RPCEmu that might be, on the same data
+ * folder, writing to a disc while we copy it.
+ */
+static bool AnyMachineInUse(const wxString &datadir)
+{
+	const wxString machines = datadir + wxFileName::GetPathSeparator() +
+	    "machines";
+
+	if (!wxDirExists(machines)) {
+		return false;
+	}
+
+	wxDir dir(machines);
+	if (!dir.IsOpened()) {
+		/* Cannot tell. Say yes: refusing to move somebody's files is a nuisance,
+		   copying them out from under a live machine is not. */
+		return true;
+	}
+
+	wxString name;
+	bool more = dir.GetFirst(&name, wxEmptyString, wxDIR_DIRS);
+	while (more) {
+		const wxString machine_dir = machines +
+		    wxFileName::GetPathSeparator() + name +
+		    wxFileName::GetPathSeparator();
+
+		if (machine_lock_acquire(machine_dir.utf8_str().data(), 0) != 0) {
+			return true;
+		}
+		machine_lock_release();
+		more = dir.GetNext(&name);
+	}
+	return false;
+}
+
+/*
+ * Point RPCEmu at a different data folder, and offer to take the files along.
+ *
+ * It used to only change the pointer, on the grounds that relocating machines,
+ * discs and ROMs that may be gigabytes and may be open is how data gets lost. That
+ * is a fair worry but the wrong conclusion: somebody who moves their data folder
+ * wants their machines to follow, and leaving them behind produces exactly the
+ * "where have my machines gone" moment the old wording had to apologise for.
+ *
+ * So the files are offered a lift, under the rules in folder_transfer.h - verified
+ * before anything is deleted, and the pointer only changed once they have arrived.
+ * Declining still works exactly as it did before.
  */
 void ConfigSelectorDialog::OnChooseDataDir()
 {
@@ -617,6 +668,53 @@ void ConfigSelectorDialog::OnChooseDataDir()
 		return;
 	}
 
+	/*
+	 * The offer comes first, because it decides what the confirmation should
+	 * say. Telling somebody their machines stay behind and then offering to move
+	 * them would be two dialogues arguing with each other.
+	 */
+	unsigned long long bytes = 0;
+	const folder_move_facts facts = FolderTransferGatherFacts(current, chosen,
+	    AnyMachineInUse(current) || AnyMachineInUse(chosen), &bytes);
+	folder_move_reason why = FOLDER_MOVE_OK;
+	const folder_move_offer offer = folder_move_decide(&facts, &why);
+	FolderTransferChoice choice = FolderTransferChoice::Manual;
+
+	if (offer != FOLDER_MOVE_OFFER_NOTHING ||
+	    (why != FOLDER_MOVE_SAME_PLACE && why != FOLDER_MOVE_SOURCE_EMPTY &&
+	     why != FOLDER_MOVE_SOURCE_MISSING)) {
+		choice = FolderTransferAsk(this, "data folder", current, chosen, offer,
+		    why, bytes);
+		if (choice == FolderTransferChoice::Cancel) {
+			return;
+		}
+	}
+
+	if (choice == FolderTransferChoice::Move ||
+	    choice == FolderTransferChoice::Copy) {
+		/* The log lives in the folder being moved and we are holding it open;
+		   Windows will not move an open file. Reopens at the new location on the
+		   next message. */
+		rpclog_close();
+
+		const FolderTransferResult result = FolderTransferRun(this, current,
+		    chosen, choice);
+
+		if (!result.ok) {
+			wxMessageBox(result.message, "The files were not moved",
+			    wxOK | wxICON_ERROR, this);
+			/* Pointer left where it was, so the machines are still found. */
+			return;
+		}
+		SetDataDir(chosen.utf8_string());
+		wxMessageBox(result.message + "\n\nRestart RPCEmu for the new data "
+		    "folder to take effect.", "RPCEmu Extended - Data Folder",
+		    wxOK | wxICON_INFORMATION, this);
+		return;
+	}
+
+	/* Manual: the old behaviour, and the old warning, which is still the right
+	   thing to say when the files are staying where they are. */
 	const wxString message = wxString::Format(
 	    "RPCEmu will use:\n%s\n\n"
 	    "Your existing machines, discs and ROMs are NOT moved. They stay in:\n%s\n\n"

--- a/src/gui/folder_transfer.cpp
+++ b/src/gui/folder_transfer.cpp
@@ -446,7 +446,23 @@ FolderTransferRun(wxWindow *parent, const wxString &from, const wxString &to,
 		 * code - which is the destructive part, and the part worth testing - on a
 		 * console build with no display, including in CI.
 		 */
-		const bool have_gui = (wxTheApp != nullptr && wxTheApp->IsGUI());
+		/*
+		 * ★ wxAppConsole::GetInstance(), NOT wxTheApp.
+		 *
+		 * wxTheApp is a macro that DOWNCASTS the application object to wxApp*,
+		 * and in a console program - which is exactly what the test is - the
+		 * object is a wxAppConsole and never was a wxApp. The cast is undefined
+		 * behaviour even though the pointer is only tested and IsGUI() is virtual
+		 * on the base, and UBSan says so:
+		 *
+		 *   runtime error: downcast of address 0x... which does not point to an
+		 *   object of type 'wxApp'
+		 *
+		 * Caught by the sanitiser job, in the first version of this file. Asking
+		 * the base class needs no cast and answers the same question.
+		 */
+		const wxAppConsole *const app = wxAppConsole::GetInstance();
+		const bool have_gui = (app != nullptr && app->IsGUI());
 		std::unique_ptr<wxProgressDialog> progress;
 
 		const int total = (int) listing.files.size();

--- a/src/gui/folder_transfer.cpp
+++ b/src/gui/folder_transfer.cpp
@@ -1,0 +1,550 @@
+/*
+  RPCEmu - An Acorn system emulator
+
+  Copyright (C) 2026 Andy Timmins
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+/*
+ * folder_transfer.cpp - bringing somebody's files across to a new folder.
+ *
+ * The properties this has to have are in folder_transfer.h. The short version:
+ * verify before deleting, and never touch the configuration until the files have
+ * arrived.
+ */
+
+#include "folder_transfer.h"
+
+#include <wx/wx.h>
+#include <wx/dir.h>
+#include <wx/filename.h>
+#include <wx/progdlg.h>
+#include <wx/stattext.h>
+
+#include <cstdio>
+#include <memory>
+#include <vector>
+
+extern "C" {
+#include "md5.h"
+#include "rpcemu.h"
+}
+
+namespace {
+
+/* Files and directories under a root, relative to it, directories first so they
+   can be created before the files that go in them. */
+struct TreeListing {
+	std::vector<wxString> dirs;
+	std::vector<wxString> files;
+	unsigned long long bytes = 0;
+	bool ok = false;
+};
+
+void
+ListTree(const wxString &root, const wxString &prefix, TreeListing &out)
+{
+	const wxChar sep = wxFileName::GetPathSeparator();
+	wxDir dir(root + (prefix.empty() ? "" : wxString(sep) + prefix));
+
+	if (!dir.IsOpened()) {
+		out.ok = false;
+		return;
+	}
+
+	wxString name;
+	bool more = dir.GetFirst(&name, wxEmptyString, wxDIR_FILES | wxDIR_HIDDEN);
+	while (more) {
+		const wxString rel = prefix.empty() ? name : prefix + sep + name;
+
+		out.files.push_back(rel);
+		out.bytes += (unsigned long long) wxFileName::GetSize(
+		    root + sep + rel).GetValue();
+		more = dir.GetNext(&name);
+	}
+
+	more = dir.GetFirst(&name, wxEmptyString, wxDIR_DIRS | wxDIR_HIDDEN);
+	while (more) {
+		const wxString rel = prefix.empty() ? name : prefix + sep + name;
+
+		out.dirs.push_back(rel);
+		ListTree(root, rel, out);
+		if (!out.ok) {
+			return;
+		}
+		more = dir.GetNext(&name);
+	}
+	out.ok = true;
+}
+
+TreeListing
+ListTree(const wxString &root)
+{
+	TreeListing out;
+
+	out.ok = true;
+	ListTree(root, wxEmptyString, out);
+	return out;
+}
+
+/* Is a directory empty? A directory holding only empty directories counts as
+   empty for this purpose: there is nothing in it to lose. */
+bool
+DirIsEmpty(const wxString &path)
+{
+	const TreeListing listing = ListTree(path);
+
+	return listing.ok && listing.files.empty();
+}
+
+/* Can we write here? Asked by writing, because every other answer (permissions,
+   read-only mounts, Windows ACLs) is a guess. */
+bool
+CanWriteIn(const wxString &dir)
+{
+	const wxString probe = dir + wxFileName::GetPathSeparator() +
+	    ".rpcemu-write-test";
+
+	if (!wxDirExists(dir)) {
+		return false;
+	}
+	{
+		wxFile f;
+
+		if (!f.Create(probe, true)) {
+			return false;
+		}
+	}
+	wxRemoveFile(probe);
+	return true;
+}
+
+/*
+ * The nearest existing directory at or above `path`.
+ *
+ * Used to ask about writability and free space for a destination that does not
+ * exist yet: the questions have to be put to something that is there.
+ */
+wxString
+NearestExisting(const wxString &path)
+{
+	wxFileName fn;
+
+	fn.AssignDir(path);
+	while (fn.GetDirCount() > 0 && !wxDirExists(fn.GetPath())) {
+		fn.RemoveLastDir();
+	}
+	return fn.GetPath();
+}
+
+/* Same file content, checked properly. A size comparison would pass for a copy
+   truncated by a full disc, which is exactly the failure this exists to catch. */
+bool
+SameContent(const wxString &a, const wxString &b)
+{
+	char hex_a[33];
+	char hex_b[33];
+
+	if (wxFileName::GetSize(a) != wxFileName::GetSize(b)) {
+		return false;
+	}
+	if (md5_file_hex(a.utf8_str().data(), hex_a) != 0) {
+		return false;
+	}
+	if (md5_file_hex(b.utf8_str().data(), hex_b) != 0) {
+		return false;
+	}
+	return memcmp(hex_a, hex_b, 32) == 0;
+}
+
+/*
+ * Remove a tree we created ourselves.
+ *
+ * Only ever called on a destination that folder_move_decide() confirmed was empty
+ * or absent before the transfer started, so everything in it was put there by us.
+ * That is the entire justification for a recursive delete living in this file.
+ */
+void
+RemoveOurTree(const wxString &root, bool remove_root)
+{
+	const TreeListing listing = ListTree(root);
+	const wxChar sep = wxFileName::GetPathSeparator();
+
+	if (!listing.ok) {
+		return;
+	}
+	for (const wxString &f : listing.files) {
+		wxRemoveFile(root + sep + f);
+	}
+	/* Deepest first, or a parent will not be empty when its turn comes. */
+	for (size_t i = listing.dirs.size(); i > 0; i--) {
+		wxRmdir(root + sep + listing.dirs[i - 1]);
+	}
+	if (remove_root) {
+		wxRmdir(root);
+	}
+}
+
+wxString
+Pretty(unsigned long long bytes)
+{
+	if (bytes >= 1024ull * 1024 * 1024) {
+		return wxString::Format("%.1f GB",
+		    (double) bytes / (1024.0 * 1024.0 * 1024.0));
+	}
+	if (bytes >= 1024ull * 1024) {
+		return wxString::Format("%.0f MB", (double) bytes / (1024.0 * 1024.0));
+	}
+	if (bytes >= 1024) {
+		return wxString::Format("%.0f KB", (double) bytes / 1024.0);
+	}
+	return wxString::Format("%llu bytes", bytes);
+}
+
+} /* namespace */
+
+folder_move_facts
+FolderTransferGatherFacts(const wxString &from, const wxString &to, bool in_use,
+                          unsigned long long *bytes)
+{
+	folder_move_facts f;
+
+	memset(&f, 0, sizeof(f));
+	f.in_use = in_use ? 1 : 0;
+
+	/* Normalised, so the same folder spelled two ways is recognised as the same
+	   folder and the user is told there is nothing to do. */
+	{
+		wxFileName a;
+		wxFileName b;
+
+		a.AssignDir(from);
+		b.AssignDir(to);
+		a.Normalize(wxPATH_NORM_ABSOLUTE | wxPATH_NORM_DOTS | wxPATH_NORM_TILDE);
+		b.Normalize(wxPATH_NORM_ABSOLUTE | wxPATH_NORM_DOTS | wxPATH_NORM_TILDE);
+		f.same_place = (a.GetPath() == b.GetPath()) ? 1 : 0;
+	}
+
+	f.source_exists = wxDirExists(from) || wxFileExists(from);
+	f.source_is_dir = wxDirExists(from) ? 1 : 0;
+	f.source_empty = f.source_is_dir ? (DirIsEmpty(from) ? 1 : 0) : 1;
+	f.source_writable = f.source_is_dir ? (CanWriteIn(from) ? 1 : 0) : 0;
+
+	f.dest_exists = (wxDirExists(to) || wxFileExists(to)) ? 1 : 0;
+	f.dest_is_dir = wxDirExists(to) ? 1 : 0;
+	f.dest_empty = f.dest_is_dir ? (DirIsEmpty(to) ? 1 : 0) : 1;
+
+	{
+		const wxString anchor = f.dest_is_dir ? to : NearestExisting(to);
+
+		f.dest_parent_writable = (!anchor.empty() && CanWriteIn(anchor)) ? 1 : 0;
+
+		if (f.source_is_dir) {
+			const TreeListing listing = ListTree(from);
+
+			f.bytes_needed = listing.ok ? listing.bytes : 0;
+		}
+		/*
+		 * Free space where the files are going. Left at zero when it cannot be
+		 * had: folder_move_space_is_enough() treats a pair of zeroes as "not
+		 * measured" and does not refuse, which is deliberate - a filesystem we
+		 * cannot size should not cost the user the feature.
+		 */
+		wxLongLong free_bytes;
+		if (!anchor.empty() && wxGetDiskSpace(anchor, NULL, &free_bytes)) {
+			f.bytes_free = (unsigned long long) free_bytes.GetValue();
+		} else {
+			f.bytes_needed = 0;
+			f.bytes_free = 0;
+		}
+	}
+
+	if (bytes != NULL) {
+		*bytes = f.source_is_dir ? ListTree(from).bytes : 0;
+	}
+	return f;
+}
+
+FolderTransferChoice
+FolderTransferAsk(wxWindow *parent, const wxString &what, const wxString &from,
+                  const wxString &to, folder_move_offer offer,
+                  folder_move_reason why, unsigned long long bytes)
+{
+	wxDialog dlg(parent, wxID_ANY, wxString::Format("Move your %s?", what));
+	wxBoxSizer *root = new wxBoxSizer(wxVERTICAL);
+
+	wxString text;
+
+	text << "Your files are in:\n    " << from << "\n\nThe new folder is:\n    "
+	     << to << "\n\n";
+
+	if (offer == FOLDER_MOVE_OFFER_NOTHING) {
+		text << folder_move_reason_text(why) << "\n\n"
+		     << "You can still change the setting and move the files across "
+		        "yourself.";
+	} else {
+		if (bytes > 0) {
+			text << "There is " << Pretty(bytes) << " to bring across.\n\n";
+		}
+		text << "Move - the files are copied and checked, and only then removed "
+		        "from the old folder.\n";
+		if (offer == FOLDER_MOVE_OFFER_BOTH) {
+			text << "Copy - the old folder is left exactly as it is, so it "
+			        "doubles as a backup. Needs room for both.\n";
+		} else {
+			text << "\n" << folder_move_reason_text(why) << "\n";
+		}
+		text << "\nEither way, please make sure you have a backup first: this is "
+		        "your "
+		     << what
+		     << ". Nothing is deleted until every file has been copied and "
+		        "checked, but an automatic move is not a substitute for a backup.";
+	}
+
+	root->Add(new wxStaticText(&dlg, wxID_ANY, text), 0, wxALL, 12);
+
+	wxBoxSizer *buttons = new wxBoxSizer(wxHORIZONTAL);
+	const int ID_MOVE = wxID_HIGHEST + 1;
+	const int ID_COPY = wxID_HIGHEST + 2;
+	const int ID_MANUAL = wxID_HIGHEST + 3;
+
+	if (offer != FOLDER_MOVE_OFFER_NOTHING) {
+		if (offer == FOLDER_MOVE_OFFER_BOTH) {
+			buttons->Add(new wxButton(&dlg, ID_MOVE, "Move my files"), 0,
+			    wxRIGHT, 8);
+		}
+		buttons->Add(new wxButton(&dlg, ID_COPY, "Copy my files"), 0, wxRIGHT, 8);
+	}
+	buttons->Add(new wxButton(&dlg, ID_MANUAL, "I'll do it myself"), 0,
+	    wxRIGHT, 8);
+	buttons->Add(new wxButton(&dlg, wxID_CANCEL, "Cancel"));
+	root->Add(buttons, 0, wxALIGN_RIGHT | wxALL, 12);
+
+	FolderTransferChoice choice = FolderTransferChoice::Cancel;
+	auto pick = [&dlg, &choice](FolderTransferChoice c) {
+		choice = c;
+		dlg.EndModal(wxID_OK);
+	};
+	dlg.Bind(wxEVT_BUTTON, [&pick](wxCommandEvent &) {
+		pick(FolderTransferChoice::Move);
+	}, ID_MOVE);
+	dlg.Bind(wxEVT_BUTTON, [&pick](wxCommandEvent &) {
+		pick(FolderTransferChoice::Copy);
+	}, ID_COPY);
+	dlg.Bind(wxEVT_BUTTON, [&pick](wxCommandEvent &) {
+		pick(FolderTransferChoice::Manual);
+	}, ID_MANUAL);
+
+	dlg.SetSizerAndFit(root);
+	dlg.Centre();
+	if (dlg.ShowModal() != wxID_OK) {
+		return FolderTransferChoice::Cancel;
+	}
+	return choice;
+}
+
+FolderTransferResult
+FolderTransferRun(wxWindow *parent, const wxString &from, const wxString &to,
+                  FolderTransferChoice choice)
+{
+	FolderTransferResult result;
+	const wxChar sep = wxFileName::GetPathSeparator();
+	const bool moving = (choice == FolderTransferChoice::Move);
+	const bool dest_existed = wxDirExists(to);
+
+	if (choice != FolderTransferChoice::Move &&
+	    choice != FolderTransferChoice::Copy) {
+		result.message = "Nothing was moved.";
+		return result;
+	}
+
+	const TreeListing listing = ListTree(from);
+
+	if (!listing.ok) {
+		result.message = wxString::Format("Could not read '%s', so nothing was "
+		    "moved. The setting has been left as it was.", from);
+		return result;
+	}
+
+	/*
+	 * ★ REFUSED HERE AS WELL AS IN folder_move_decide(), not instead of it.
+	 *
+	 * The cleanup after a failure removes everything at the destination, and its
+	 * only justification is that the destination was empty beforehand, so
+	 * everything in it is ours. That justification is the caller's to establish -
+	 * and a destructive function that trusts its caller for the one fact keeping
+	 * it safe is one refactor away from deleting somebody's files.
+	 *
+	 * Found by a test that called this directly with an occupied destination, to
+	 * check "this must be safe on its own". It was not: the pre-existing file was
+	 * deleted during cleanup.
+	 */
+	if (dest_existed && !DirIsEmpty(to)) {
+		result.message = wxString::Format(
+		    "'%s' already has files in it, so nothing was moved. RPCEmu will not "
+		    "mix two sets of files together.", to);
+		return result;
+	}
+
+	/*
+	 * A move within one filesystem is a rename: instant whatever the size, and
+	 * nothing is copied so nothing can be half-copied. Tried first, and if it
+	 * fails for any reason (a different filesystem being the usual one) the copy
+	 * path below runs instead.
+	 *
+	 * An existing empty destination is removed first, because renaming onto an
+	 * existing directory fails on both Windows and Unix. Safe only because it was
+	 * checked to be empty; see folder_move_decide().
+	 */
+	if (moving) {
+		bool cleared = true;
+
+		if (dest_existed && !wxRmdir(to)) {
+			cleared = false;
+		}
+		if (cleared && wxRenameFile(from, to, false)) {
+			result.ok = true;
+			result.files = (unsigned long) listing.files.size();
+			result.message = wxString::Format(
+			    "Moved %lu file%s to '%s'.", result.files,
+			    result.files == 1 ? "" : "s", to);
+			return result;
+		}
+		if (cleared && dest_existed && !wxDirExists(to)) {
+			/* Put back what we removed, so a failure leaves things as they
+			   were. */
+			wxDir::Make(to, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+		}
+	}
+
+	if (!wxDirExists(to) && !wxDir::Make(to, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL)) {
+		result.message = wxString::Format("Could not create '%s', so nothing was "
+		    "moved. The setting has been left as it was.", to);
+		return result;
+	}
+
+	{
+		/*
+		 * ★ The progress dialogue is optional so that this function can be tested.
+		 *
+		 * wxProgressDialog needs a GUI toolkit and a display; everything else here
+		 * is wxBase and needs neither. Creating it only when there is a GUI lets
+		 * tests/test_folder_transfer.cpp drive the real copy, verify and delete
+		 * code - which is the destructive part, and the part worth testing - on a
+		 * console build with no display, including in CI.
+		 */
+		const bool have_gui = (wxTheApp != nullptr && wxTheApp->IsGUI());
+		std::unique_ptr<wxProgressDialog> progress;
+
+		const int total = (int) listing.files.size();
+
+		if (have_gui) {
+			progress.reset(new wxProgressDialog(
+			    moving ? "Moving files" : "Copying files",
+			    /* Sized for the widest message it will show later, or the dialogue
+			       grows as it goes and the text jumps about. */
+			    wxString::Format("Copying %d files to\n%s", total, to),
+			    total + 1, parent,
+			    wxPD_APP_MODAL | wxPD_AUTO_HIDE | wxPD_CAN_ABORT |
+			    wxPD_ELAPSED_TIME | wxPD_REMAINING_TIME | wxPD_ESTIMATED_TIME));
+		}
+		/*
+		 * Named files and a running count, not just a bar: a disc with a thousand
+		 * files on it takes long enough that "is it stuck?" is a fair question, and
+		 * the answer should be on screen. Each file is copied AND verified before
+		 * the next update, so the name shown is genuinely the one being worked on.
+		 */
+		auto keep_going = [&progress, total](int done, const wxString &label) {
+			if (!progress) {
+				return true;
+			}
+			return progress->Update(done,
+			    wxString::Format("File %d of %d\n%s", done + 1, total, label));
+		};
+
+		for (const wxString &d : listing.dirs) {
+			if (!wxDirExists(to + sep + d) &&
+			    !wxDir::Make(to + sep + d, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL)) {
+				RemoveOurTree(to, !dest_existed);
+				result.message = wxString::Format(
+				    "Could not create '%s'. Nothing has been moved and the "
+				    "setting has been left as it was.", to + sep + d);
+				return result;
+			}
+		}
+
+		int done = 0;
+		for (const wxString &f : listing.files) {
+			const wxString src = from + sep + f;
+			const wxString dst = to + sep + f;
+
+			if (!keep_going(done++, f)) {
+				/* Cancelled. The destination was empty before we started, so
+				   everything in it is ours to remove. */
+				RemoveOurTree(to, !dest_existed);
+				result.message = "Cancelled. Your files have not been moved and "
+				    "the setting has been left as it was.";
+				return result;
+			}
+
+			if (!wxCopyFile(src, dst, true) || !SameContent(src, dst)) {
+				/*
+				 * ★ The failure that matters, and why nothing is deleted until
+				 * the whole copy has been verified. A disc that fills up half way
+				 * leaves a truncated file, which a size check would pass and an
+				 * MD5 does not.
+				 */
+				RemoveOurTree(to, !dest_existed);
+				result.message = wxString::Format(
+				    "Could not copy '%s' (there may not be enough room). Your "
+				    "files are untouched in '%s' and the setting has been left "
+				    "as it was.", f, from);
+				return result;
+			}
+			result.files++;
+		}
+		keep_going(total, "Finishing off...");
+	}
+
+	/* Every file is at the destination and verified. Only now is the old folder
+	   touched, and only for a move. */
+	if (moving) {
+		RemoveOurTree(from, false);
+		if (!DirIsEmpty(from)) {
+			result.source_left_behind = true;
+		}
+	}
+
+	result.ok = true;
+	if (moving && result.source_left_behind) {
+		result.message = wxString::Format(
+		    "Copied and checked %lu file%s into '%s'. Some of the originals in "
+		    "'%s' could not be removed, so they are still there - your machine "
+		    "is using the new folder.",
+		    result.files, result.files == 1 ? "" : "s", to, from);
+	} else if (moving) {
+		result.message = wxString::Format(
+		    "Moved %lu file%s to '%s', checking each one.", result.files,
+		    result.files == 1 ? "" : "s", to);
+	} else {
+		result.message = wxString::Format(
+		    "Copied %lu file%s to '%s', checking each one. The old folder in "
+		    "'%s' has been left exactly as it was.", result.files,
+		    result.files == 1 ? "" : "s", to, from);
+	}
+	rpclog("Folder transfer: %s\n", result.message.utf8_str().data());
+	return result;
+}

--- a/src/gui/folder_transfer.h
+++ b/src/gui/folder_transfer.h
@@ -1,0 +1,120 @@
+/*
+  RPCEmu - An Acorn system emulator
+
+  Copyright (C) 2026 Andy Timmins
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifndef FOLDER_TRANSFER_H
+#define FOLDER_TRANSFER_H
+
+#include <wx/string.h>
+
+class wxWindow;
+
+extern "C" {
+#include "folder_move.h"
+}
+
+/*
+ * Moving somebody's files when they point a folder somewhere new.
+ *
+ * Pointing HostFS, or the data folder, at a new place used to leave the files
+ * behind: the new folder was created empty and the machine booted from a blank
+ * disc. This offers to bring them across.
+ *
+ * ★ THE RULE THE WHOLE THING RESTS ON: the configuration is only changed after a
+ * transfer has completely succeeded. If anything fails part way, both copies are
+ * still on disc and the machine still boots from the old folder. A failed move is
+ * then an inconvenience rather than a lost hard disc - which matters more than any
+ * warning text, because people click through warnings.
+ *
+ * Two more properties worth stating, because they are what make the destructive
+ * parts safe:
+ *
+ *   - Nothing is deleted from the old folder until every file has been copied AND
+ *     its content verified (MD5 both sides, not just a size). A move is a verified
+ *     copy followed by a delete, never an unchecked one.
+ *   - A partial transfer is cleaned up, and that is safe to do because the
+ *     destination was checked to be empty (or absent) before anything started, so
+ *     everything in it is ours. folder_move_decide() is what guarantees that, and
+ *     it refuses rather than merging into a folder with files in it.
+ *
+ * The decision about whether to offer at all is folder_move.c, kept separate and
+ * unit tested. This is the doing.
+ */
+
+/** What the user chose. */
+enum class FolderTransferChoice {
+	Move,		/**< Bring the files across and empty the old folder. */
+	Copy,		/**< Bring the files across and leave the old folder alone. */
+	Manual,		/**< Change the setting; the user will move files themselves. */
+	Cancel		/**< Change nothing at all. */
+};
+
+/** How a transfer went. */
+struct FolderTransferResult {
+	bool ok = false;		/**< Are the files at the destination? */
+	bool source_left_behind = false; /**< A move that could not empty the source. */
+	unsigned long files = 0;	/**< Files brought across. */
+	wxString message;		/**< For showing; never empty. */
+};
+
+/**
+ * Ask the filesystem the questions folder_move_decide() needs.
+ *
+ * @param from   The folder in use now.
+ * @param to     The folder being chosen.
+ * @param in_use Is a machine running from either? The caller knows; this cannot.
+ * @param bytes  Filled with the size of @from, for the space check and the
+ *               dialogue. May be NULL.
+ */
+folder_move_facts FolderTransferGatherFacts(const wxString &from,
+                                            const wxString &to, bool in_use,
+                                            unsigned long long *bytes);
+
+/**
+ * Put the choice to the user.
+ *
+ * @param what  What is being moved, in the user's terms: "hard disc",
+ *              "data folder". Used in the wording.
+ * @param offer What folder_move_decide() allows.
+ * @param why   Its reason, shown when a move cannot be offered.
+ * @return The choice. FolderTransferChoice::Manual when nothing can be offered
+ *         and the user accepted that, Cancel when they backed out.
+ */
+FolderTransferChoice FolderTransferAsk(wxWindow *parent, const wxString &what,
+                                       const wxString &from, const wxString &to,
+                                       folder_move_offer offer,
+                                       folder_move_reason why,
+                                       unsigned long long bytes);
+
+/**
+ * Bring the files across, with a progress dialogue.
+ *
+ * A move on one filesystem is a rename, which is instant whatever the size. Across
+ * filesystems, and for every copy, each file is copied and then verified before
+ * anything is removed.
+ *
+ * @return Whether the files are now at the destination. On failure the source is
+ *         untouched and any partial destination has been cleaned up, so the caller
+ *         must leave the configuration alone.
+ */
+FolderTransferResult FolderTransferRun(wxWindow *parent, const wxString &from,
+                                       const wxString &to,
+                                       FolderTransferChoice choice);
+
+#endif /* FOLDER_TRANSFER_H */

--- a/src/gui/machine_edit_dialog.cpp
+++ b/src/gui/machine_edit_dialog.cpp
@@ -25,6 +25,7 @@
 #include "riscos_fetch.h"
 
 #include "config_paths.h"
+#include "folder_transfer.h"
 
 extern "C" {
 #include "hostfs_advice.h"
@@ -230,10 +231,8 @@ static wxString MachineSharingHostfs(const wxString &root, const wxString &self)
  * Uses the same rules the emulator will, rather than a second copy of them, so
  * the dialogue cannot disagree with what actually happens at startup.
  */
-wxString MachineEditDialog::ResolvedHostfsRoot() const
+wxString MachineEditDialog::ResolveHostfsValue(const wxString &configured) const
 {
-	const wxString configured = hostfs_edit_ != nullptr
-	    ? hostfs_edit_->GetValue().Trim().Trim(false) : wxString();
 	const wxString name = new_name_.empty() ? original_name_ : new_name_;
 	const wxString machine_dir =
 	    ConfigPathsMachinesDir() + wxFileName::GetPathSeparator() +
@@ -245,6 +244,12 @@ wxString MachineEditDialog::ResolvedHostfsRoot() const
 		return machine_dir;
 	}
 	return wxString::FromUTF8(out);
+}
+
+wxString MachineEditDialog::ResolvedHostfsRoot() const
+{
+	return ResolveHostfsValue(hostfs_edit_ != nullptr
+	    ? hostfs_edit_->GetValue().Trim().Trim(false) : wxString());
 }
 
 /*
@@ -1619,6 +1624,9 @@ void MachineEditDialog::LoadSettings()
 
 		settings.Read("hostfs_path", &hostfs, wxEmptyString);
 		hostfs_edit_->SetValue(hostfs);
+		/* Kept so OK can tell whether the folder changed, and offer to bring
+		   the files across if it did. */
+		original_hostfs_ = hostfs;
 		UpdateHostfsNote();
 	}
 
@@ -2116,6 +2124,96 @@ void MachineEditDialog::OnOk(wxCommandEvent &)
 		wxMessageBox(wxString::FromUTF8(msg), "ROM compatibility", wxOK | wxICON_WARNING, this);
 		return;
 	}
+	/* Before saving, because the setting must not change unless the files
+	   actually got there. See folder_transfer.h. */
+	if (!OfferToBringHostfsFilesAcross()) {
+		return;
+	}
 	SaveSettings();
 	EndModal(wxID_OK);
+}
+
+/*
+ * The HostFS folder has been pointed somewhere new: offer to take the files with
+ * it.
+ *
+ * ★ THE ORDER IS THE SAFETY. The transfer happens first and the configuration is
+ * only written if it succeeded, so a failure leaves the machine booting from the
+ * folder it was booting from before. Getting this the other way round would mean a
+ * failed copy and a machine pointed at an empty folder, which is the very thing
+ * this feature exists to stop.
+ *
+ * @return false when the user cancelled, or when a transfer failed - in both
+ *         cases nothing should be saved and the dialogue stays open.
+ */
+bool MachineEditDialog::OfferToBringHostfsFilesAcross()
+{
+	if (hostfs_edit_ == nullptr) {
+		return true;
+	}
+
+	const wxString now = hostfs_edit_->GetValue().Trim().Trim(false);
+
+	if (now == original_hostfs_) {
+		return true;
+	}
+
+	const wxString from = ResolveHostfsValue(original_hostfs_);
+	const wxString to = ResolveHostfsValue(now);
+	unsigned long long bytes = 0;
+	const folder_move_facts facts =
+	    FolderTransferGatherFacts(from, to, emulator_running_, &bytes);
+	folder_move_reason why = FOLDER_MOVE_OK;
+	const folder_move_offer offer = folder_move_decide(&facts, &why);
+
+	if (offer == FOLDER_MOVE_OFFER_NOTHING) {
+		/*
+		 * Nothing to move is the ordinary case - a new machine, or the same
+		 * folder spelled differently - and saying so would be noise. The others
+		 * are worth a word, because the user asked for something that cannot
+		 * happen and would otherwise find an empty disc later.
+		 */
+		if (why == FOLDER_MOVE_SAME_PLACE || why == FOLDER_MOVE_SOURCE_EMPTY ||
+		    why == FOLDER_MOVE_SOURCE_MISSING) {
+			return true;
+		}
+		const FolderTransferChoice choice = FolderTransferAsk(this, "hard disc",
+		    from, to, offer, why, bytes);
+
+		return choice != FolderTransferChoice::Cancel;
+	}
+
+	const FolderTransferChoice choice = FolderTransferAsk(this, "hard disc",
+	    from, to, offer, why, bytes);
+
+	switch (choice) {
+	case FolderTransferChoice::Cancel:
+		return false;
+
+	case FolderTransferChoice::Manual:
+		/* The note under the field already says what an empty folder means, and
+		   they have just read it in the dialogue. Nothing more to add. */
+		return true;
+
+	case FolderTransferChoice::Move:
+	case FolderTransferChoice::Copy: {
+		const FolderTransferResult result =
+		    FolderTransferRun(this, from, to, choice);
+
+		if (!result.ok) {
+			wxMessageBox(result.message, "The files were not moved",
+			    wxOK | wxICON_ERROR, this);
+			/* Put the field back, so pressing OK again saves everything else
+			   without pointing the machine at a folder its files are not in. */
+			hostfs_edit_->SetValue(original_hostfs_);
+			UpdateHostfsNote();
+			return false;
+		}
+		wxMessageBox(result.message,
+		    choice == FolderTransferChoice::Move ? "Files moved" : "Files copied",
+		    wxOK | wxICON_INFORMATION, this);
+		return true;
+	}
+	}
+	return true;
 }

--- a/src/gui/machine_edit_dialog.h
+++ b/src/gui/machine_edit_dialog.h
@@ -130,11 +130,17 @@ private:
 	wxStaticText *hostfs_note_ = nullptr;
 
 	wxString ResolvedHostfsRoot() const;
+	wxString ResolveHostfsValue(const wxString &configured) const;
+	/* Returns false when the user backed out and nothing should be saved. */
+	bool OfferToBringHostfsFilesAcross();
 	void UpdateHostfsNote();
 	bool renamed_ = false;
 	bool allow_rename_ = true;
 	bool loading_settings_ = false;
 	bool emulator_running_ = false;
+	/* The hostfs_path as loaded, so a change can be spotted on OK and the files
+	   offered a lift to the new folder. */
+	wxString original_hostfs_;
 	bool cdrom_enabled_ = false;
 
 	wxTextCtrl *name_edit_ = nullptr;

--- a/src/rpcemu.c
+++ b/src/rpcemu.c
@@ -894,6 +894,15 @@ rpclog(const char *format, ...)
 	fflush(arclog);
 }
 
+void
+rpclog_close(void)
+{
+	if (arclog != NULL) {
+		fclose(arclog);
+		arclog = NULL;
+	}
+}
+
 /**
  * Reinitialise all emulated subsystems based on current configuration. This
  * is equivalent to resetting the emulated hardware.

--- a/src/rpcemu.h
+++ b/src/rpcemu.h
@@ -422,6 +422,15 @@ extern void rpcemu_floppy_load(int drive, const char *filename);
 extern void rpcemu_floppy_eject(int drive);
 extern void rpclog(const char *format, ...)
 	RPCEMU_FORMAT_PRINTF(1, 2);
+/*
+ * Close the log file, so the next rpclog() opens it again at whatever
+ * rpcemu_get_log_path() says by then.
+ *
+ * For moving the data folder: the log lives inside it and we are holding it open,
+ * and Windows will not move a file that is open. Nothing else needs this - the log
+ * is opened lazily and never otherwise closed.
+ */
+extern void rpclog_close(void);
 extern void rpcemu_model_changed(Model model);
 extern const char *rpcemu_file_get_extension(const char *filename);
 extern int rpcemu_config_is_reset_required(const Config *new_config, Model new_model);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -202,6 +202,42 @@ target_include_directories(test_hostfs_path PRIVATE
                            ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 rpcemu_add_test(test_hostfs_path)
 
+# Whether moving somebody's files can be offered at all. Copying a hard disc is the
+# most destructive thing RPCEmu does to the host filesystem, and every condition
+# that makes it unsafe - a destination with files in it, a full disc, a machine
+# still running from the folder - is awkward to arrange for real. So the rules are
+# pure over facts the caller gathers, and this puts the combinations to them. The
+# doing is src/gui/folder_transfer.cpp. See docs/hostfs.md.
+add_executable(test_folder_move test_folder_move.c
+               ${CMAKE_CURRENT_SOURCE_DIR}/../src/folder_move.c)
+target_include_directories(test_folder_move PRIVATE
+                           ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+rpcemu_add_test(test_folder_move)
+
+# C++ for the tests that need it. Enabled here as well as in src/CMakeLists.txt
+# because enable_language() sets its variables in the calling directory's scope, and
+# tests/ is a sibling of src/ rather than a child - without this, configuring fails
+# with "CMAKE_CXX_LINK_EXECUTABLE not set" while confusingly still compiling.
+enable_language(CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# The doing, on real files: copy, verify, delete, and above all what happens when a
+# transfer fails half way through. Needs wx (wxBase, for file and directory work)
+# but NOT a display: FolderTransferRun() creates its progress dialogue only when
+# there is a GUI, which is what lets this run in CI. rpcemu_core comes along for
+# md5_file_hex(), which is how a copy is verified rather than merely sized.
+add_executable(test_folder_transfer test_folder_transfer.cpp
+               ${CMAKE_CURRENT_SOURCE_DIR}/../src/gui/folder_transfer.cpp
+               ${CMAKE_CURRENT_SOURCE_DIR}/../src/folder_move.c
+               test_stubs.c)
+target_include_directories(test_folder_transfer PRIVATE
+                           ${CMAKE_CURRENT_SOURCE_DIR}/../src
+                           ${CMAKE_CURRENT_SOURCE_DIR}/../src/gui)
+target_link_libraries(test_folder_transfer PRIVATE rpcemu_core m)
+rpcemu_setup_wxwidgets(test_folder_transfer)
+rpcemu_add_test(test_folder_transfer)
+
 # What the machine editor warns about when a HostFS folder is chosen. Split out of
 # the dialog because the decision was wrong in a way that read correctly: the
 # "no !Boot" warning lived in the branch for a folder that already existed, so a
@@ -399,7 +435,7 @@ rpcemu_add_test(test_unzip)
 #
 # Raise RPCEMU_EXPECTED_TESTS when adding a test. If that feels like a chore, it
 # is the only line in the file that cannot go stale without being noticed.
-set(RPCEMU_EXPECTED_TESTS 24)	# tests that build on every platform
+set(RPCEMU_EXPECTED_TESTS 26)	# tests that build on every platform
 if(RPCEMU_JIT_TESTS)
     math(EXPR RPCEMU_EXPECTED_TESTS "${RPCEMU_EXPECTED_TESTS} + 8")	# JIT differential
 endif()

--- a/tests/test_folder_move.c
+++ b/tests/test_folder_move.c
@@ -1,0 +1,313 @@
+/*
+ * Whether moving somebody's files can be offered.
+ *
+ * Copying a hard disc is the most destructive thing RPCEmu does to the host's
+ * filesystem, and every condition that makes it unsafe is awkward to arrange for
+ * real: a destination with files already in it, a full disc, a machine still
+ * running from the folder. So the rules are a pure function over facts somebody
+ * else gathered, and this puts the combinations to them.
+ *
+ * The cases that matter most are the refusals. An offer that should not have been
+ * made is how people lose data.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "folder_move.h"
+
+static int failures;
+
+static void
+check(const char *what, int ok)
+{
+	printf("  %-68s %s\n", what, ok ? "ok" : "FAIL");
+	if (!ok) {
+		failures++;
+	}
+}
+
+/* The ordinary case: files here, empty folder there, room for them. */
+static folder_move_facts good(void)
+{
+	folder_move_facts f;
+
+	memset(&f, 0, sizeof(f));
+	f.source_exists = 1;
+	f.source_is_dir = 1;
+	f.source_writable = 1;
+	f.source_empty = 0;
+	f.dest_exists = 1;
+	f.dest_is_dir = 1;
+	f.dest_empty = 1;
+	f.dest_parent_writable = 1;
+	f.bytes_needed = 100ull * 1024 * 1024;
+	f.bytes_free = 900ull * 1024 * 1024;
+	return f;
+}
+
+static void
+test_the_ordinary_case(void)
+{
+	folder_move_facts f = good();
+	folder_move_reason why = FOLDER_MOVE_NO_SPACE;
+
+	puts("Files to bring across and an empty folder to put them in:");
+
+	check("both a move and a copy are offered",
+	    folder_move_decide(&f, &why) == FOLDER_MOVE_OFFER_BOTH);
+	check("and there is nothing to explain", why == FOLDER_MOVE_OK);
+
+	/* A destination that does not exist yet is normal: it gets created. */
+	f.dest_exists = 0;
+	f.dest_is_dir = 0;
+	f.dest_empty = 1;
+	check("a destination that does not exist yet is fine, it will be created",
+	    folder_move_decide(&f, &why) == FOLDER_MOVE_OFFER_BOTH);
+}
+
+static void
+test_refusals(void)
+{
+	folder_move_reason why;
+
+	puts("The refusals, which are the point of this:");
+
+	/* ★ The dangerous one. Files are opened as the guest asks for them, so
+	   moving them under a live machine damages whatever it reads next. */
+	{
+		folder_move_facts f = good();
+
+		f.in_use = 1;
+		check("a machine running from either folder refuses everything",
+		    folder_move_decide(&f, &why) == FOLDER_MOVE_OFFER_NOTHING);
+		check("and says so, since that is the reason worth hearing",
+		    why == FOLDER_MOVE_IN_USE);
+	}
+
+	/* In use outranks everything else: it is the only reason that describes
+	   damage rather than inconvenience. */
+	{
+		folder_move_facts f = good();
+
+		f.in_use = 1;
+		f.dest_empty = 0;
+		f.bytes_free = 0;
+		f.bytes_needed = 1;
+		folder_move_decide(&f, &why);
+		check("being in use is reported ahead of any other problem",
+		    why == FOLDER_MOVE_IN_USE);
+	}
+
+	/* ★ Never merge. Two hard discs interleaved is not what anybody asked for. */
+	{
+		folder_move_facts f = good();
+
+		f.dest_empty = 0;
+		check("a destination with files in it refuses everything",
+		    folder_move_decide(&f, &why) == FOLDER_MOVE_OFFER_NOTHING);
+		check("and explains that files will not be mixed together",
+		    why == FOLDER_MOVE_DEST_NOT_EMPTY);
+	}
+
+	{
+		folder_move_facts f = good();
+
+		f.dest_exists = 1;
+		f.dest_is_dir = 0;
+		check("a destination that is a file is refused",
+		    folder_move_decide(&f, &why) == FOLDER_MOVE_OFFER_NOTHING);
+		check("named as such", why == FOLDER_MOVE_DEST_NOT_A_DIR);
+	}
+
+	{
+		folder_move_facts f = good();
+
+		f.dest_parent_writable = 0;
+		check("a destination that cannot be written to is refused",
+		    folder_move_decide(&f, &why) == FOLDER_MOVE_OFFER_NOTHING);
+		check("named as such", why == FOLDER_MOVE_DEST_READ_ONLY);
+	}
+
+	{
+		folder_move_facts f = good();
+
+		f.same_place = 1;
+		check("the same folder twice is nothing to do",
+		    folder_move_decide(&f, &why) == FOLDER_MOVE_OFFER_NOTHING);
+		check("named as such", why == FOLDER_MOVE_SAME_PLACE);
+	}
+
+	{
+		folder_move_facts f = good();
+
+		f.source_empty = 1;
+		check("an empty source is nothing to do",
+		    folder_move_decide(&f, &why) == FOLDER_MOVE_OFFER_NOTHING);
+		check("named as such", why == FOLDER_MOVE_SOURCE_EMPTY);
+	}
+
+	{
+		folder_move_facts f = good();
+
+		f.source_exists = 0;
+		check("a source that is not there is nothing to do",
+		    folder_move_decide(&f, &why) == FOLDER_MOVE_OFFER_NOTHING);
+		check("named as such", why == FOLDER_MOVE_SOURCE_MISSING);
+	}
+
+	{
+		folder_move_facts f = good();
+
+		/* A path that exists but is a file, not a directory. */
+		f.source_is_dir = 0;
+		check("a source that is a file is refused",
+		    folder_move_decide(&f, &why) == FOLDER_MOVE_OFFER_NOTHING);
+	}
+
+	check("NULL facts refuse rather than crash",
+	    folder_move_decide(NULL, &why) == FOLDER_MOVE_OFFER_NOTHING);
+	/* A caller that does not want the reason must not be a special case. */
+	{
+		folder_move_facts f = good();
+
+		check("a NULL reason pointer is allowed",
+		    folder_move_decide(&f, NULL) == FOLDER_MOVE_OFFER_BOTH);
+	}
+}
+
+/*
+ * A source that cannot be emptied afterwards gets the copy offered anyway. The
+ * files end up where they are needed, which is the point; the leftovers are
+ * visible rather than lost.
+ */
+static void
+test_copy_only(void)
+{
+	folder_move_facts f = good();
+	folder_move_reason why;
+
+	puts("A source that cannot be emptied afterwards:");
+
+	f.source_writable = 0;
+	check("the copy is still offered",
+	    folder_move_decide(&f, &why) == FOLDER_MOVE_OFFER_COPY_ONLY);
+	check("with the reason the move is not",
+	    why == FOLDER_MOVE_SOURCE_READ_ONLY);
+}
+
+static void
+test_space(void)
+{
+	folder_move_reason why;
+
+	puts("Free space, with a margin, because filling a disc is its own failure:");
+
+	check("plenty of room is enough",
+	    folder_move_space_is_enough(100ull * 1024 * 1024,
+	        900ull * 1024 * 1024));
+	check("an exact fit is NOT enough - it would leave nothing spare",
+	    !folder_move_space_is_enough(100ull * 1024 * 1024,
+	        100ull * 1024 * 1024));
+	check("nor is a hair over, below the 16 MB floor",
+	    !folder_move_space_is_enough(100ull * 1024 * 1024,
+	        100ull * 1024 * 1024 + 1024));
+	check("5% clear of a large copy is enough",
+	    folder_move_space_is_enough(10000ull * 1024 * 1024,
+	        10600ull * 1024 * 1024));
+	check("but 1% clear of a large copy is not",
+	    !folder_move_space_is_enough(10000ull * 1024 * 1024,
+	        10100ull * 1024 * 1024));
+
+	/* The floor. A percentage of a small disc is no margin at all. */
+	check("a small copy still needs the 16 MB floor",
+	    !folder_move_space_is_enough(1024 * 1024, 2ull * 1024 * 1024));
+	check("and passes once there is that much room",
+	    folder_move_space_is_enough(1024 * 1024, 32ull * 1024 * 1024));
+
+	/* ★ Unknown sizes must not refuse. A caller that cannot measure should not
+	   have the feature taken away, and this is said in the header too. */
+	check("both zero means 'not measured' and does not refuse",
+	    folder_move_space_is_enough(0, 0));
+
+	/* Overflow: needed + margin must not wrap and turn far-too-big into fine. */
+	check("a size near the top of the range does not wrap into 'plenty'",
+	    !folder_move_space_is_enough(0xffffffffffffffffull, 1024));
+
+	{
+		folder_move_facts f = good();
+
+		f.bytes_needed = 500ull * 1024 * 1024;
+		f.bytes_free = 100ull * 1024 * 1024;
+		check("a full destination refuses the whole offer",
+		    folder_move_decide(&f, &why) == FOLDER_MOVE_OFFER_NOTHING);
+		check("named as such", why == FOLDER_MOVE_NO_SPACE);
+
+		f.bytes_needed = 0;
+		f.bytes_free = 0;
+		check("and an unmeasured pair does not",
+		    folder_move_decide(&f, &why) == FOLDER_MOVE_OFFER_BOTH);
+	}
+}
+
+/*
+ * Every reason must have something to show. A dialog that explains nothing is
+ * how the original complaint started.
+ */
+static void
+test_every_reason_says_something(void)
+{
+	static const folder_move_reason all[] = {
+		FOLDER_MOVE_OK,
+		FOLDER_MOVE_SAME_PLACE,
+		FOLDER_MOVE_SOURCE_EMPTY,
+		FOLDER_MOVE_SOURCE_MISSING,
+		FOLDER_MOVE_DEST_NOT_EMPTY,
+		FOLDER_MOVE_DEST_NOT_A_DIR,
+		FOLDER_MOVE_NO_SPACE,
+		FOLDER_MOVE_IN_USE,
+		FOLDER_MOVE_DEST_READ_ONLY,
+		FOLDER_MOVE_SOURCE_READ_ONLY,
+	};
+	size_t i;
+	int all_have_text = 1;
+
+	puts("Every reason can be shown to somebody:");
+
+	for (i = 0; i < sizeof(all) / sizeof(all[0]); i++) {
+		const char *text = folder_move_reason_text(all[i]);
+
+		if (text == NULL || text[0] == '\0') {
+			all_have_text = 0;
+		}
+	}
+	check("all ten reasons have wording", all_have_text);
+	check("and so does a value that is not one of them, rather than NULL",
+	    folder_move_reason_text((folder_move_reason) 999) != NULL);
+
+	/* The two that must carry the specific warning, since they are the ones
+	   people will meet. */
+	check("the in-use reason says to close the machine first",
+	    strstr(folder_move_reason_text(FOLDER_MOVE_IN_USE), "Close it") != NULL);
+	check("the not-empty reason explains why files are not mixed",
+	    strstr(folder_move_reason_text(FOLDER_MOVE_DEST_NOT_EMPTY),
+	        "will not mix") != NULL);
+}
+
+int
+main(void)
+{
+	test_the_ordinary_case();
+	test_refusals();
+	test_copy_only();
+	test_space();
+	test_every_reason_says_something();
+
+	if (failures != 0) {
+		printf("\n%d check%s failed\n", failures, failures == 1 ? "" : "s");
+		return EXIT_FAILURE;
+	}
+	puts("\nall folder move checks passed");
+	return EXIT_SUCCESS;
+}

--- a/tests/test_folder_transfer.cpp
+++ b/tests/test_folder_transfer.cpp
@@ -1,0 +1,361 @@
+/*
+ * Actually moving somebody's files.
+ *
+ * tests/test_folder_move.c covers the decision. This covers the doing, on real
+ * files, because the doing is the part that can lose a hard disc. It runs without
+ * a display: FolderTransferRun() only creates its progress dialogue when there is
+ * a GUI, which is what makes this possible in CI.
+ *
+ * ★ THE CASE THAT MATTERS MOST is the failure half way through. A copy that dies
+ * on file three must leave the originals untouched, and must not leave a
+ * half-populated destination for the machine to boot from. It is arranged here by
+ * making a source file unreadable, which is the closest thing to a full disc that
+ * a test can arrange portably.
+ */
+
+#include <wx/wx.h>
+#include <wx/dir.h>
+#include <wx/filefn.h>
+#include <wx/filename.h>
+#include <wx/init.h>
+#include <wx/textfile.h>
+
+#include "folder_transfer.h"
+
+#include <cstdio>
+
+static int failures;
+
+static void
+check(const char *what, bool ok)
+{
+	printf("  %-68s %s\n", what, ok ? "ok" : "FAIL");
+	if (!ok) {
+		failures++;
+	}
+}
+
+/*
+ * wxFileName::SetPermissions is a member, so it needs an object. Wrapped because
+ * this is used to arrange the failure cases and reading it inline is noise.
+ *
+ * On Windows clearing the read bit does not make a file unreadable, so the callers
+ * check whether the arrangement actually worked and skip rather than assert
+ * something the platform will not do.
+ */
+static bool
+SetPerms(const wxString &path, int mode)
+{
+	return wxFileName(path).SetPermissions(mode);
+}
+
+static wxString
+Sep()
+{
+	return wxString(wxFileName::GetPathSeparator());
+}
+
+static void
+WriteFile(const wxString &path, const wxString &contents)
+{
+	wxFileName fn(path);
+
+	wxDir::Make(fn.GetPath(), wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+
+	wxFile f;
+	f.Create(path, true);
+	f.Write(contents);
+	f.Close();
+}
+
+static wxString
+ReadFile(const wxString &path)
+{
+	wxFile f(path);
+	wxString out;
+
+	if (!f.IsOpened()) {
+		return wxEmptyString;
+	}
+	f.ReadAll(&out);
+	return out;
+}
+
+/* A source tree with a couple of levels, some content, and an empty directory -
+   which a naive copy that walks files only would silently drop. */
+static void
+MakeSourceTree(const wxString &root)
+{
+	WriteFile(root + Sep() + "!Boot", "boot");
+	WriteFile(root + Sep() + "Apps" + Sep() + "Draw", "draw");
+	WriteFile(root + Sep() + "Apps" + Sep() + "Deep" + Sep() + "File", "deep");
+	wxDir::Make(root + Sep() + "Empty", wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+}
+
+static bool
+TreeArrived(const wxString &root)
+{
+	return ReadFile(root + Sep() + "!Boot") == "boot" &&
+	    ReadFile(root + Sep() + "Apps" + Sep() + "Draw") == "draw" &&
+	    ReadFile(root + Sep() + "Apps" + Sep() + "Deep" + Sep() + "File") == "deep";
+}
+
+/* wx does the recursion, and does it without complaining about directories that
+   are not empty yet - which a hand-rolled version did, printing wx errors that
+   read exactly like test failures. */
+static void
+Nuke(const wxString &root)
+{
+	if (!wxDirExists(root)) {
+		return;
+	}
+	wxFileName::Rmdir(root, wxPATH_RMDIR_RECURSIVE);
+}
+
+static void
+test_copy(const wxString &tmp)
+{
+	const wxString from = tmp + Sep() + "copy-from";
+	const wxString to = tmp + Sep() + "copy-to";
+
+	puts("Copy brings the files across and leaves the originals alone:");
+
+	Nuke(from);
+	Nuke(to);
+	MakeSourceTree(from);
+
+	const FolderTransferResult r = FolderTransferRun(NULL, from, to,
+	    FolderTransferChoice::Copy);
+
+	check("it reports success", r.ok);
+	check("every file arrived, with its content intact", TreeArrived(to));
+	check("an empty directory came too, rather than being dropped",
+	    wxDirExists(to + Sep() + "Empty"));
+	check("three files were counted", r.files == 3);
+	check("the originals are still there - this doubles as a backup",
+	    TreeArrived(from));
+	check("and the message says the old folder was left alone",
+	    r.message.Contains("left exactly as it was"));
+}
+
+static void
+test_move(const wxString &tmp)
+{
+	const wxString from = tmp + Sep() + "move-from";
+	const wxString to = tmp + Sep() + "move-to";
+
+	puts("Move brings the files across and empties the old folder:");
+
+	Nuke(from);
+	Nuke(to);
+	MakeSourceTree(from);
+
+	const FolderTransferResult r = FolderTransferRun(NULL, from, to,
+	    FolderTransferChoice::Move);
+
+	check("it reports success", r.ok);
+	check("every file arrived, with its content intact", TreeArrived(to));
+	check("nothing is left in the old folder",
+	    !wxFileExists(from + Sep() + "!Boot") &&
+	    !wxFileExists(from + Sep() + "Apps" + Sep() + "Draw"));
+	check("and it does not claim files were left behind",
+	    !r.source_left_behind);
+}
+
+/*
+ * Moving into a destination that already exists but is empty. The rename path has
+ * to clear it first, because renaming onto an existing directory fails on both
+ * Windows and Unix - and getting that wrong would break the ordinary case where
+ * the user picked a folder with a file browser, which creates it.
+ */
+static void
+test_move_into_existing_empty_dir(const wxString &tmp)
+{
+	const wxString from = tmp + Sep() + "existing-from";
+	const wxString to = tmp + Sep() + "existing-to";
+
+	puts("Moving into a folder that exists and is empty:");
+
+	Nuke(from);
+	Nuke(to);
+	MakeSourceTree(from);
+	wxDir::Make(to, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+
+	const FolderTransferResult r = FolderTransferRun(NULL, from, to,
+	    FolderTransferChoice::Move);
+
+	check("it reports success", r.ok);
+	check("every file arrived", TreeArrived(to));
+}
+
+/* ★ The one that matters. */
+static void
+test_failure_leaves_everything_as_it_was(const wxString &tmp)
+{
+	const wxString from = tmp + Sep() + "fail-from";
+	const wxString to = tmp + Sep() + "fail-to";
+	const wxString unreadable = from + Sep() + "Apps" + Sep() + "Draw";
+
+	puts("A copy that fails part way through changes nothing:");
+
+	Nuke(from);
+	Nuke(to);
+	MakeSourceTree(from);
+
+	/* Unreadable, so the copy of this one file fails. Standing in for the real
+	   cause, a disc that fills up. */
+	if (!SetPerms(unreadable, 0)) {
+		puts("  (cannot make a file unreadable here - skipped)");
+		return;
+	}
+	/* Root ignores permissions, so make sure the arrangement actually worked
+	   before drawing a conclusion from it. */
+	{
+		wxFile probe(unreadable);
+
+		if (probe.IsOpened()) {
+			puts("  (running as root, permissions do not apply - skipped)");
+			SetPerms(unreadable, wxS_DEFAULT);
+			return;
+		}
+	}
+
+	/* The failure is deliberate, so wx's own report of it is not news. Without
+	   this the output carries scary red errors that read as test failures. */
+	FolderTransferResult r;
+	{
+		wxLogNull quiet;
+
+		r = FolderTransferRun(NULL, from, to, FolderTransferChoice::Copy);
+	}
+
+	check("it reports failure", !r.ok);
+	check("it says the files are untouched, and where they are",
+	    r.message.Contains(from));
+
+	/* The destination must not be left half full: it is what the machine would
+	   boot from if the caller had switched the setting. */
+	check("the partial destination has been cleaned up entirely",
+	    !wxDirExists(to) || !wxFileExists(to + Sep() + "!Boot"));
+
+	SetPerms(unreadable, wxS_DEFAULT);
+	check("and the source is intact, including the file that could not be read",
+	    TreeArrived(from));
+}
+
+/*
+ * A move never destroys anything on the way, whichever path it takes.
+ *
+ * Two things are checked, because a move has two implementations. On one
+ * filesystem it is a rename, which cannot half-happen - so the assertion is simply
+ * that it worked and the files are all there. And whatever the path, an occupied
+ * destination is refused outright: the cleanup after a failure removes everything
+ * at the destination, and that is only safe because the destination was empty to
+ * begin with.
+ *
+ * ★ That second check exists because the first version of this test called the
+ * transfer directly with an occupied destination "to prove it is safe on its own",
+ * and it was not - the pre-existing file was deleted during cleanup. The guard in
+ * FolderTransferRun() came from this test failing.
+ */
+static void
+test_move_never_destroys(const wxString &tmp)
+{
+	const wxString from = tmp + Sep() + "failmove-from";
+	const wxString to = tmp + Sep() + "failmove-to";
+
+	puts("A move cannot half-happen, and will not touch an occupied folder:");
+
+	Nuke(from);
+	Nuke(to);
+	MakeSourceTree(from);
+
+	{
+		const FolderTransferResult r = FolderTransferRun(NULL, from, to,
+		    FolderTransferChoice::Move);
+
+		check("on one filesystem it succeeds as a rename", r.ok);
+		check("with everything present afterwards", TreeArrived(to));
+	}
+
+	/* Now the refusal. A file the caller did not put there must survive. */
+	Nuke(from);
+	MakeSourceTree(from);
+	WriteFile(to + Sep() + "someone-elses-file", "precious");
+
+	{
+		const FolderTransferResult r = FolderTransferRun(NULL, from, to,
+		    FolderTransferChoice::Move);
+
+		check("an occupied destination is refused", !r.ok);
+		check("the file that was already there is untouched",
+		    ReadFile(to + Sep() + "someone-elses-file") == "precious");
+		check("and the source is untouched too", TreeArrived(from));
+	}
+}
+
+static void
+test_manual_and_cancel_do_nothing(const wxString &tmp)
+{
+	const wxString from = tmp + Sep() + "noop-from";
+	const wxString to = tmp + Sep() + "noop-to";
+
+	puts("The choices that are not transfers do nothing at all:");
+
+	Nuke(from);
+	Nuke(to);
+	MakeSourceTree(from);
+
+	FolderTransferResult r = FolderTransferRun(NULL, from, to,
+	    FolderTransferChoice::Manual);
+	check("'I'll do it myself' copies nothing", !r.ok && !wxDirExists(to));
+
+	r = FolderTransferRun(NULL, from, to, FolderTransferChoice::Cancel);
+	check("Cancel copies nothing", !r.ok && !wxDirExists(to));
+	check("the source is untouched either way", TreeArrived(from));
+	check("and there is always a message to show", !r.message.empty());
+}
+
+int
+main(int argc, char **argv)
+{
+	wxInitializer init(argc, argv);
+
+	if (!init.IsOk()) {
+		fputs("could not initialise wxWidgets\n", stderr);
+		return EXIT_FAILURE;
+	}
+
+	const wxString tmp = wxFileName::GetTempDir() + Sep() +
+	    wxString::Format("rpcemu-transfer-test-%ld", (long) wxGetProcessId());
+
+	wxDir::Make(tmp, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+
+	test_copy(tmp);
+	test_move(tmp);
+	test_move_into_existing_empty_dir(tmp);
+	test_failure_leaves_everything_as_it_was(tmp);
+	test_move_never_destroys(tmp);
+	test_manual_and_cancel_do_nothing(tmp);
+
+	/* Tidy up, whatever happened. */
+	{
+		static const char *const names[] = {
+			"copy-from", "copy-to", "move-from", "move-to",
+			"existing-from", "existing-to", "fail-from", "fail-to",
+			"failmove-from", "failmove-to", "noop-from", "noop-to"
+		};
+
+		for (const char *n : names) {
+			Nuke(tmp + Sep() + wxString::FromUTF8(n));
+		}
+		wxRmdir(tmp);
+	}
+
+	if (failures != 0) {
+		printf("\n%d check%s failed\n", failures, failures == 1 ? "" : "s");
+		return EXIT_FAILURE;
+	}
+	puts("\nall folder transfer checks passed");
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Stacked on #100 (based on `hostfs-empty-folder-warning`, so review that one first — this diff is only the new work).

Warning somebody they are about to get a blank disc is better than silence. Doing the thing they obviously wanted is better still.

```
  [ Move my files ]   [ Copy my files ]   [ I'll do it myself ]   [ Cancel ]
```

"I'll do it myself" is the old behaviour, warnings and all. Offered for **both** the per-machine HostFS folder and the data folder.

## The ordering is the safety

**The setting is only changed after the transfer has completely succeeded.** A failure leaves both copies on disc and the machine still booting from the folder it was booting from before, so a failed move is an inconvenience rather than a lost hard disc. That matters more than any wording, because people click through warnings.

The rest:

- Nothing is deleted until every file is copied **and verified** — MD5 both sides. A size check passes for a copy truncated by a disc filling up, which is the failure this is for.
- A move within one filesystem is a **rename**: instant whatever the size, and it cannot half-happen.
- A destination with files in it is **refused, never merged**.
- **Refused outright while a machine is running** from either folder — HostFS opens files as the guest asks for them.
- **Free space checked first**, with a margin, since a copy that exactly fills the disc leaves nothing for the machine to write next.

## How it is tested, given it is the most destructive thing we do

The decision (`src/folder_move.c`) is pure and unit tested, because every condition that makes a transfer unsafe — occupied destination, full disc, machine still running — is awkward to arrange for real.

The doing (`src/gui/folder_transfer.cpp`) creates its progress dialogue **only when there is a GUI**. That is what lets `tests/test_folder_transfer.cpp` drive the real copy, verify and delete code on a console build with no display, including a transfer that fails half way through (arranged by making a source file unreadable).

**That test earned its keep immediately.** It called the transfer directly with an occupied destination to check it was "safe on its own" — and it was not: the cleanup-after-failure step deleted a file that was already there. The destination is now checked inside `FolderTransferRun()` as well as in the decision layer, because a destructive function that trusts its caller for the one fact keeping it safe is one refactor away from deleting somebody's files.

## Progress feedback

Named file, running count, remaining time, and a Cancel that leaves everything as it was. Driven under Xvfb against a real 1,830-file RISC OS disc rather than assumed:

```
File 1710 of 1830
!Boot/Resources/!ThemeDefs/Themes/Iyonix/Sprites,ff9
[==================================================    ]
        Elapsed time:  0:00:02
      Estimated time:  0:00:02
      Remaining time:  0:00:00
                                          [ Cancel ]
```

## Two things specific to the data folder

- `rpclog_close()`, because the log lives inside the folder being moved and **Windows will not move an open file**. It reopens at the new location on the next message.
- The running-machine check tries to **take each machine's lock** rather than looking for a lock *file*: the file outlives a crash and would refuse the move for a machine that stopped running last week. The lock underneath is an `flock`, which the kernel drops when the holder dies.

## Verification

- 34 tests on Linux, 34 on the Windows build under Wine
- warnings gate clean, `cli_smoke.sh` green on both binaries
- the GUI path exercised for real: 1,830 files copied and verified under Xvfb
- macOS not exercised locally; covered by CI and by the platform-independent tests

## Open question

`test_folder_transfer` is the first test that links wxWidgets. It needs no display, but if the macOS job dislikes `wxInitializer` in a non-bundled console program I will drop it to wxBase only or gate it — CI will say.