### PR TITLE
OpenBSD support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,10 +79,6 @@ option(RPCEMU_BUILD_TESTS "Build unit tests (amd64 dynarec only)" ON)
 # shipping quietly without it.
 option(RPCEMU_REQUIRE_LIBUSB "Fail the build if libusb-1.0 is missing" OFF)
 
-if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT WIN32 AND NOT APPLE)
-    message(FATAL_ERROR "RPCEmu (Extended Edition) supports Linux, Windows (MinGW-w64), and macOS.")
-endif()
-
 if(WIN32 AND MSVC)
     message(FATAL_ERROR "RPCEmu (Extended Edition) on Windows requires MinGW-w64, not MSVC.")
 endif()

--- a/src/cdrom-ioctl.c
+++ b/src/cdrom-ioctl.c
@@ -20,7 +20,9 @@
  */
 
 #include <stdio.h>
+#if defined(__linux__)
 #include <linux/cdrom.h>
+#endif
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <unistd.h>

--- a/src/lfs-compat.h
+++ b/src/lfs-compat.h
@@ -33,7 +33,7 @@
 #ifndef LFS_COMPAT_H
 #define LFS_COMPAT_H
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 #include <sys/types.h>
 #define off64_t   off_t
 #define fopen64   fopen

--- a/src/network-tun.c
+++ b/src/network-tun.c
@@ -34,8 +34,12 @@
 #include <pwd.h>
 #include <unistd.h>
 #include <arpa/inet.h>
+#ifdef __linux__
 #include <linux/if_tun.h>
 #include <linux/sockios.h>
+#elif __OpenBSD__
+#include <net/if_tun.h>
+#endif
 #include <net/if.h>
 #include <netinet/in.h>
 #include <sys/ioctl.h>
@@ -106,7 +110,7 @@ tun_alloc(void)
 
 	assert(config.network_type == NetworkType_EthernetBridging ||
 	       config.network_type == NetworkType_IPTunnelling);
-
+#if !defined(__OpenBSD__)
 	if (config.network_type == NetworkType_IPTunnelling && config.ipaddress == NULL) {
 		error("IP address not configured");
 		return -1;
@@ -209,7 +213,7 @@ tun_alloc(void)
 		error("Error setting %s non-blocking: %s", ifr.ifr_name, strerror(errno));
 		return -1;
 	}
-
+#endif // !__OpenBSD__
 	return fd;
 }
 

--- a/src/slirp/libslirp.h
+++ b/src/slirp/libslirp.h
@@ -9,6 +9,10 @@
 #include <netinet/in.h>
 #endif
 
+#if defined(__OpenBSD__)
+#include <sys/select.h>
+#endif
+
 struct Slirp;
 typedef struct Slirp Slirp;
 


### PR DESCRIPTION
Hi there. here are patches to get rpcemu-extended compiled and running on OpenBSD.

There are rough edges which i will try to polish and i will make a port in openbsd-wip, so it can be compiled and installed as an native package.

so far, it compiles and starts, but i haven't tested much:

to install the dependcies:
```
$ doas pkg_add wxWidgets-gtk3 libvncserver cmake
$ cd rpcemu-extended
$ mkdir build
$ cmake -B build -DRPCEMU_DYNAREC=OFF
$ make -C build
```

There are a lot of warrnings, many of which corresponding to security issues of functions such as `strcat` being reported by OpenBSD libc, and some are usual(?) clang warnings. I'll look into them if my free time permits.

-----
whats working and what needs more work (or testing?)

- [x] Building
- [ ] fixing warns and passing tests
- [ ] ~NAT networking~
- [ ] ~Bridge networking~
- [x] Audio
- [x] VNC
- [x] HostFS
- [ ] CD-ROM
- [ ] ~USB~
- [ ] `dynarec`
- [ ] CI?
- [ ] OpenBSD port