### PR TITLE
macOS: show the machine window's menus, and quit when it closes (#53)

### DIFF
--- a/src/gui/emulator_host.cpp
+++ b/src/gui/emulator_host.cpp
@@ -321,13 +321,6 @@ extern "C" void rpcemu_set_host_clipboard_image(int file_type, const void *data,
 	}
 }
 
-extern "C" void rpcemu_send_nat_rule_to_gui(PortForwardRule rule)
-{
-	if (g_emulator_host != nullptr) {
-		g_emulator_host->StoreNatRuleForGui(rule);
-	}
-}
-
 extern "C" void rpcemu_request_poweroff(void)
 {
 	/* Guest soft power-off: ask the active front-end to quit. Fall back to
@@ -1446,26 +1439,6 @@ std::string EmulatorHost::DisassembleAt(uint32_t address, int count)
 
 	disasm_cv_.wait(lock, [this]() { return disasm_ready_ || g_fatal_occurred.load(); });
 	return disasm_result_;
-}
-
-void EmulatorHost::StoreNatRuleForGui(PortForwardRule rule)
-{
-	{
-		std::lock_guard<std::mutex> lock(nat_rules_mutex_);
-		pending_nat_rules_.push_back(rule);
-	}
-
-	if (gui_bridge_ != nullptr) {
-		gui_bridge_->PostNatRule(rule);
-	}
-}
-
-std::vector<PortForwardRule> EmulatorHost::TakePendingNatRules()
-{
-	std::lock_guard<std::mutex> lock(nat_rules_mutex_);
-	std::vector<PortForwardRule> rules(pending_nat_rules_.begin(), pending_nat_rules_.end());
-	pending_nat_rules_.clear();
-	return rules;
 }
 
 void EmulatorHost::NotifyDebuggerStateChanged()

--- a/src/gui/emulator_host.h
+++ b/src/gui/emulator_host.h
@@ -25,7 +25,6 @@
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
-#include <deque>
 #include <mutex>
 #include <queue>
 #include <string>
@@ -220,11 +219,9 @@ public:
 	bool SaveState(const std::string &path);
 	bool LoadState(const std::string &path, std::string *error_out);
 
-	void StoreNatRuleForGui(PortForwardRule rule);
 	/* Host clipboard text, on its way to the guest (emulator thread). */
 	void HostClipboardChanged(int file_type, const std::string &data);
 	void ClipboardEnabled(bool enabled);
-	std::vector<PortForwardRule> TakePendingNatRules();
 
 	void IdleProcessEvents();
 	int64_t GetElapsedTimerNs() const;
@@ -276,9 +273,6 @@ private:
 	bool trace_ready_ = false;
 	std::vector<DebugTraceEvent> trace_result_{};
 	uint32_t trace_dropped_ = 0;
-
-	std::mutex nat_rules_mutex_;
-	std::deque<PortForwardRule> pending_nat_rules_;
 
 	std::atomic<bool> flyback_pending_{false};
 };

--- a/src/gui/gui_bridge.h
+++ b/src/gui/gui_bridge.h
@@ -42,7 +42,6 @@ public:
 	virtual void ShowError(const std::string &message) = 0;
 	virtual void ShowFatal(const std::string &message) = 0;
 
-	virtual void PostNatRule(PortForwardRule rule) = 0;
 	virtual void PostDebuggerStateChanged() = 0;
 	virtual void PostMachineSwitched(const std::string &machine_name) = 0;
 

--- a/src/gui/headless_bridge.cpp
+++ b/src/gui/headless_bridge.cpp
@@ -38,10 +38,6 @@ void HeadlessBridge::PostMoveHostMouse(const MouseMoveUpdate & /*update*/)
 {
 }
 
-void HeadlessBridge::PostNatRule(PortForwardRule /*rule*/)
-{
-}
-
 void HeadlessBridge::PostDebuggerStateChanged()
 {
 }

--- a/src/gui/headless_bridge.h
+++ b/src/gui/headless_bridge.h
@@ -45,7 +45,6 @@ public:
 	void ShowError(const std::string &message) override;
 	void ShowFatal(const std::string &message) override;
 
