### PR TITLE
Manager window - multi-machine on Windows, and fixes found testing it

### DIFF
--- a/src/gui/machine_ipc.cpp
+++ b/src/gui/machine_ipc.cpp
@@ -574,6 +574,17 @@ void MachineIpcClient::ReadLoop()
 
 	while (connected_.load()) {
 		if (!RecvExact(fd_, &ev, sizeof(ev), &connected_)) {
+			/* Losing the connection is the only notice that a machine the
+			   Manager attached to, rather than started, has gone: there is no
+			   process to watch and nothing sends an explicit Quit. Tested
+			   again because Disconnect() clears it, and a disconnection this
+			   end asked for is not news. */
+			if (connected_.load() && on_event_) {
+				IpcEvent gone{};
+
+				gone.type = IpcEventType::Quit;
+				on_event_(gone);
+			}
 			break;
 		}
 		if (on_event_) {

--- a/src/gui/machine_ipc.cpp
+++ b/src/gui/machine_ipc.cpp
@@ -245,10 +245,29 @@ bool SharedFramebuffer::ReadInto(std::vector<uint32_t> *out, int *width, int *he
 	return true;
 }
 
-std::string MachineIpcNameFor(const std::string &machine_dir, long pid)
+/* FNV-1a rather than std::hash, which is only required to agree within one
+   execution - and this name is arrived at separately by two processes. */
+static uint32_t NameHash(const std::string &s)
 {
-	const size_t h = std::hash<std::string>{}(machine_dir);
-	char buf[64];
+	uint32_t h = 2166136261u;
+
+	for (unsigned char c : s) {
+		h = (h ^ c) * 16777619u;
+	}
+	return h;
+}
+
+std::string MachineIpcNameFor(const std::string &data_dir,
+                              const std::string &machine_name, long pid)
+{
+	/* Enough to tell machines apart at a glance, and keeps the whole name
+	   inside the shortest limit: Windows object names are capped at MAX_PATH
+	   including the "Local\" prefix Map() adds. */
+	static const size_t kMaxNameChars = 32;
+
+	const uint32_t h = NameHash(data_dir);
+	const std::string shown = machine_name.substr(0, kMaxNameChars);
+	char buf[128];
 
 	if (pid < 0) {
 #ifdef _WIN32
@@ -258,13 +277,11 @@ std::string MachineIpcNameFor(const std::string &machine_dir, long pid)
 #endif
 	}
 
-#ifdef _WIN32
-	std::snprintf(buf, sizeof(buf), "rpcemu-fb-%08lx-%ld",
-	    (unsigned long) (h & 0xffffffffu), pid);
-#else
-	std::snprintf(buf, sizeof(buf), "/rpcemu-fb-%08lx-%ld",
-	    (unsigned long) (h & 0xffffffffu), pid);
-#endif
+	/* The hash covers the data directory alone: names are unique within one,
+	   and two RPCEmus on different --datadir trees can each hold a machine of
+	   the same name. */
+	std::snprintf(buf, sizeof(buf), "rpcemu-fb-%08lx-%s-%ld",
+	    (unsigned long) h, shown.c_str(), pid);
 	return std::string(buf);
 }
 

--- a/src/gui/machine_ipc.cpp
+++ b/src/gui/machine_ipc.cpp
@@ -598,6 +598,10 @@ void MachineIpcClient::Disconnect()
 {
 	connected_ = false;
 	if (fd_ >= 0) {
+		/* Before the close, not instead of it: WSAPoll() does not report a
+		   handle closed underneath it, so the reader stayed in poll() and the
+		   join below waited for ever. */
+		shutdown(fd_, SHUT_RDWR);
 		closesocket(fd_);
 	}
 	if (read_thread_.joinable()) {

--- a/src/gui/machine_ipc.cpp
+++ b/src/gui/machine_ipc.cpp
@@ -448,6 +448,9 @@ void MachineIpcServer::AcceptLoop()
 		if (cfd < 0) {
 			continue;
 		}
+#ifdef _WIN32
+		socket_set_nodelay(cfd);	/* the other platforms use AF_UNIX */
+#endif
 
 		/* One client at a time - the Manager. A fresh connection (e.g. the
 		   Manager restarting after a crash) replaces whatever was there,
@@ -563,6 +566,7 @@ bool MachineIpcClient::Connect(const std::string &endpoint,
 		closesocket(fd);
 		return false;
 	}
+	socket_set_nodelay(fd);
 #else
 	struct sockaddr_un addr;
 	if (endpoint.empty() || endpoint.size() >= sizeof(addr.sun_path)) {

--- a/src/gui/machine_ipc.cpp
+++ b/src/gui/machine_ipc.cpp
@@ -73,30 +73,31 @@ bool SharedFramebuffer::Map(const std::string &name, bool create)
 	}
 	file_mapping_handle_ = handle;
 #else
+	const std::string full = "/" + name;	/* shm_open names begin with one */
 	int flags = create ? (O_CREAT | O_RDWR | O_EXCL) : O_RDWR;
-	int fd = shm_open(name.c_str(), flags, 0600);
+	int fd = shm_open(full.c_str(), flags, 0600);
 
 	if (fd < 0 && create && errno == EEXIST) {
 		/* A segment from a previous run of this pid survived somehow (the
 		   name already includes the pid, so a genuine collision would mean
 		   pid reuse racing us, vanishingly unlikely) - clear it rather than
 		   fail outright. */
-		shm_unlink(name.c_str());
-		fd = shm_open(name.c_str(), O_CREAT | O_RDWR | O_EXCL, 0600);
+		shm_unlink(full.c_str());
+		fd = shm_open(full.c_str(), O_CREAT | O_RDWR | O_EXCL, 0600);
 	}
 	if (fd < 0) {
 		return false;
 	}
 	if (create && ftruncate(fd, (off_t) total) != 0) {
 		close(fd);
-		shm_unlink(name.c_str());
+		shm_unlink(full.c_str());
 		return false;
 	}
 	mem = mmap(nullptr, total, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
 	close(fd);	/* the mapping keeps the segment alive; the fd is not needed after mmap */
 	if (mem == MAP_FAILED) {
 		if (create) {
-			shm_unlink(name.c_str());
+			shm_unlink(full.c_str());
 		}
 		return false;
 	}
@@ -165,7 +166,9 @@ void SharedFramebuffer::Close()
 	   to do here even for the owner. */
 #else
 	if (owner_ && !name_.empty()) {
-		shm_unlink(name_.c_str());
+		const std::string full = "/" + name_;
+
+		shm_unlink(full.c_str());
 	}
 #endif
 	header_ = nullptr;

--- a/src/gui/machine_ipc.h
+++ b/src/gui/machine_ipc.h
@@ -126,10 +126,14 @@ private:
 };
 
 /*
- * A shared-memory segment name unique to one machine run, derived from its
- * own data directory and the owning process's pid so two launches of the
- * same machine (which machine_lock already refuses) can never collide, and a
- * stale segment from a killed process is unambiguous to spot.
+ * A shared-memory segment name unique to one machine run: the data directory
+ * hashed, the machine's name, and the owning process's pid. The pid means two
+ * launches of the same machine (which machine_lock already refuses) can never
+ * collide, and a stale segment from a killed process is unambiguous to spot.
+ *
+ * Both the machine and the Manager work this out separately, so it is built
+ * from the two things each can state exactly rather than from a path one of
+ * them has to reconstruct.
  *
  * `pid` must be the pid of the process that called (or will call)
  * CreateNew() - the managed child - not the caller's own pid. The child
@@ -140,7 +144,8 @@ private:
  * the Manager's pid is never the child's, so the two processes named two
  * different segments and OpenExisting() always failed.
  */
-std::string MachineIpcNameFor(const std::string &machine_dir, long pid = -1);
+std::string MachineIpcNameFor(const std::string &data_dir,
+                              const std::string &machine_name, long pid = -1);
 
 /* ----------------------------------------------------------------------
  * Control channel wire messages

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -30,6 +30,7 @@
 #include <string>
 
 #ifdef __WXMSW__
+#include <winsock2.h>	/* before windows.h, or the old winsock.h clashes */
 #include <windows.h>
 #endif
 
@@ -801,6 +802,21 @@ bool RpcemuApp::OnInit()
 			 * do. A scripted or remote launch that wants exactly one machine
 			 * and nothing else still has --machine for that.
 			 */
+#ifdef __WXMSW__
+			/* This process stops short of rpcemu_prestart(), which is what
+			   starts Winsock, and it still opens a socket to every machine it
+			   shows. Without this those connections failed with
+			   WSANOTINITIALISED and no machine ever appeared. */
+			{
+				WSADATA wsadata;
+
+				if (WSAStartup(MAKEWORD(2, 2), &wsadata) != 0) {
+					wxMessageBox("Could not start Windows Sockets.",
+					    "RPCEmu Extended Manager", wxOK | wxICON_ERROR);
+					return false;
+				}
+			}
+#endif
 			auto *manager = new ManagerFrame();
 			manager->Show(true);
 			SetTopWindow(manager);

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -332,10 +332,8 @@ void MainFrame::EnableManagedMode()
 {
 	managed_mode_ = true;
 
-	const std::string machine_dir = rpcemu_get_machine_datadir();
-
 	shared_fb_ = std::make_unique<SharedFramebuffer>();
-	if (!shared_fb_->CreateNew(MachineIpcNameFor(machine_dir))) {
+	if (!shared_fb_->CreateNew(MachineIpcNameFor(rpcemu_get_datadir(), config.name))) {
 		rpclog("MainFrame: could not create the shared framebuffer; "
 		       "this machine will not be visible to the Manager\n");
 	}
@@ -345,7 +343,8 @@ void MainFrame::EnableManagedMode()
 #ifdef _WIN32
 	const std::string control_endpoint;	/* --managed always gets an OS-assigned TCP port on Windows */
 #else
-	const std::string control_endpoint = machine_dir + "manager.sock";
+	const std::string control_endpoint =
+	    std::string(rpcemu_get_machine_datadir()) + "manager.sock";
 #endif
 
 	if (ipc_server_->Start(control_endpoint,

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -938,6 +938,23 @@ void ManagerFrame::StopMachine(const wxString &name)
 	   whatever state it is in. Asking twice is harmless. */
 }
 
+/* Ask every machine to stop, and close once they have. */
+void ManagerFrame::StopAllAndClose()
+{
+	closing_after_stop_ = true;
+
+	std::vector<wxString> names;
+
+	for (const auto &entry : running_) {
+		names.push_back(entry.first);
+	}
+	for (const wxString &name : names) {
+		StopMachine(name);
+	}
+
+	UpdateButtons();
+}
+
 void ManagerFrame::RemoveRunningEntry(const wxString &name)
 {
 	auto it = running_.find(name);
@@ -966,6 +983,13 @@ void ManagerFrame::RemoveRunningEntry(const wxString &name)
 
 	running_.erase(it);
 	RefreshMachineList();
+
+	/* The last one asked to stop before closing has gone, so the window can
+	   follow it. Queued rather than closed here: this runs from a panel
+	   callback, and Close() would take that panel down underneath it. */
+	if (closing_after_stop_ && running_.empty()) {
+		CallAfter([this]() { Close(true); });
+	}
 }
 
 void ManagerFrame::OnChildProcessEnded(const wxString &machine_name, int /*pid*/, int /*status*/)
@@ -1713,6 +1737,35 @@ void ManagerFrame::OnExit(wxCommandEvent & /*event*/)
 
 void ManagerFrame::OnClose(wxCloseEvent &event)
 {
+	/*
+	 * A machine outliving this window is the intended behaviour, but not an
+	 * obvious one: nothing on screen afterwards says the machine is still
+	 * there. Say so, and offer the other choice.
+	 */
+	if (!running_.empty() && !closing_after_stop_) {
+		const size_t count = running_.size();
+		wxRichMessageDialog dlg(this,
+		    wxString::Format("%zu machine%s still running.", count,
+		        count == 1 ? " is" : "s are"),
+		    "RPCEmu Extended Manager", wxOK | wxCANCEL | wxICON_QUESTION);
+
+		dlg.SetExtendedMessage(
+		    "Closing this window leaves them running in the background.\n\n"
+		    "Opening RPCEmu Extended again reconnects to them.");
+		dlg.ShowCheckBox("Stop the running machines first", false);
+
+		if (dlg.ShowModal() != wxID_OK) {
+			event.Veto();
+			return;
+		}
+
+		if (dlg.IsCheckBoxChecked()) {
+			StopAllAndClose();
+			event.Veto();	/* closes itself once they have gone */
+			return;
+		}
+	}
+
 	/* Running machines are independent processes and are left running,
 	   exactly as closing VirtualBox's or VMware Workstation's manager
 	   window does not stop the VMs it was showing - only Stop, or closing

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -546,9 +546,12 @@ wxString ManagerFrame::MachineDirFor(const wxString &name) const
 	/* Matches rpcemu_set_machine_datadir()'s convention exactly (see
 	   rpc-machdep.c) - this process never loads any machine's config, so it
 	   has to compute the directory the same way rather than ask the core
-	   for "the" machine directory, which is a single-machine notion. */
-	return wxString::FromUTF8(rpcemu_get_datadir()) + "machines" +
-	    wxFileName::GetPathSeparator() + name + wxFileName::GetPathSeparator();
+	   for "the" machine directory, which is a single-machine notion.
+
+	   Forward slashes, as that function writes them, rather than the host's
+	   separator: the string is hashed to name the shared framebuffer, so on
+	   Windows a backslash here named one the machine had not created. */
+	return wxString::FromUTF8(rpcemu_get_datadir()) + "machines/" + name + "/";
 }
 
 void ManagerFrame::RefreshMachineList()

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -320,7 +320,13 @@ void ManagerFrame::PositionCollapseButton()
 
 void ManagerFrame::OnStatusBarSize(wxSizeEvent &event)
 {
+	wxStatusBar *status = GetStatusBar();
+
 	PositionCollapseButton();
+	/* Moving the button by hand leaves the fields unpainted. */
+	if (status != nullptr) {
+		status->Refresh();
+	}
 	event.Skip();
 }
 

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -692,7 +692,7 @@ void ManagerFrame::DiscoverAlreadyRunningMachines()
 			continue;	/* running, but not as a --managed child - nothing for us to attach to */
 		}
 
-		AttachPanelFor(name, wxString::FromUTF8(MachineIpcNameFor(dir.utf8_str().data(), pid)),
+		AttachPanelFor(name, wxString::FromUTF8(MachineIpcNameFor(rpcemu_get_datadir(), name.utf8_str().data(), pid)),
 		    wxString::FromUTF8(endpoint), false);
 	}
 	RefreshMachineList();
@@ -863,7 +863,7 @@ void ManagerFrame::OnPollTimer(wxTimerEvent & /*event*/)
 		    machine_lock_owner_alive(pid) &&
 		    machine_lock_read_ipc_endpoint(dir.utf8_str().data(), endpoint, sizeof(endpoint)) &&
 		    endpoint[0] != '\0') {
-			AttachPanelFor(name, wxString::FromUTF8(MachineIpcNameFor(dir.utf8_str().data(), pid)),
+			AttachPanelFor(name, wxString::FromUTF8(MachineIpcNameFor(rpcemu_get_datadir(), name.utf8_str().data(), pid)),
 			    wxString::FromUTF8(endpoint), true);
 
 			/* Still starting means the attempt failed, so fall through to

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -23,6 +23,7 @@
 #include <wx/dcmemory.h>
 #include <wx/dir.h>
 #include <wx/filename.h>
+#include <wx/progdlg.h>
 #include <wx/statbmp.h>
 #include <wx/stdpaths.h>
 #include <wx/textdlg.h>
@@ -937,7 +938,32 @@ void ManagerFrame::OnClone(wxCommandEvent & /*event*/)
 
 	const wxString dest_path = ConfigPathsConfigsDir() + wxFileName::GetPathSeparator() + sanitized + ".cfg";
 	wxCopyFile(source_path, dest_path);
-	ConfigPathsCopyDirectory(MachineDirFor(name), MachineDirFor(sanitized));
+
+	/* Pulsed rather than counted: the copy walks the tree as it goes, and
+	   counting it first would mean walking the whole thing twice to tell
+	   somebody a number they are not waiting on. */
+	bool copied;
+	{
+		wxProgressDialog progress("Clone Machine",
+		    wxString::Format("Copying '%s'...", name), 100, this,
+		    wxPD_APP_MODAL | wxPD_AUTO_HIDE | wxPD_ELAPSED_TIME);
+		int seen = 0;
+
+		copied = ConfigPathsCopyDirectory(MachineDirFor(name),
+		    MachineDirFor(sanitized),
+		    [&progress, &seen](const wxString &) {
+			    if ((++seen & 0x1f) == 0) {
+				    progress.Pulse();
+			    }
+		    });
+	}
+
+	if (!copied) {
+		wxRemoveFile(dest_path);
+		wxMessageBox("Could not copy the machine's files.", "Clone Machine",
+		             wxOK | wxICON_ERROR, this);
+		return;
+	}
 
 	RefreshMachineList();
 }
@@ -958,20 +984,44 @@ void ManagerFrame::OnDelete(wxCommandEvent & /*event*/)
 
 	wxRemoveFile(ConfigPathsConfigsDir() + wxFileName::GetPathSeparator() + name + ".cfg");
 
-	wxArrayString files;
+	/*
+	 * The files go one at a time so there is something to report: a machine's
+	 * hard disc is thousands of them, and the window answers nothing while they
+	 * are removed. What is left afterwards is the empty directories they were
+	 * in, which the recursive remove clears in one quick pass - GetAllFiles()
+	 * reports files only, so nothing here would otherwise take them.
+	 */
 	const wxString dir = MachineDirFor(name);
 	if (wxDirExists(dir)) {
+		wxArrayString files;
+
 		wxDir::GetAllFiles(dir, &files);
-		files.Sort();
-		std::reverse(files.begin(), files.end());
-		for (const auto &f : files) {
-			if (wxDirExists(f)) {
-				wxRmdir(f);
-			} else {
-				wxRemoveFile(f);
+
+		{
+			wxProgressDialog progress("Delete Machine",
+			    wxString::Format("Deleting '%s'...", name),
+			    static_cast<int>(files.GetCount()), this,
+			    wxPD_APP_MODAL | wxPD_AUTO_HIDE | wxPD_ELAPSED_TIME);
+
+			for (size_t i = 0; i < files.GetCount(); i++) {
+				wxRemoveFile(files[i]);
+				/* Every so often rather than every file: the update costs more
+				   than the unlink, and a bar moving in steps of one is no more
+				   informative. */
+				if ((i & 0x1f) == 0) {
+					progress.Update(static_cast<int>(i));
+				}
 			}
 		}
-		wxRmdir(dir);
+
+		if (!wxFileName::Rmdir(dir, wxPATH_RMDIR_RECURSIVE)) {
+			wxMessageBox(wxString::Format(
+			                 "'%s' has been removed from the list, but its data "
+			                 "could not be deleted from\n\n%s\n\nYou may want to "
+			                 "remove that folder yourself.",
+			                 name, dir),
+			             "Delete Machine", wxOK | wxICON_WARNING, this);
+		}
 	}
 
 	RefreshMachineList();

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -76,11 +76,11 @@ enum {
 	kStatusIconStopped,
 };
 
-/* How long a --managed child gets to publish its control-channel endpoint
-   before the Manager gives up on it (ROM loading and machine start can
-   legitimately take a few seconds; a genuinely wedged/crashed launch should
-   not hang the UI forever). */
-constexpr int kStartupTimeoutMs = 20000;
+/* How long a --managed child gets to publish its control-channel endpoint and
+   become attachable. Only process startup happens in that window - the child
+   publishes before rpcemu_start(), so ROM loading and booting RISC OS are on
+   the far side of it and a machine reads as "Running" throughout them. */
+constexpr int kStartupTimeoutMs = 10000;
 constexpr int kPollIntervalMs = 200;
 
 /* A small filled circle for the machine list's status column - cheaper and

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -545,15 +545,12 @@ void ManagerFrame::BuildToolBar()
 
 wxString ManagerFrame::MachineDirFor(const wxString &name) const
 {
-	/* Matches rpcemu_set_machine_datadir()'s convention exactly (see
-	   rpc-machdep.c) - this process never loads any machine's config, so it
-	   has to compute the directory the same way rather than ask the core
-	   for "the" machine directory, which is a single-machine notion.
+	/* Named, not current: this process never loads any machine's
+	   configuration, so rpcemu_get_machine_datadir() has nothing to answer. */
+	char dir[1024];
 
-	   Forward slashes, as that function writes them, rather than the host's
-	   separator: the string is hashed to name the shared framebuffer, so on
-	   Windows a backslash here named one the machine had not created. */
-	return wxString::FromUTF8(rpcemu_get_datadir()) + "machines/" + name + "/";
+	rpcemu_machine_datadir_for(dir, sizeof(dir), name.utf8_str().data());
+	return wxString::FromUTF8(dir);
 }
 
 void ManagerFrame::RefreshMachineList()

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -25,6 +25,7 @@
 #include <wx/dir.h>
 #include <wx/filename.h>
 #include <wx/progdlg.h>
+#include <wx/richmsgdlg.h>
 #include <wx/statbmp.h>
 #include <wx/stdpaths.h>
 #include <wx/textdlg.h>
@@ -704,12 +705,24 @@ void ManagerFrame::AttachPanelFor(const wxString &name, const wxString &shared_f
 
 	if (!panel->IsLive()) {
 		/* Stale lock / the process ended between discovery and here. */
+		const wxString why = panel->AttachError();
+
 		panel->Destroy();
-		if (newly_started) {
-			wxMessageBox("'" + name + "' did not start.", "RPCEmu Extended Manager",
-			    wxOK | wxICON_ERROR, this);
-		}
 		RemoveRunningEntry(name);
+		if (newly_started) {
+			/* What went wrong is names and sockets, which mean nothing to
+			   somebody who only wanted to run a machine - so it goes behind
+			   Details, where it is still there for a bug report. */
+			wxRichMessageDialog dlg(this,
+			    wxString::Format("'%s' started but could not be displayed.", name),
+			    "RPCEmu Extended Manager", wxOK | wxICON_ERROR);
+
+			dlg.SetExtendedMessage(
+			    "The machine may still be running. Stopping it and starting it "
+			    "again usually clears this.");
+			dlg.ShowDetailedText(why);
+			dlg.ShowModal();
+		}
 		return;
 	}
 
@@ -855,9 +868,9 @@ void ManagerFrame::OnPollTimer(wxTimerEvent & /*event*/)
 		}
 
 		if ((wxGetLocalTimeMillis() - it->second.start_time_ms).ToLong() > kStartupTimeoutMs) {
+			RemoveRunningEntry(name);
 			wxMessageBox("'" + name + "' did not finish starting in time.",
 			    "RPCEmu Extended Manager", wxOK | wxICON_ERROR, this);
-			RemoveRunningEntry(name);
 		}
 	}
 }

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -293,8 +293,7 @@ void ManagerFrame::BuildUi()
 	    wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
 	collapse_button_->SetToolTip("Hide the machine list");
 	collapse_button_->Bind(wxEVT_BUTTON, [this](wxCommandEvent &) {
-		SetMachinesPanelCollapsed(
-		    splitter_->GetSashPosition() > kMachinesPanelCollapsed);
+		SetMachinesPanelCollapsed(!machines_panel_collapsed_);
 	});
 	status->Bind(wxEVT_SIZE, &ManagerFrame::OnStatusBarSize, this);
 	PositionCollapseButton();
@@ -334,11 +333,16 @@ void ManagerFrame::OnStatusBarSize(wxSizeEvent &event)
 void ManagerFrame::SetMachinesPanelCollapsed(bool collapsed)
 {
 	if (collapsed) {
-		machines_panel_width_ = splitter_->GetSashPosition();
+		const int width = splitter_->GetSashPosition();
+
+		if (width > kMachinesPanelCollapsed) {
+			machines_panel_width_ = width;
+		}
 		splitter_->SetSashPosition(kMachinesPanelCollapsed);
 	} else {
 		splitter_->SetSashPosition(machines_panel_width_);
 	}
+	machines_panel_collapsed_ = collapsed;
 
 	if (collapse_button_ != nullptr) {
 		collapse_button_->SetBitmap(wxArtProvider::GetBitmap(

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -1692,6 +1692,12 @@ void ManagerFrame::OnClose(wxCloseEvent &event)
 			proc->Forget();
 			proc->Detach();
 		}
+		/* Here rather than in the panel's destructor: closing a connection
+		   waits for its reader thread, and doing that as the window came down
+		   stopped the window coming down at all. */
+		if (entry.second.panel != nullptr) {
+			entry.second.panel->CloseConnection();
+		}
 	}
 	poll_timer_.Stop();
 	event.Skip();

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -20,6 +20,7 @@
 
 #include "manager_frame.h"
 
+#include <wx/artprov.h>
 #include <wx/dcmemory.h>
 #include <wx/dir.h>
 #include <wx/filename.h>
@@ -47,6 +48,12 @@ extern "C" {
 }
 
 namespace {
+
+/* Where the sash stops, so a collapsed machine list is still visibly a list
+   rather than an edge, and the width of the status bar field the button that
+   collapses it sits in. */
+const int kMachinesPanelCollapsed = 12;
+const int kCollapseButtonField = 28;
 
 enum {
 	ID_NEW = wxID_HIGHEST + 500,
@@ -216,7 +223,10 @@ void ManagerFrame::BuildUi()
 
 	auto *splitter = new wxSplitterWindow(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
 	    wxSP_LIVE_UPDATE | wxSP_3DSASH);
-	splitter->SetMinimumPaneSize(240);
+	/* As small as the collapsed list, and no smaller: at zero, double-clicking
+	   the sash takes the machine list away altogether. */
+	splitter->SetMinimumPaneSize(kMachinesPanelCollapsed);
+	splitter_ = splitter;
 
 	auto *left_panel = new wxPanel(splitter);
 	auto *left_sizer = new wxBoxSizer(wxVERTICAL);
@@ -264,7 +274,71 @@ void ManagerFrame::BuildUi()
 	root->Add(splitter, 1, wxEXPAND);
 	SetSizer(root);
 
-	CreateStatusBar();
+	/*
+	 * Two fields: a narrow one the collapse button sits over, and the machine
+	 * count. A status bar does not lay out children itself, so the button is
+	 * placed by hand over the first field and moved again whenever the bar is
+	 * resized.
+	 */
+	wxStatusBar *status = CreateStatusBar(2);
+	const int widths[] = { kCollapseButtonField, -1 };
+
+	status->SetStatusWidths(2, widths);
+	SetStatusBarPane(1);
+
+	collapse_button_ = new wxBitmapButton(status, wxID_ANY,
+	    wxArtProvider::GetBitmap(wxART_GO_BACK, wxART_BUTTON, wxSize(16, 16)),
+	    wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
+	collapse_button_->SetToolTip("Hide the machine list");
+	collapse_button_->Bind(wxEVT_BUTTON, [this](wxCommandEvent &) {
+		SetMachinesPanelCollapsed(
+		    splitter_->GetSashPosition() > kMachinesPanelCollapsed);
+	});
+	status->Bind(wxEVT_SIZE, &ManagerFrame::OnStatusBarSize, this);
+	PositionCollapseButton();
+}
+
+/* Over the first status bar field, which is sized for it. */
+void ManagerFrame::PositionCollapseButton()
+{
+	wxStatusBar *status = GetStatusBar();
+	wxRect rect;
+
+	if (collapse_button_ == nullptr || status == nullptr ||
+	    !status->GetFieldRect(0, rect)) {
+		return;
+	}
+
+	wxSize size = collapse_button_->GetBestSize();
+
+	size.y = wxMin(size.y, rect.height);
+	collapse_button_->SetSize(rect.x + (rect.width - size.x) / 2,
+	    rect.y + (rect.height - size.y) / 2, size.x, size.y);
+}
+
+void ManagerFrame::OnStatusBarSize(wxSizeEvent &event)
+{
+	PositionCollapseButton();
+	event.Skip();
+}
+
+/* Collapse or restore the machine list, and turn the button round. */
+void ManagerFrame::SetMachinesPanelCollapsed(bool collapsed)
+{
+	if (collapsed) {
+		machines_panel_width_ = splitter_->GetSashPosition();
+		splitter_->SetSashPosition(kMachinesPanelCollapsed);
+	} else {
+		splitter_->SetSashPosition(machines_panel_width_);
+	}
+
+	if (collapse_button_ != nullptr) {
+		collapse_button_->SetBitmap(wxArtProvider::GetBitmap(
+		    collapsed ? wxART_GO_FORWARD : wxART_GO_BACK,
+		    wxART_BUTTON, wxSize(16, 16)));
+		collapse_button_->SetToolTip(collapsed ? "Show the machine list"
+		                                       : "Hide the machine list");
+	}
 }
 
 void ManagerFrame::BuildMenus()
@@ -521,7 +595,7 @@ void ManagerFrame::RefreshMachineList()
 	}
 
 	SetStatusText(wxString::Format("%zu machine%s, %zu running",
-	    machine_names_.size(), machine_names_.size() == 1 ? "" : "s", running_count));
+	    machine_names_.size(), machine_names_.size() == 1 ? "" : "s", running_count), 1);
 
 	UpdateButtons();
 }

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -606,10 +606,28 @@ void ManagerFrame::RefreshMachineList()
 		    wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED);
 	}
 
-	SetStatusText(wxString::Format("%zu machine%s, %zu running",
-	    machine_names_.size(), machine_names_.size() == 1 ? "" : "s", running_count), 1);
+	running_count_ = running_count;
+	UpdateStatusText();
 
 	UpdateButtons();
+}
+
+/*
+ * Which machine is being shown, as well as how many there are.
+ *
+ * Clicking the empty part of the list deselects it without changing which
+ * machine is displayed, and that highlight was the only thing saying which.
+ */
+void ManagerFrame::UpdateStatusText()
+{
+	SetTitle(active_machine_.empty()
+	    ? wxString("RPCEmu Extended")
+	    : wxString::Format("RPCEmu Extended - %s", active_machine_));
+
+	SetStatusText(wxString::Format("Current machine: %s   |   %zu machine%s, %zu running",
+	    active_machine_.empty() ? wxString("None") : active_machine_,
+	    machine_names_.size(), machine_names_.size() == 1 ? "" : "s",
+	    running_count_), 1);
 }
 
 wxString ManagerFrame::SelectedMachineName() const
@@ -927,6 +945,7 @@ void ManagerFrame::ShowMachinePanel(const wxString &name)
 		active_machine_.clear();
 		display_book_->SetSelection((size_t) placeholder_page_);
 	}
