### PR TITLE
Only redraw the invalidated region in scaled/fullscreen display modes

### DIFF
--- a/src/gui/emulator_panel.cpp
+++ b/src/gui/emulator_panel.cpp
@@ -522,8 +522,51 @@ void EmulatorPanel::OnPaint(wxPaintEvent &event)
 			dc.DrawRectangle(dest);
 		}
 
-		dc.StretchBlit(offset_x_, offset_y_, scaled_x_, scaled_y_, &memDC, 0, 0, image_width_,
-		               image_height_, wxCOPY, false);
+		if (scaled_x_ <= 0 || scaled_y_ <= 0) {
+			return;
+		}
+
+		wxRect blit_dest = dest;
+		blit_dest.Intersect(wxRect(offset_x_, offset_y_, scaled_x_, scaled_y_));
+		if (blit_dest.IsEmpty()) {
+			return;
+		}
+
+		/*
+		 * Rescaling the whole guest frame to the whole screen on every paint
+		 * call, even when GetUpdateRegion() said only a few rows were dirty,
+		 * is what pegged a core on macOS: a hardware cursor gets re-marked
+		 * dirty every vsync frame whether or not it moved (vidcthread_gfxcard()
+		 * in vidc20.c), so this ran a full-frame CoreGraphics rescale up to 60
+		 * times a second even on a static desktop - dropping the refresh rate
+		 * didn't help because the per-frame cost, not the rate, dominated.
+		 *
+		 * Map the invalidated destination rect back to source pixels instead,
+		 * padded by one guest pixel on each side so the two rects' scaled edges
+		 * always overlap and no seam is left between repaints, and blit only
+		 * that band - mirroring what the unscaled path below already does.
+		 */
+		int sx0 = (blit_dest.x - offset_x_) * image_width_ / scaled_x_;
+		int sx1 = ((blit_dest.x + blit_dest.width - offset_x_) * image_width_ + scaled_x_ - 1) / scaled_x_;
+		int sy0 = (blit_dest.y - offset_y_) * image_height_ / scaled_y_;
+		int sy1 = ((blit_dest.y + blit_dest.height - offset_y_) * image_height_ + scaled_y_ - 1) / scaled_y_;
+
+		sx0 = std::max(0, sx0 - 1);
+		sy0 = std::max(0, sy0 - 1);
+		sx1 = std::min(image_width_, sx1 + 1);
+		sy1 = std::min(image_height_, sy1 + 1);
+
+		if (sx1 <= sx0 || sy1 <= sy0) {
+			return;
+		}
+
+		const int dx0 = offset_x_ + (sx0 * scaled_x_) / image_width_;
+		const int dx1 = offset_x_ + (sx1 * scaled_x_ + image_width_ - 1) / image_width_;
+		const int dy0 = offset_y_ + (sy0 * scaled_y_) / image_height_;
+		const int dy1 = offset_y_ + (sy1 * scaled_y_ + image_height_ - 1) / image_height_;
+
+		dc.StretchBlit(dx0, dy0, dx1 - dx0, dy1 - dy0, &memDC, sx0, sy0,
+		               sx1 - sx0, sy1 - sy0, wxCOPY, false);
 		return;
 	}
 


### PR DESCRIPTION
## Summary

- `EmulatorPanel::OnPaint()` computed the actual invalidated rect (`dest`) in the full-screen / integer-scaling / fit-to-window path, but then ignored it and rescaled the *entire* guest framebuffer to the *entire* screen on every paint call, regardless of what had actually changed.
- The guest's hardware cursor gets re-marked dirty every vsync frame in `vidcthread_gfxcard()` (`src/vidc20.c`) whether or not it moved, so this ran a full-frame rescale up to 60 times a second even on a static desktop with nothing else happening. Reported as the wxApp thread pegged at 100% CPU in full-screen on macOS, with an Instruments trace pointing at `wxOSXDrawImage`/`StretchBlit` as the hot path — and explaining why lowering the configured refresh rate didn't help much, since the fixed per-frame cost dominated over the rate.
- This code path has no platform-specific branching, so Windows and Linux/GTK builds were doing the same wasted work; macOS's Core Graphics-backed blit is just the one where it showed up worst.
- Fix: map the invalidated destination rect back to source pixels (padded by one guest pixel on each side so the two rects' scaled edges always overlap and no seam is left between repaints) and blit only that band, mirroring what the unscaled window path a few lines below already did correctly.

## Test plan

- [x] Full local build (`cmake --build .` for the `rpcemu-recompiler` GUI target) succeeds with no new warnings from the changed file.
- [x] `ctest` — all 35 existing tests pass.
- [ ] Manual verification in full-screen mode on macOS (cannot be done from this environment) — please confirm CPU usage drops on an idle/static desktop.


---
_Generated by [Claude Code](https://claude.ai/code/session_016Z13QtvPdSrrPSGdJE1DAB)_