-	void PostNatRule(PortForwardRule rule) override;
 	void PostDebuggerStateChanged() override;
 	void PostMachineSwitched(const std::string &machine_name) override;
 	void PostGuestCommandResult(unsigned token, unsigned rc,

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -21,6 +21,7 @@
 #include <wx/wx.h>
 #include <wx/cmdline.h>
 #include <wx/display.h>
+#include <wx/evtloop.h>
 
 #include <cstdarg>
 #include <cstdio>
@@ -57,6 +58,27 @@ class RpcemuApp : public wxApp {
 public:
 	bool OnInit() override;
 	void OnInitCmdLine(wxCmdLineParser &parser) override;
+
+	/*
+	 * wxAppConsoleBase::ExitMainLoop() only acts while the main loop is the
+	 * active one, and IsRunning() means exactly that - GetActive() == this. A
+	 * request arriving from anywhere else is dropped without a word, which is
+	 * how closing the machine window left the application running.
+	 *
+	 * ScheduleExit() is wx's answer for that case: it marks the loop to finish
+	 * without needing it to be the active one. It does require the loop to have
+	 * been started, so fall back to the base version when there is none.
+	 */
+	void ExitMainLoop() override
+	{
+		wxEventLoopBase *loop = GetMainLoop();
+
+		if (loop != nullptr && !loop->IsRunning()) {
+			loop->ScheduleExit(0);
+			return;
+		}
+		wxApp::ExitMainLoop();
+	}
 
 private:
 	void InstallSignalHandlers();

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -249,7 +249,6 @@ MainFrame::MainFrame()
 	}
 
 	emulator_ = std::make_unique<EmulatorHost>(this);
-	nat_list_dialog_ = std::make_unique<NatListDialog>(this, emulator_.get());
 
 #ifdef RPCEMU_VNC
 	/*
@@ -752,9 +751,9 @@ void MainFrame::OnMachine(wxCommandEvent &) { EditMachineConfiguration(); }
 void MainFrame::OnNatList(wxCommandEvent &)
 {
 #ifdef RPCEMU_NETWORKING
-	if (nat_list_dialog_) {
-		nat_list_dialog_->ShowRules();
-	}
+	NatListDialog dlg(this, emulator_.get());
+
+	dlg.ShowRules();
 #else
 	/* Networking (and the NAT list) is not compiled in - nothing to do.
 	   (The handler's wxCommandEvent parameter is unnamed, so nothing to void.) */
@@ -1972,11 +1971,6 @@ void MainFrame::ShowFatal(const std::string &message)
 	// which would themselves try to join the spinning thread).
 	fflush(nullptr);
 	std::_Exit(EXIT_FAILURE);
-}
-
-void MainFrame::PostNatRule(PortForwardRule rule)
-{
-	CallAfter([rule]() { NatListDialogNotifyRule(rule); });
 }
 
 void MainFrame::PostDebuggerStateChanged()

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -1808,6 +1808,8 @@ void MainFrame::OnActivate(wxActivateEvent &event)
 	} else if (panel_ != nullptr) {
 		panel_->FocusPanel();
 	}