+	UpdateStatusText();
 	UpdateButtons();
 	UpdateMachineMenuState();
 }

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -704,24 +704,24 @@ void ManagerFrame::AttachPanelFor(const wxString &name, const wxString &shared_f
 	    ipc_endpoint.utf8_str().data());
 
 	if (!panel->IsLive()) {
-		/* Stale lock / the process ended between discovery and here. */
 		const wxString why = panel->AttachError();
 
 		panel->Destroy();
-		RemoveRunningEntry(name);
-		if (newly_started) {
-			/* What went wrong is names and sockets, which mean nothing to
-			   somebody who only wanted to run a machine - so it goes behind
-			   Details, where it is still there for a bug report. */
-			wxRichMessageDialog dlg(this,
-			    wxString::Format("'%s' started but could not be displayed.", name),
-			    "RPCEmu Extended Manager", wxOK | wxICON_ERROR);
 
-			dlg.SetExtendedMessage(
-			    "The machine may still be running. Stopping it and starting it "
-			    "again usually clears this.");
-			dlg.ShowDetailedText(why);
-			dlg.ShowModal();
+		/* Kept for the deadline to report, this being the only account of why
+		   a machine that never appeared did not. */
+		auto failed = running_.find(name);
+		if (failed != running_.end()) {
+			failed->second.last_attach_error = why;
+		}
+
+		/* A machine we started is left for the next poll to try again -
+		   giving up on the first attempt lost it from the window for the rest
+		   of the session, still running and no longer listed. OnPollTimer's
+		   deadline decides when to stop. Discovery has no entry to leave: the
+		   lock file it was found by is stale. */
+		if (!newly_started) {
+			RemoveRunningEntry(name);
 		}
 		return;
 	}
@@ -864,13 +864,31 @@ void ManagerFrame::OnPollTimer(wxTimerEvent & /*event*/)
 		    endpoint[0] != '\0') {
 			AttachPanelFor(name, wxString::FromUTF8(MachineIpcNameFor(dir.utf8_str().data(), pid)),
 			    wxString::FromUTF8(endpoint), true);
-			continue;
+
+			/* Still starting means the attempt failed, so fall through to
+			   the deadline rather than trying for ever. */
+			it = running_.find(name);
+			if (it == running_.end() || !it->second.starting) {
+				continue;
+			}
 		}
 
 		if ((wxGetLocalTimeMillis() - it->second.start_time_ms).ToLong() > kStartupTimeoutMs) {
+			const wxString why = it->second.last_attach_error;
+
 			RemoveRunningEntry(name);
-			wxMessageBox("'" + name + "' did not finish starting in time.",
-			    "RPCEmu Extended Manager", wxOK | wxICON_ERROR, this);
+
+			wxRichMessageDialog dlg(this,
+			    wxString::Format("'%s' started but could not be displayed.", name),
+			    "RPCEmu Extended Manager", wxOK | wxICON_ERROR);
+
+			dlg.SetExtendedMessage(
+			    "The machine may still be running. Stopping it and starting it "
+			    "again usually clears this.");
+			if (!why.empty()) {
+				dlg.ShowDetailedText(why);
+			}
+			dlg.ShowModal();
 		}
 	}
 }

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -134,6 +134,7 @@ private:
 wxBEGIN_EVENT_TABLE(ManagerFrame, wxFrame)
 	EVT_LIST_ITEM_SELECTED(wxID_ANY, ManagerFrame::OnMachineSelected)
 	EVT_LIST_ITEM_ACTIVATED(wxID_ANY, ManagerFrame::OnMachineActivated)
