### PR TITLE
Poll the NAT stack per instruction batch, not per loop (#74)

### DIFF
--- a/src/gui/emulator_host.cpp
+++ b/src/gui/emulator_host.cpp
@@ -1611,6 +1611,17 @@ void EmulatorHost::MainEmuLoop()
 				instruction_count.fetch_add(static_cast<int>(inscount >> 16), std::memory_order_release);
 				inscount &= 0xffff;
 			}
+
+			/* Inside the batch, not outside it. The one-in-four rate came
+			   from the Qt front end, where the loop ran execrpcemu() once
+			   per turn; batching 32 of them made the same test fire once
+			   every 32 batches instead, and NAT throughput fell with it. */
+			if (config.network_type == NetworkType_NAT) {
+				network_nat_rate++;
+				if ((network_nat_rate & 0x3u) == 0u) {
+					network_nat_poll();
+				}
+			}
 		}
 
 		if (debugger_is_paused()) {
@@ -1623,13 +1634,6 @@ void EmulatorHost::MainEmuLoop()
 
 		ServiceTimers(GetElapsedTimerNs());
 		perfprof_poll();
-
-		if (config.network_type == NetworkType_NAT) {
-			network_nat_rate++;
-			if ((network_nat_rate & 0x3u) == 0u) {
-				network_nat_poll();
-			}
-		}
 	}
 
 	perfprof_stop();


### PR DESCRIPTION
Fixes #74: downloads inside the guest ran at about 250KB/s.

## Cause

The polling rate is inherited from the upstream RPCEmu Qt front end, which polls the NAT stack once every four `execrpcemu()` calls:

```c
if (config.network_type == NetworkType_NAT) {
    network_nat_rate++;
    if ((network_nat_rate & 0x3u) == 0u) {
        network_nat_poll();
    }
}
```

Upstream's loop runs `execrpcemu()` once per turn, so that test genuinely fires every fourth call. This front end kept the test verbatim but added `kEmuBatch`, running 32 executions per turn, and left the test *outside* that loop. The same "every fourth time" then counted batches rather than executions - a poll once every 128 `execrpcemu()` calls, or every 2,560,000 emulated cycles instead of 80,000.

## Fix

Move the test inside the batch loop so it counts executions again, as it does upstream. The one-in-four ratio is unchanged and the poll interval returns to upstream's 80,000 cycles - this restores the upstream behaviour rather than inventing a new rate for it.

A machine with networking off short-circuits on `config.network_type` before any of this, so it is unaffected.

## Measurements

Downloading the same file in the guest:

| | Throughput |
| --- | --- |
| Before | 257 KB/s |
| This change alone | 5.42 MB/s |
| With the TCP window fix as well | 6.29 MB/s |

The two fixes are independent and compose: this one restores how often the stack is serviced, the window size raises how much can be in flight per round trip.

## Emulated MIPS while downloading

Reported MIPS falls from ~350 idle to ~42 during a saturated download. That is the guest doing the work rather than cycles being lost: at 6.29 MB/s it takes roughly 4,400 frames a second, and each one raises a podule interrupt that RISC OS has to service - emulated instructions, which is what the counter counts. An idle desktop keeps its ~350.

## Testing

Measured on Windows by @david-ramsden. @riscosports has since tested and reports network speeds as expected with no emulator performance loss.

Builds clean with no warnings from this project's own code. 34/35 tests pass; `test_openbus_decode` fails identically on `main` without this change (`assert(ramsize <= 512)` in `mem_reset`) and is unrelated.
