### PR TITLE
test_openbus_decode: ask mem_reset() for 8MB, not 8388608MB (#109)

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -164,7 +164,7 @@ mem_reset(uint32_t ramsize, uint32_t vram_size)
 	   SDRAM banks (physical 0x20000000 and 0x30000000). */
 	have_sdram = ramsize > 256;
 
-	/* Convert ramsize from bytes to megabytes */
+	/* Convert ramsize from megabytes to bytes */
 	ramsize *= (1024 * 1024);
 
 	if (have_sdram) {

--- a/tests/test_openbus_decode.c
+++ b/tests/test_openbus_decode.c
@@ -63,7 +63,7 @@ main(void)
 {
 	/* Enough of a machine for the physical accessors to work. */
 	mem_init();
-	mem_reset(8 * 1024 * 1024, 0);
+	mem_reset(8, 0);
 
 	puts("With an empty second slot, the window is not claimed:");
 	openbus_init(&ops);


### PR DESCRIPTION
Fixes #109.

`mem_reset()` takes megabytes - `@param ramsize Amount of RAM in megabytes` - but the test passed bytes:

```c
mem_reset(8 * 1024 * 1024, 0);
```

asking for 8,388,608MB where it meant 8MB. Every other caller passes plain megabytes.

## Why CI never noticed

`mem_reset()` opens with `assert(ramsize <= 512)`. A `Release` build defines `NDEBUG`, so that is compiled out and the value goes through. The clamp for non-Kinetic models then turns it into 256MB, and the test stands up a two-SIMM 256MB machine plus a 128MB second SIMM - passing, because the OPEN Bus decode does not depend on RAM size, having allocated ~256MB to prove it.

Build with assertions live and it aborts instead:

```
test_openbus_decode: src/mem.c:154: mem_reset: Assertion `ramsize <= 512' failed.
```

## Changes

- `tests/test_openbus_decode.c` asks for 8MB.
- The comment above the multiply in `mem_reset()` said "Convert ramsize from bytes to megabytes" over code doing the opposite. Since the parameter is documented correctly, that comment is the likeliest source of the mistake, so it is corrected.

## Testing

Both build types, before and after:

| | before | after |
| --- | --- | --- |
| Release (`NDEBUG`) | passes, 0.92s | passes, 0.02s |
| assertions live | **aborts** | passes |

The full suite is now 36/36 with assertions enabled; it was 35/36 before.

The drop from 0.92s to 0.02s is the 256MB of allocation going away.