+	EVT_LIST_ITEM_RIGHT_CLICK(wxID_ANY, ManagerFrame::OnMachineRightClick)
 	EVT_BUTTON(ID_NEW, ManagerFrame::OnNew)
 	EVT_BUTTON(ID_EDIT, ManagerFrame::OnEdit)
 	EVT_BUTTON(ID_CLONE, ManagerFrame::OnClone)
@@ -883,6 +884,33 @@ void ManagerFrame::OnMachineActivated(wxListEvent & /*event*/)
 		return;
 	}
 	StartMachine(name);
+}
+
+/* Start and Stop on the machine that was clicked. */
+void ManagerFrame::OnMachineRightClick(wxListEvent &event)
+{
+	/* Right-clicking does not move the selection by itself, so without this the
+	   menu would act on whichever machine happened to be selected rather than
+	   the one under the pointer. */
+	machine_list_->SetItemState(event.GetIndex(),
+	    wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED,
+	    wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED);
+
+	const wxString name = SelectedMachineName();
+
+	if (name.empty()) {
+		return;
+	}
+
+	const bool is_running = running_.count(name) != 0;
+	wxMenu menu;
+
+	menu.Append(ID_START, "Start");
+	menu.Append(ID_STOP, "Stop");
+	menu.Enable(ID_START, !is_running);
+	menu.Enable(ID_STOP, is_running);
+
+	PopupMenu(&menu);
 }
 
 void ManagerFrame::OnNew(wxCommandEvent & /*event*/)

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -23,6 +23,7 @@
 #include <wx/artprov.h>
 #include <wx/dcmemory.h>
 #include <wx/dir.h>
