### PR TITLE
Do not poll a NAT stack that is not there yet

### DIFF
--- a/src/network-nat.c
+++ b/src/network-nat.c
@@ -376,6 +376,12 @@ network_nat_poll(void)
 	int fd_max, ret;
 	struct timeval tv;
 
+	/* Networking can be switched on while the emulator thread is running, so
+	   this is reached before network_nat_open() has made a stack to poll. */
+	if (nat.slirp == NULL) {
+		return;
+	}
+
 	FD_ZERO(&rfds);
 	FD_ZERO(&wfds);
 	FD_ZERO(&efds);


### PR DESCRIPTION
Switching a running machine's networking from Off to NAT segfaulted:

```
Thread 10 "rpcemu-recompil" received signal SIGSEGV, Segmentation fault.
#0  slirp_select_fill ()
#1  network_nat_poll ()
#2  EmulatorHost::MainEmuLoop ()
```

## Cause

The emulator thread decides whether to poll on `config.network_type` alone:

```c
if (config.network_type == NetworkType_NAT) {
    network_nat_rate++;
    if ((network_nat_rate & 0x3u) == 0u) {
        network_nat_poll();
    }
}
```

The machine settings dialogue writes that value straight into the live configuration from the GUI thread as soon as it is accepted - `config_apply_machine_edit()`, reached from `MachineEditDialog::ApplySavedSettingsToGlobalConfig()`. The emulator thread is running throughout, so it sees NAT on the next turn of the loop, which is before the machine has reset and run `network_nat_open()`. `nat.slirp` is still NULL, and `network_nat_poll()` passes it to SLiRP unguarded.

The other thread in the backtrace confirms it: thread 1 is inside `EditMachineConfiguration()` showing the modal dialogue while thread 10 dies.

## Fix

Return early when there is no stack to poll.

`network_nat_tx()` uses `nat.slirp` too but is not exposed the same way: the podule the guest reaches it through is registered only after initialisation succeeds (`src/network.c:359`), so the guest cannot call it first.

## Testing

Reproduced and confirmed fixed on Linux: Off -> NAT on a running machine no longer crashes.

Not yet exercised: the NAT -> Off direction, and macOS and Windows. The change is a null check in shared code with no platform-specific behaviour, so I would expect it to hold, but it has not been run there.

## Two things left alone

- **`network_nat_close()` never tears the stack down.** `slirp_cleanup()` is declared in `src/slirp/libslirp.h:22` but never called, so switching NAT off leaks the SLiRP stack and a later re-enable silently reuses the old one (`network_nat_open()` only builds a stack `if (nat.slirp == NULL)`). Freeing it properly wants the threading below sorted out first, or the leak becomes a use-after-free.
- **`config.network_type` is shared mutable state**, written by the GUI thread and read by the emulator thread with no synchronisation. This check makes the crash impossible rather than making the access safe. Worth addressing on its own.

Found while testing #108, but unrelated to it: it reproduces on `main` with that branch's changes stashed out.