+	/* wxFrame's handler is what puts this window's menu bar up on macOS. */
+	event.Skip();
 }
 
 /* Let the guest change screen mode to match the host display.

--- a/src/gui/main_frame.h
+++ b/src/gui/main_frame.h
@@ -171,7 +171,6 @@ public:
 	void PostMoveHostMouse(const MouseMoveUpdate &update) override;
 	void ShowError(const std::string &message) override;
 	void ShowFatal(const std::string &message) override;
-	void PostNatRule(PortForwardRule rule) override;
 	void PostDebuggerStateChanged() override;
 	void PostMachineSwitched(const std::string &machine_name) override;
 	void PostGuestCommandResult(unsigned token, unsigned rc,
@@ -294,7 +293,6 @@ private:
 	Config config_copy_{};
 	Model model_copy_ = Model_RPCARM710;
 	std::unique_ptr<EmulatorHost> emulator_;
-	std::unique_ptr<NatListDialog> nat_list_dialog_;
 	MachineInspectorWindow *machine_inspector_window_ = nullptr;
 #ifdef RPCEMU_VNC
 	/* Borrowed from vnc_app: the process owns the server, this window only points

--- a/src/gui/nat_list_dialog.cpp
+++ b/src/gui/nat_list_dialog.cpp
@@ -28,8 +28,6 @@ enum {
 	ID_NAT_LIST_DELETE,
 };
 
-static NatListDialog *g_active_nat_list_dialog = nullptr;
-
 NatListDialog::NatListDialog(wxWindow *parent, EmulatorHost *emulator_host)
 	: wxDialog(parent, wxID_ANY, "Configure NAT Port Forwarding Rules", wxDefaultPosition, wxSize(560, 360),
 	           wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxCLOSE_BOX)
@@ -39,23 +37,6 @@ NatListDialog::NatListDialog(wxWindow *parent, EmulatorHost *emulator_host)
 	LoadRulesFromConfig();
 	Fit();
 	CentreOnParent();
-
-	g_active_nat_list_dialog = this;
-}
-
-NatListDialog::~NatListDialog()
-{
-	if (g_active_nat_list_dialog == this) {
-		g_active_nat_list_dialog = nullptr;
-	}
-	delete nat_edit_dialog_;
-}
-
-void NatListDialogNotifyRule(PortForwardRule rule)
-{
-	if (g_active_nat_list_dialog != nullptr) {
-		g_active_nat_list_dialog->AddNatRule(rule);
-	}
 }
 
 void NatListDialog::BuildUi()

--- a/src/gui/nat_list_dialog.h
+++ b/src/gui/nat_list_dialog.h
@@ -35,7 +35,6 @@ class NatEditDialog;
 class NatListDialog : public wxDialog {
 public:
 	NatListDialog(wxWindow *parent, EmulatorHost *emulator_host);
-	~NatListDialog() override;
 
 	void AddNatRule(PortForwardRule rule);
 
@@ -66,6 +65,5 @@ private:
 	NatEditDialog *nat_edit_dialog_ = nullptr;
 };
 
-void NatListDialogNotifyRule(PortForwardRule rule);
 
 #endif

--- a/src/network-nat.c
+++ b/src/network-nat.c
@@ -313,8 +313,6 @@ network_nat_open(void)
 		for (i = 0; i < MAX_PORT_FORWARDS; i++) {
 			if (port_forward_rules[i].type != PORT_FORWARD_NONE) {
 				network_nat_forward_add(port_forward_rules[i]);
-
-				rpcemu_send_nat_rule_to_gui(port_forward_rules[i]);
 			}
 		}
 	}

--- a/src/rpcemu.h
+++ b/src/rpcemu.h
@@ -466,7 +466,6 @@ extern int debugger_swi_hook(uint32_t swinum, uint32_t opcode);
 extern void rpcemu_video_update(const uint32_t *buffer, int xsize, int ysize, int yl, int yh, int double_size, int host_xsize, int host_ysize);
 extern void rpcemu_move_host_mouse(uint16_t x, uint16_t y);
 extern void rpcemu_idle_process_events(void);
-extern void rpcemu_send_nat_rule_to_gui(PortForwardRule rule);
 extern uint64_t rpcemu_nsec_timer_ticks(void);
 
 extern int drawscre;

--- a/tests/test_stubs.c
+++ b/tests/test_stubs.c
@@ -58,7 +58,6 @@ void rpcemu_video_update(const uint32_t *buffer, int xsize, int ysize, int yl,
 void rpcemu_move_host_mouse(uint16_t x, uint16_t y) { (void) x; (void) y; }
 void rpcemu_idle_process_events(void) {}
 void rpcemu_request_poweroff(void) {}
-void rpcemu_send_nat_rule_to_gui(void) {}
 /* Emulated time. Most tests never run a timer and are happy with zero, but a
    test that boots a machine must have time advance or the IOMD timers never fire
    and RISC OS waits for an interrupt for ever. Such a test defines


### PR DESCRIPTION
Fixes #53, reported by @riscos-richard: closing a machine left RPCEmu running in the Dock with a menu bar that did nothing, and the machine window's own menus never appeared.

Three faults, one commit each.

## 1. The machine window's menus never appeared

`MainFrame::OnActivate()` handled the event and stopped there. On macOS the menu bar belongs to the application rather than to a window, and `wxFrame::OnActivate()` is what installs the active window's bar (`src/osx/carbon/frame.cpp:214`), so without `event.Skip()` File, Disc, Settings, Tools and Debug were never put up at all.

## 2. Closing the machine window did not quit

`wxAppConsoleBase::ExitMainLoop()` only acts while the main loop is the *active* one - `IsRunning()` is literally `GetActive() == this` (`include/wx/evtloop.h:366`) - and returns without a word otherwise. Closing the window asked to exit at a point where no loop was active, so the request was dropped and the process stayed in the Dock.

`ScheduleExit()` is wx's answer for that case: it marks the loop to finish without needing it to be active, asking only that `Run()` has been entered, which `IsInsideRun()` reports independently of nesting.

## 3. Two hidden dialogues kept the application alive

`NatListDialog` and its child `NatEditDialog` were built with the machine window and kept hidden. `wxTopLevelWindow::ShouldPreventAppExit()` returns true by default and takes no notice of whether a window is shown (`include/wx/toplevel.h:231`), so wx counted both and never treated the machine window as the last one.

They were built up front to catch rules pushed from the emulator thread. That bridge is inherited from the Qt front end, where the dialogue only built widgets and the signal was the sole thing that filled its list. The wx rewrite added `LoadRulesFromConfig()`, and 8b69b08 moved it into `ShowRules()`, so both ends now read `port_forward_rules[]` and everything the bridge delivered was overwritten before anyone saw it - and it only ever fired once, at NAT startup, for rules just read from the config.

So the dialogue is built when it is asked for, like every other dialogue here, and the bridge goes. `TakePendingNatRules()` and its deque had no callers at all, and the test stub for `rpcemu_send_nat_rule_to_gui()` declared it taking no argument against a header saying `PortForwardRule`.

That removes two hidden top level windows per machine **on every platform**, and with them the reason for any `ShouldPreventAppExit()` override.

## Testing

macOS: the red X and Cmd-Q both quit cleanly and the Dock icon goes; the machine window's menus all work; the NAT dialogue lists its rules and add/edit/delete behave.

Linux: NAT rules add, edit and delete with no duplicates, and the dialogue survives repeated open/close. Builds clean; 34/35 tests pass, `test_openbus_decode` failing identically on `main`.

## Two things deliberately left out

- **The application menu before a machine starts is minimal.** The selector is a modal dialogue, exactly as on Windows and Linux, neither of which offers a menu bar there. Making Cmd-Q work at that point needs a non-modal selector, which is a larger change than this.
- **A pre-existing segfault**, found while testing and reproduced with this branch's changes stashed out: switching networking Off then back to NAT crashes in `slirp_select_fill`. The emulator thread polls on `config.network_type == NetworkType_NAT` alone, so it can enter `network_nat_poll()` while `nat.slirp` is still NULL. Raising separately.