+#include <wx/fileconf.h>
 #include <wx/filename.h>
 #include <wx/progdlg.h>
 #include <wx/richmsgdlg.h>
@@ -1074,6 +1075,23 @@ void ManagerFrame::OnClone(wxCommandEvent & /*event*/)
 
 	const wxString dest_path = ConfigPathsConfigsDir() + wxFileName::GetPathSeparator() + sanitized + ".cfg";
 	wxCopyFile(source_path, dest_path);
+
+	/*
+	 * The copy still calls itself by the name of the machine it came from, and
+	 * that field is what decides which directory a machine uses
+	 * (rpcemu_set_machine_datadir, via config_load). A clone left as copied
+	 * therefore ran out of the original's directory: the same cmos.ram, the
+	 * same HostFS, the same hard discs, and the lock refusing to start it
+	 * because the original already held it - under the original's name.
+	 */
+	{
+		wxFileConfig settings(wxEmptyString, wxEmptyString, dest_path, wxEmptyString,
+		                      wxCONFIG_USE_RELATIVE_PATH);
+
+		ConfigFileUseGeneralGroup(settings);
+		settings.Write("name", sanitized);
+		settings.Flush();
+	}
 
 	/* Pulsed rather than counted: the copy walks the tree as it goes, and
 	   counting it first would mean walking the whole thing twice to tell

--- a/src/gui/manager_frame.h
+++ b/src/gui/manager_frame.h
@@ -87,6 +87,10 @@ private:
 	void OnMachineSelected(wxListEvent &event);
 	void OnMachineActivated(wxListEvent &event);
 	void OnMachineRightClick(wxListEvent &event);
+	void OnStatusBarSize(wxSizeEvent &event);
+
+	void SetMachinesPanelCollapsed(bool collapsed);
+	void PositionCollapseButton();
 	void OnNew(wxCommandEvent &event);
 	void OnEdit(wxCommandEvent &event);
 	void OnClone(wxCommandEvent &event);
@@ -132,6 +136,12 @@ private:
 	wxImageList *status_images_ = nullptr;
 	wxSimplebook *display_book_ = nullptr;
 	int placeholder_page_ = -1;
+
+	/* The machine list collapses, so the width it had is kept to put it back
+	   where the user had it. */
+	wxSplitterWindow *splitter_ = nullptr;
+	int machines_panel_width_ = 300;
+	wxBitmapButton *collapse_button_ = nullptr;
 	wxButton *new_button_ = nullptr;
 	wxButton *edit_button_ = nullptr;
 	wxButton *clone_button_ = nullptr;

--- a/src/gui/manager_frame.h
+++ b/src/gui/manager_frame.h
@@ -144,6 +144,7 @@ private:
 	   where the user had it. */
 	wxSplitterWindow *splitter_ = nullptr;
 	int machines_panel_width_ = 300;
+	bool machines_panel_collapsed_ = false;
 	wxBitmapButton *collapse_button_ = nullptr;
 	wxButton *new_button_ = nullptr;
 	wxButton *edit_button_ = nullptr;

--- a/src/gui/manager_frame.h
+++ b/src/gui/manager_frame.h
@@ -77,6 +77,8 @@ private:
 	void UpdateButtons();
 	wxString MachineDirFor(const wxString &name) const;
 
+	void StopAllAndClose();
+
 	void DiscoverAlreadyRunningMachines();
 	void StartMachine(const wxString &name, bool resume = false);
 	void StopMachine(const wxString &name);
@@ -153,6 +155,10 @@ private:
 	wxMenuItem *resume_item_ = nullptr;
 	wxMenuItem *stop_item_ = nullptr;
 	wxMenuItem *start_item_ = nullptr;
+
+	/* Set while waiting for the machines to stop so the window can close
+	   behind them; suppresses the warning when that close arrives. */
+	bool closing_after_stop_ = false;
 
 	std::map<wxString, RunningMachine> running_;
 	std::vector<wxString> machine_names_;	/* same order as machine_list_'s rows */

--- a/src/gui/manager_frame.h
+++ b/src/gui/manager_frame.h
@@ -73,6 +73,7 @@ private:
 	void BuildStatusImages();
 	wxPanel *BuildPlaceholderPage();
 	void RefreshMachineList();
+	void UpdateStatusText();
 	wxString SelectedMachineName() const;
 	void UpdateButtons();
 	wxString MachineDirFor(const wxString &name) const;
@@ -164,6 +165,7 @@ private:
 	std::map<wxString, RunningMachine> running_;
 	std::vector<wxString> machine_names_;	/* same order as machine_list_'s rows */
 	wxString active_machine_;
+	size_t running_count_ = 0;
 	wxTimer poll_timer_;
 
 	wxDECLARE_EVENT_TABLE();

--- a/src/gui/manager_frame.h
+++ b/src/gui/manager_frame.h
@@ -63,6 +63,7 @@ private:
 		RemoteEmulatorPanel *panel = nullptr;
 		int book_page = -1;
 		bool starting = false;		/* waiting for the child to publish its IPC endpoint */
+		wxString last_attach_error;	/* why the most recent attempt failed */
 		wxLongLong start_time_ms;
 	};
 

--- a/src/gui/manager_frame.h
+++ b/src/gui/manager_frame.h
@@ -86,6 +86,7 @@ private:
 
 	void OnMachineSelected(wxListEvent &event);
 	void OnMachineActivated(wxListEvent &event);
+	void OnMachineRightClick(wxListEvent &event);
 	void OnNew(wxCommandEvent &event);
 	void OnEdit(wxCommandEvent &event);
 	void OnClone(wxCommandEvent &event);

--- a/src/gui/remote_emulator_panel.cpp
+++ b/src/gui/remote_emulator_panel.cpp
@@ -478,6 +478,15 @@ void RemoteEmulatorPanel::OnKeyDown(wxKeyEvent &event)
 		return;
 	}
 
+	/* A click rather than a keystroke, as in a machine's own window. */
+	if (InputIsThirdMouseButtonKey(event)) {
+		IpcRequest request;
+		request.type = IpcRequestType::MousePress;
+		request.arg1 = 4;
+		SendRequest(request);
+		return;
+	}
+
 	const unsigned key_id = InputKeyIdentityFromKeyEvent(event);
 	const unsigned scan_code = InputNativeScancodeFromKeyEvent(event);
 
@@ -493,6 +502,14 @@ void RemoteEmulatorPanel::OnKeyUp(wxKeyEvent &event)
 {
 	if (!live_) {
 		event.Skip();
+		return;
+	}
+
+	if (InputIsThirdMouseButtonKey(event)) {
+		IpcRequest request;
+		request.type = IpcRequestType::MouseRelease;
+		request.arg1 = 4;
+		SendRequest(request);
 		return;
 	}
 

--- a/src/gui/remote_emulator_panel.cpp
+++ b/src/gui/remote_emulator_panel.cpp
@@ -21,7 +21,6 @@
 #include "remote_emulator_panel.h"
 
 #include <algorithm>
-#include <cstdio>
 
 #include <wx/graphics.h>
 
@@ -75,10 +74,13 @@ RemoteEmulatorPanel::RemoteEmulatorPanel(wxWindow *parent, const std::string &sh
 		 * running perfectly well with neither the user nor the log able to
 		 * say why it is not on screen.
 		 */
-		std::fprintf(stderr, "Manager: cannot attach to a machine: "
-		    "framebuffer '%s' %s, control socket '%s' %s\n",
-		    shared_fb_name.c_str(), fb_ok ? "opened" : "FAILED",
-		    ipc_endpoint.c_str(), ipc_ok ? "connected" : "FAILED");
+		attach_error_ = wxString::Format(
+		    "Framebuffer '%s': %s\nControl socket '%s': %s",
+		    wxString::FromUTF8(shared_fb_name), fb_ok ? "opened" : "FAILED",
+		    wxString::FromUTF8(ipc_endpoint), ipc_ok ? "connected" : "FAILED");
+
+		rpclog("Manager: cannot attach to a machine: %s\n",
+		    attach_error_.utf8_str().data());
 		ipc_client_.Disconnect();
 		shared_fb_.Close();
 	}

--- a/src/gui/remote_emulator_panel.cpp
+++ b/src/gui/remote_emulator_panel.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 
+#include <wx/dcbuffer.h>
 #include <wx/graphics.h>
 
 #include "input_helpers.h"
@@ -237,7 +238,10 @@ void RemoteEmulatorPanel::RefreshFrame()
 
 void RemoteEmulatorPanel::OnPaint(wxPaintEvent & /*event*/)
 {
-	wxPaintDC dc(this);
+	/* Buffered, as EmulatorPanel's own paint is: the letterboxed case clears
+	   the panel and draws the picture over it, and unbuffered that black frame
+	   reached the screen on its own first. */
+	wxBufferedPaintDC dc(this);
 
 	if (live_ && frame_dirty_) {
 		RefreshFrame();

--- a/src/gui/remote_emulator_panel.cpp
+++ b/src/gui/remote_emulator_panel.cpp
@@ -221,14 +221,13 @@ void RemoteEmulatorPanel::RefreshFrame()
 	}
 
 	/*
-	 * ★ Kept at the guest's own size. The scaling is done by the blit.
+	 * ★ Kept at the guest's own size. OnPaint does the scaling.
 	 *
 	 * This used to wxImage::Rescale() to the panel size on every frame, which
-	 * is a full bilinear resample of the whole image in software and was the
-	 * single most expensive thing this panel did - most of a CPU core to show
-	 * a machine doing nothing. EmulatorPanel has always scaled with
-	 * StretchBlit instead, which hands the work to the toolkit; OnPaint now
-	 * does the same, so there is nothing to rescale here.
+	 * is a full resample of the whole image in software and was the single
+	 * most expensive thing this panel did - most of a CPU core to show a
+	 * machine doing nothing. The toolkit does that work now, so there is
+	 * nothing to rescale here.
 	 */
 	display_bitmap_ = wxBitmap(image);
 
@@ -275,7 +274,7 @@ void RemoteEmulatorPanel::OnPaint(wxPaintEvent & /*event*/)
 			 * ★ Scaled through a graphics context, and with the aspect
 			 * ratio kept.
 			 *
-			 * StretchBlit is what EmulatorPanel uses, and on GTK it is a
+			 * StretchBlit is what EmulatorPanel uses, and is a
 			 * nearest-neighbour copy: every scale factor that is not a whole
 			 * number drops and duplicates rows and columns, which is what
 			 * made this look pixelated and grainy at any guest resolution.
@@ -283,9 +282,10 @@ void RemoteEmulatorPanel::OnPaint(wxPaintEvent & /*event*/)
 			 * frame in software on the way to every paint, which is what
 			 * used to cost a CPU core.
 			 *
-			 * A graphics context is the third option: Cairo (or Direct2D, or
-			 * CoreGraphics) does the filtering itself, so it looks like the
-			 * bilinear version and costs like the blit.
+			 * A graphics context is the third option: the platform's own
+			 * renderer does the filtering, so it looks like the resampled
+			 * version without the software cost. Which renderer that is
+			 * matters on Windows - see below.
 			 *
 			 * The panel is a fixed shape and the guest's screen is not, so
 			 * without this the picture was also stretched out of shape.
@@ -303,10 +303,24 @@ void RemoteEmulatorPanel::OnPaint(wxPaintEvent & /*event*/)
 			dc.SetBackground(*wxBLACK_BRUSH);
 			dc.Clear();
 
-			wxGraphicsContext *gc = wxGraphicsContext::Create(dc);
+			/* Direct2D rather than the GDI+ default, which is slow enough to
+			   create per paint that typing felt laggy. */
+			wxGraphicsRenderer *renderer = nullptr;
+
+#ifdef __WXMSW__
+			renderer = wxGraphicsRenderer::GetDirect2DRenderer();
+#endif
+			if (renderer == nullptr) {
+				renderer = wxGraphicsRenderer::GetDefaultRenderer();
+			}
+
+			wxGraphicsContext *gc =
+			    renderer != nullptr ? renderer->CreateContext(dc) : nullptr;
 
 			if (gc != nullptr) {
-				gc->SetInterpolationQuality(wxINTERPOLATION_GOOD);
+				/* BEST, not GOOD: the guest screen is usually scaled down,
+				   and GOOD is bilinear, which breaks single-pixel text. */
+				gc->SetInterpolationQuality(wxINTERPOLATION_BEST);
 				gc->DrawBitmap(display_bitmap_, dx, dy, dw, dh);
 				delete gc;
 			} else {

--- a/src/gui/remote_emulator_panel.cpp
+++ b/src/gui/remote_emulator_panel.cpp
@@ -88,6 +88,12 @@ RemoteEmulatorPanel::RemoteEmulatorPanel(wxWindow *parent, const std::string &sh
 	UpdateCursor();
 }
 
+void RemoteEmulatorPanel::CloseConnection()
+{
+	live_ = false;
+	ipc_client_.Disconnect();
+}
+
 RemoteEmulatorPanel::~RemoteEmulatorPanel()
 {
 	ipc_client_.Disconnect();

--- a/src/gui/remote_emulator_panel.h
+++ b/src/gui/remote_emulator_panel.h
@@ -67,6 +67,10 @@ public:
 	/* Why IsLive() is false, for a caller with a window to say so in. */
 	const wxString &AttachError() const { return attach_error_; }
 
+	/* Drop the connection to the machine. Safe to call twice; the destructor
+	   does it too. */
+	void CloseConnection();
+
 	/* Whether this is the machine currently shown to the user. Only an
 	   active panel pulls new frames out of shared memory and repaints;
 	   backgrounded machines keep running (this process has no say in

--- a/src/gui/remote_emulator_panel.h
+++ b/src/gui/remote_emulator_panel.h
@@ -64,6 +64,9 @@ public:
 
 	bool IsLive() const { return live_; }
 
+	/* Why IsLive() is false, for a caller with a window to say so in. */
+	const wxString &AttachError() const { return attach_error_; }
+
 	/* Whether this is the machine currently shown to the user. Only an
 	   active panel pulls new frames out of shared memory and repaints;
 	   backgrounded machines keep running (this process has no say in
@@ -123,6 +126,7 @@ private:
 	ErrorCallback on_error_;
 
 	bool live_ = false;
+	wxString attach_error_;
 	bool active_ = false;
 	std::vector<uint32_t> frame_pixels_;
 	int frame_width_ = 640;

--- a/src/gui/settings.cpp
+++ b/src/gui/settings.cpp
@@ -102,11 +102,12 @@ static void peripheral_config_save(wxFileConfig &settings)
 
 static void machine_cmos_sync(const char *machine_name, Model model, unsigned mem_size, unsigned vram_size)
 {
-	char meta_path[512];
+	char machine_dir[512];
+	char meta_path[560];	/* the directory plus the longest name below */
 	char cmos_path[512];
 
-	snprintf(meta_path, sizeof(meta_path), "%smachines/%s/emulator.meta",
-	         rpcemu_get_datadir(), machine_name);
+	rpcemu_machine_datadir_for(machine_dir, sizeof(machine_dir), machine_name);
+	snprintf(meta_path, sizeof(meta_path), "%semulator.meta", machine_dir);
 
 	wxFileConfig meta(wxEmptyString, wxEmptyString,
 	                  wxString::FromUTF8(meta_path), wxEmptyString,

--- a/src/rpc-machdep.c
+++ b/src/rpc-machdep.c
@@ -139,15 +139,19 @@ rpcemu_set_resourcedir(const char *path)
 }
 
 void
+rpcemu_machine_datadir_for(char *out, size_t size, const char *machine_name)
+{
+	if (out == NULL || size == 0) {
+		return;
+	}
+	snprintf(out, size, "%smachines/%s/", rpcemu_get_datadir(),
+	         (machine_name && machine_name[0] != '\0') ? machine_name : "Default");
+}
+
+void
 rpcemu_set_machine_datadir(const char *machine_name)
 {
-	if (machine_name && machine_name[0] != '\0') {
-		snprintf(machinedir, sizeof(machinedir), "%smachines/%s/",
-		         rpcemu_get_datadir(), machine_name);
-	} else {
-		snprintf(machinedir, sizeof(machinedir), "%smachines/Default/",
-		         rpcemu_get_datadir());
-	}
+	rpcemu_machine_datadir_for(machinedir, sizeof(machinedir), machine_name);
 	logpath[0] = '\0';
 
 	ensure_machine_dirs();

--- a/src/rpcemu.c
+++ b/src/rpcemu.c
@@ -1473,6 +1473,21 @@ rpcemu_log_information(void)
 void
 rpcemu_prestart(void)
 {
+#ifdef _WIN32
+	/* Initialise Winsock before anything opens a socket (the Manager control
+	   channel, hostcmd/debugcmd, SLiRP NAT, the TCP modem, the broadcast
+	   relay). Here rather than in rpcemu_start(): a --managed machine publishes
+	   its control channel before that runs, and socket() was failing. */
+	{
+		WSADATA wsadata;
+		int err = WSAStartup(MAKEWORD(2, 2), &wsadata);
+
+		if (err != 0) {
+			fatal("WSAStartup failed: %d", err);
+		}
+	}
+#endif
+
 	/* On startup log additional information about the build and environment */
 	rpcemu_log_information();
 
@@ -1491,17 +1506,6 @@ void
 rpcemu_start(void)
 {
 #ifdef _WIN32
-	/* Initialise Winsock before anything opens a socket (hostcmd/debugcmd
-	   control sockets, SLiRP NAT, the TCP modem, the broadcast relay). */
-	{
-		WSADATA wsadata;
-		int err = WSAStartup(MAKEWORD(2, 2), &wsadata);
-
-		if (err != 0) {
-			fatal("WSAStartup failed: %d", err);
-		}
-	}
-
 	/* Raise the system timer resolution to 1ms. Windows' default granularity is
 	   ~15.6ms, which makes the Sleep(1) in rpcemu_idle() (used by "Reduce CPU
 	   Usage" when RISC OS calls Portable_Idle) sleep for up to ~15ms - long

--- a/src/rpcemu.h
+++ b/src/rpcemu.h
@@ -439,6 +439,7 @@ extern void rpcemu_set_datadir(const char *path);
 extern void rpcemu_set_resourcedir(const char *path);
 extern const char *rpcemu_get_machine_datadir(void);
 extern void rpcemu_set_machine_datadir(const char *machine_name);
+extern void rpcemu_machine_datadir_for(char *out, size_t size, const char *machine_name);
 extern const char *rpcemu_get_log_path(void);
 
 /**

--- a/src/socket-compat.h
+++ b/src/socket-compat.h
@@ -55,6 +55,9 @@
 #ifndef MSG_DONTWAIT
 #define MSG_DONTWAIT 0	/* our sockets are put in non-blocking mode explicitly */
 #endif
+#ifndef SHUT_RDWR
+#define SHUT_RDWR SD_BOTH	/* shutdown()'s "both directions" is spelled differently */
+#endif
 
 /* Socket errors come from WSAGetLastError(), not errno. */
 #define sock_errno()      WSAGetLastError()

--- a/src/socket-compat.h
+++ b/src/socket-compat.h
@@ -95,6 +95,24 @@
 #endif /* _WIN32 */
 
 /**
+ * Send small writes at once rather than coalescing them.
+ *
+ * For a control channel carrying one keystroke or mouse position at a time,
+ * where Nagle's algorithm holds each one back waiting for company.
+ *
+ * @param fd Socket descriptor
+ * @return   0 on success, non-zero on error
+ */
+static inline int
+socket_set_nodelay(int fd)
+{
+	int on = 1;
+
+	return setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (const char *) &on,
+	                  sizeof(on));
+}
+
+/**
  * Put a socket into non-blocking mode.
  *
  * @param fd Socket descriptor

--- a/tests/test_machine_ipc.cpp
+++ b/tests/test_machine_ipc.cpp
@@ -101,17 +101,41 @@ static void test_shared_framebuffer()
  * to override it, so the managed child (creating the segment, its own pid)
  * and the Manager (opening it, the Manager's own pid) computed two different
  * names for the same machine and OpenExisting() always failed. The name must
- * depend only on the machine directory and an explicitly passed pid - the
- * child's pid, supplied by both sides - never on whichever process happens
- * to be calling.
+ * depend only on what both sides can state exactly - the data directory, the
+ * machine's name, and an explicitly passed pid - never on whichever process
+ * happens to be calling.
  */
 static void test_ipc_name_for()
 {
-	const std::string dir = "/tmp/some/machine/dir/";
+	const std::string data = "/tmp/some/datadir/";
 
-	CHECK(MachineIpcNameFor(dir, 111) == MachineIpcNameFor(dir, 111));
-	CHECK(MachineIpcNameFor(dir, 111) != MachineIpcNameFor(dir, 222));
-	CHECK(MachineIpcNameFor(dir, 111) != MachineIpcNameFor("/tmp/other/dir/", 111));
+	CHECK(MachineIpcNameFor(data, "Alpha", 111) == MachineIpcNameFor(data, "Alpha", 111));
+	CHECK(MachineIpcNameFor(data, "Alpha", 111) != MachineIpcNameFor(data, "Alpha", 222));
+	CHECK(MachineIpcNameFor(data, "Alpha", 111) != MachineIpcNameFor(data, "Beta", 111));
+
+	/* Two RPCEmus on different --datadir trees, each holding a machine of the
+	   same name. */
+	CHECK(MachineIpcNameFor(data, "Alpha", 111) !=
+	      MachineIpcNameFor("/tmp/other/datadir/", "Alpha", 111));
+
+	/* The machine's name is in the segment's, so one can be traced back to the
+	   other. */
+	CHECK(MachineIpcNameFor(data, "Alpha", 111).find("Alpha") != std::string::npos);
+
+	/*
+	 * A name too long to embed whole is cut rather than overrunning the buffer
+	 * or the shortest platform limit. Two machines whose names differ only past
+	 * the cut therefore share a segment name until the pid is taken into
+	 * account - which it always is, and only one of them can be running,
+	 * machine_lock seeing to that.
+	 */
+	const std::string long_a(80, 'a');
+	const std::string long_b = long_a + "-different-tail";
+
+	CHECK(MachineIpcNameFor(data, long_a, 111).size() < 100);
+	CHECK(MachineIpcNameFor(data, long_a, 111) == MachineIpcNameFor(data, long_a, 111));
+	CHECK(MachineIpcNameFor(data, long_a, 111) != MachineIpcNameFor(data, long_a, 222));
+	CHECK(MachineIpcNameFor(data, long_a, 111) == MachineIpcNameFor(data, long_b, 111));
 }
 
 static void test_ipc_roundtrip()


### PR DESCRIPTION
Multi-machine now runs on Windows as well as Linux. Everything below is tested on both unless it says otherwise.

## Windows could not show a machine at all

Three faults, each enough on its own to stop a machine appearing.

**`e2bd22a` Winsock was never started in two of the processes.** `WSAStartup()` was called from `rpcemu_start()`, but a `--managed` machine publishes its control channel from `EnableManagedMode()` before that runs, and the Manager never calls either - its startup returns as soon as the window is up. Moved to `rpcemu_prestart()`, and started on the Manager's own path.

**`50a726a` The two sides spelled a machine's directory differently.** That string is hashed to name the shared framebuffer, and the Manager used the host separator - a backslash - where the machine hardcodes a forward slash. Different hashes, so it opened a segment nobody had created.

**`a2a6f23` A failed attach would not say why.** The panel already worked out which half had failed and printed it to `stderr`, which a GUI-subsystem Windows build has no console for. It now reaches the dialogue, with the names and sockets behind Details, and `rpclog()` takes a copy. Both failure messages also forget the machine before showing the box rather than after - the box runs its own event loop, and a machine still listed as starting brought up another every time the poll timer fired.

## The display

**`bf490be` It was sluggish to type at on Windows.** wx's default graphics renderer there is GDI+, and building one of its contexts per paint - once per frame the machine draws - is the cost; the same machine in its own window has always been fine, because that window uses `StretchBlit` and never creates one. Direct2D is hardware accelerated and keeps the filtering a scaled guest screen needs. The interpolation goes from `GOOD` to `BEST` with it: `GOOD` is bilinear, which samples four source pixels however many are really being averaged away, and a guest screen larger than the panel is scaled down - single-pixel text strokes thinned and broke up. Cairo, on GTK, is cheap to create, so its default is left alone.

**`5b74a9a` It flickered on Windows.** The panel painted straight to the screen, and the letterboxed case clears it black before drawing the picture over the top, so that black frame was visible on its own. Buffered now, as the machine window's own panel has always been.

**`d850096` Control messages waited to be coalesced.** The Manager's channel is a TCP loopback socket on Windows carrying one keystroke or mouse position at a time, which is what Nagle's algorithm holds back. The other platforms use AF_UNIX and have no such thing.

## Input

**`f3af5ab` The menu key did nothing.** A machine's own window turns it into a press of mouse button 4 rather than a keystroke, which is how RISC OS's menu button is reached from the keyboard; the Manager's panel forwarded it as an ordinary key. It goes through `InputIsThirdMouseButtonKey()`, the same helper the machine window uses, so macOS keeps standing right Command in for a key its keyboards do not have (issue #91) without this having to know.

## How the two processes agree on a name

The framebuffer name was a hash of the whole machine directory path, derived separately by both processes without ever comparing notes. That has now caused three bugs: `getpid()` called internally, the separator mismatch above, and `std::hash` not being required to agree across processes.

**`8c41373`** makes it the data directory hashed with FNV-1a, the machine's name, and the pid. Only the data directory is hashed, and both sides take it from the same call; the name they already agree on exactly. It is legible now, so a segment can be traced back to its machine.

**`4242796`** moves the platform decoration - `/` for `shm_open`, `Local\` for Windows - into `Map()`, which already did half of it.

**`902948d`** gives that path derivation one home. Three places built it by hand; `rpcemu_machine_datadir_for()` is the derivation on its own, without the side effects the setter also has.

## Clone gave a machine the original's name

**`0e22683`** `Clone` copied the configuration file and left the `name` inside it alone. That field decides which directory a machine uses, so a clone ran out of the original's - the same CMOS, HostFS and hard disc images - and the lock refused to start it while the original was running.

## Manager lifecycle

**`8c9ceaf` Closing with a machine running did nothing** on Windows: the window stayed until the machine was stopped by hand. Disconnecting joins a reader thread sitting in `poll()`, and `WSAPoll()` does not report a handle closed underneath it - `shutdown()` first makes it return. The connection is also dropped from `OnClose()` rather than the panel's destructor, so the wait happens while the event loop is still running.

**`517c3c7` A machine attached to rather than started was never removed** when it stopped. It has no `wxProcess` to watch, and nothing ever sends the IPC `Quit` the other path relies on, so it sat there as "Running" with a frozen display. Losing the connection now says so.

**`34554c1` A failed attach lost the machine for the session.** One attempt arriving a moment early removed it from the list while it went on running. Retried on the next poll now, with the deadline deciding when to stop; the deadline reports the last failure's reason.

**`795ff0f` That deadline was twenty seconds**, justified by ROM loading and machine start - neither of which happens inside the window it guards, since the child publishes before `rpcemu_start()`. Ten now.

**`bee31e1` Closing said nothing about machines carrying on.** It now says how many are running and that opening the Manager again reconnects to them, with a tick box to stop them instead. That waits rather than closing straight away: a machine saves its CMOS, discs and configuration on the way out.

## UI

**`253c0fc`** Delete left a machine's HostFS directories behind - `wxDir::GetAllFiles()` reports files only, so nothing removed them and the machine's own directory would not go either. Both Delete and Clone now show progress, backported from main.

**`6a520b6`** Right-clicking a machine offers Start and Stop, enabled from the same test the toolbar uses. Reset and Restart are deliberately absent: those handlers act on the machine being displayed rather than the one clicked.

**`98ac571`** The machine list hides and shows from a small button in the status bar.

**`55ab737`** That button worked out which way to point by asking the splitter where its sash was, and wxMSW does not always report back the position it was given - so with a machine displayed the arrow stopped alternating and the list stayed put. The state is held now. The width to restore to was also saved on every collapse, so collapsing an already-collapsed list recorded the collapsed width as the one to go back to.

**`cc79879`** Maximising the window left the machine count and that button unpainted, both still there and the button still working. The button is a child of the status bar and positioned by hand, so moving it leaves the bar unaware that what was underneath has changed.

**`0d0f1b0`** Clicking the empty part of the machine list deselects it without changing which machine is displayed, and that highlight was the only thing saying which one it was - collapsing the list did the same. The title names it now, as VirtualBox and VMware Workstation's managers do, and the status bar says it alongside the counts.

## Known broken

**Full-screen.** Entering it from the Manager full-screens the machine's own frame, which in managed mode is never shown and never receives a frame - the pixels go to the shared framebuffer instead. So the full-screen window is black, and leaving it strands that frame on the desktop as a second window. On Windows the "press Alt+Enter to leave" dialogue also opens behind the Manager the first time, the machine being a windowless background process that Windows will not give the foreground to. Both want full-screen moving into the Manager, on the panel that actually holds the picture; not attempted here.
