### PR TITLE
Document the emulator host interfaces as PRM-in-XML

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -812,10 +812,11 @@ jobs:
   # not have to check out the tree and install a toolchain to read what the
   # interface does.
   #
-  # Both forms are published: each chapter on its own, and the indexed manual,
-  # which adds the contents page and the generated SWI index that lets a reader
-  # find a call without knowing which interface it belongs to. The chapter list
-  # here must be kept in step with docs/prminxml/index.xml and its Makefile.
+  # docs/prminxml/index.xml names the chapters, their order and where the output
+  # goes, so this job does not: adding a chapter is a change to that file alone.
+  # The indexed build renders every chapter as well as the contents page and the
+  # generated SWI index, which is what lets a reader find a call without already
+  # knowing which interface it belongs to.
   docs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -826,30 +827,15 @@ jobs:
         with:
           fetch-tags: true
 
-      - name: Render the PRM-in-XML chapters
+      # No style: input. index.xml sets its own page and index CSS variants, and
+      # style: would prepend a second set of them.
+      - name: Render the host interfaces manual
         uses: gerph/riscos-prminxml-action@v1
         with:
-          files: >-
-            docs/prminxml/front/title-page.xml
-            docs/prminxml/01-overview.xml
-            docs/prminxml/02-hostfs.xml
-            docs/prminxml/03-hostcmd.xml
-            docs/prminxml/04-clipboard.xml
-            docs/prminxml/05-network.xml
-            docs/prminxml/appendix/a1-reserved.xml
+          files: docs/prminxml/index.xml
+          format: index
           output: prm-output
-          style: prm
-
-      # The indexed build is driven from index.xml, whose paths are relative to
-      # its own directory, so it is run from there rather than through the
-      # action, which has no input for an index. riscos-prminxml is on PATH by
-      # this point: the action's install step appends its tool directory to
-      # GITHUB_PATH, which reaches every later step in the job.
-      - name: Build the indexed manual
-        run: |
-          cd docs/prminxml
-          mkdir -p ../../prm-output/indexed/logs
-          riscos-prminxml -f index -L ../../prm-output/indexed/logs index.xml
+          log-directory: prm-output/indexed/logs
 
       # Named from VERSION rather than the tag, so the archive matches the
       # binaries beside it in a release. version-matches-tag has already

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -798,13 +798,69 @@ jobs:
             releases/macos/*.tar.gz
           if-no-files-found: error
 
+  # Render the interface documentation under docs/prminxml/.
+  #
+  # These are PRM-in-XML: the format the RISC OS Programmer's Reference Manuals
+  # are written in, and the right one for an interface somebody else has to
+  # implement against, because it fixes the register contract in a structured
+  # form rather than in prose. docs/ is otherwise Markdown, which stays the
+  # right choice for notes about how this repository works; the distinction is
+  # between describing an interface and describing an implementation.
+  #
+  # The HTML is a release asset. Somebody writing a host-side implementation of
+  # the network SWI is not necessarily building the emulator, and should not
+  # have to check out the tree and install a toolchain to read what the
+  # interface does.
+  docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      leafname: ${{ steps.package.outputs.leafname }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-tags: true
+
+      - name: Render the PRM-in-XML documentation
+        uses: gerph/riscos-prminxml-action@v1
+        with:
+          files: docs/prminxml/network-swi.xml
+          output: prm-output
+          style: prm
+
+      # Named from VERSION rather than the tag, so the archive matches the
+      # binaries beside it in a release. version-matches-tag has already
+      # insisted the two agree before any release is published.
+      - name: Package the documentation
+        id: package
+        run: |
+          if [ -s VERSION ]; then
+            version="$(tr -d ' \t\r\n' < VERSION)"
+          else
+            version="$(git rev-parse --short HEAD)"
+          fi
+          leafname="rpcemu-interface-docs-$version.zip"
+          if [ -z "$(ls -A prm-output 2>/dev/null)" ]; then
+            echo "::error::the documentation build produced no output"
+            exit 1
+          fi
+          ( cd prm-output && zip -q9r "../$leafname" . )
+          echo "leafname=$leafname" >> "$GITHUB_OUTPUT"
+          ls -l "$leafname"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: rpcemu-interface-docs
+          path: ${{ steps.package.outputs.leafname }}
+          if-no-files-found: error
+
   release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     # The sanitiser job gates a release too. It is the only thing that looks at
     # whether the emulator's C is well defined rather than merely producing the
     # expected answer, and shipping past a report from it would mean shipping
     # something known to be relying on the compiler's goodwill.
-    needs: [version-matches-tag, linux-amd64, linux-arm64, windows-amd64, macos-universal, sanitisers]
+    needs: [version-matches-tag, linux-amd64, linux-arm64, windows-amd64, macos-universal, sanitisers, docs]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -846,7 +902,7 @@ jobs:
   # unreachable would be reporting on itself rather than on the emulator.
   notify:
     if: always() && github.event_name == 'push'
-    needs: [version-matches-tag, linux-amd64, linux-arm64, windows-amd64, macos-universal, sanitisers, release]
+    needs: [version-matches-tag, linux-amd64, linux-arm64, windows-amd64, macos-universal, sanitisers, docs, release]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -849,11 +849,18 @@ jobs:
             version="$(git rev-parse --short HEAD)"
           fi
           leafname="rpcemu-interface-docs-$version.zip"
-          if [ -z "$(ls -A prm-output 2>/dev/null)" ]; then
-            echo "::error::the documentation build produced no output"
+          # pages/ only. The rest of what the indexed build leaves behind - its
+          # logs, temporary files, per-chapter headers and index data - is build
+          # working, and a reader opening the release asset should find the
+          # manual rather than have to pick it out. The XML sources are inside
+          # pages/ beside their HTML, and are kept: they are the machine-readable
+          # form of the same thing.
+          pages=prm-output/indexed/pages
+          if [ ! -s "$pages/index.html" ]; then
+            echo "::error::the documentation build produced no manual"
             exit 1
           fi
-          ( cd prm-output && zip -q9r "../$leafname" . )
+          ( cd "$pages" && zip -q9r "$OLDPWD/$leafname" . )
           echo "leafname=$leafname" >> "$GITHUB_OUTPUT"
           ls -l "$leafname"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -808,9 +808,14 @@ jobs:
   # between describing an interface and describing an implementation.
   #
   # The HTML is a release asset. Somebody writing a host-side implementation of
-  # the network SWI is not necessarily building the emulator, and should not
-  # have to check out the tree and install a toolchain to read what the
+  # one of these interfaces is not necessarily building the emulator, and should
+  # not have to check out the tree and install a toolchain to read what the
   # interface does.
+  #
+  # Both forms are published: each chapter on its own, and the indexed manual,
+  # which adds the contents page and the generated SWI index that lets a reader
+  # find a call without knowing which interface it belongs to. The chapter list
+  # here must be kept in step with docs/prminxml/index.xml and its Makefile.
   docs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -821,12 +826,30 @@ jobs:
         with:
           fetch-tags: true
 
-      - name: Render the PRM-in-XML documentation
+      - name: Render the PRM-in-XML chapters
         uses: gerph/riscos-prminxml-action@v1
         with:
-          files: docs/prminxml/network-swi.xml
+          files: >-
+            docs/prminxml/front/title-page.xml
+            docs/prminxml/01-overview.xml
+            docs/prminxml/02-hostfs.xml
+            docs/prminxml/03-hostcmd.xml
+            docs/prminxml/04-clipboard.xml
+            docs/prminxml/05-network.xml
+            docs/prminxml/appendix/a1-reserved.xml
           output: prm-output
           style: prm
+
+      # The indexed build is driven from index.xml, whose paths are relative to
+      # its own directory, so it is run from there rather than through the
+      # action, which has no input for an index. riscos-prminxml is on PATH by
+      # this point: the action's install step appends its tool directory to
+      # GITHUB_PATH, which reaches every later step in the job.
+      - name: Build the indexed manual
+        run: |
+          cd docs/prminxml
+          mkdir -p ../../prm-output/indexed/logs
+          riscos-prminxml -f index -L ../../prm-output/indexed/logs index.xml
 
       # Named from VERSION rather than the tag, so the archive matches the
       # binaries beside it in a release. version-matches-tag has already

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,10 @@
 /riscos-progs/*/resfs.inc
 /riscos-progs/RPCEmuGfx/gfxapp
 
+# Rendered PRM-in-XML documentation. The XML under docs/prminxml/ is the source;
+# the HTML is built by CI and published as a release asset.
+/prm-output/
+
 # Editor swap files / patch leftovers
 *.swp
 *~

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Build with **CMake** — see [COMPILE.md](COMPILE.md) for full details.
 | `docs/vnc.md` | VNC: using a machine remotely, choosing one over VNC in headless mode, and the control menu for a running machine |
 | `docs/multi-machine.md` | Running several machines at once: how it works today, the virtual switch planned, and why the core is one machine per process |
 | `docs/hostcmd.md` | HostCmd: drive the RISC OS command line from the host (`rpcemu-run`/`rpcemu-shell`) |
+| `docs/prminxml/network-swi.xml` | The network interface (SWI `&56AC4`) the guest driver calls, in PRM-in-XML: reason codes, the mbuf and receive-header layouts, and the interrupt cycle — enough to write an alternative host implementation. Rendered to HTML by CI and published with each release |
 | `tools/mcp/README.md` | MCP server: drive a RISC OS machine from Claude / an agent (commands, files, screen, debugger). Setup + tool reference. |
 | `docs/debugcmd.md` | DebugCmd: control the emulated CPU over a socket (`rpcemu-debug`) — registers, memory, disassembly, conditional breakpoints, stepping over and out, backtraces, symbols |
 | `docs/disassembly.md` | The ARM disassembler: what it covers, the FPA and RISC OS SWI names, and why it is not a library |

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Build with **CMake** — see [COMPILE.md](COMPILE.md) for full details.
 | `docs/vnc.md` | VNC: using a machine remotely, choosing one over VNC in headless mode, and the control menu for a running machine |
 | `docs/multi-machine.md` | Running several machines at once: how it works today, the virtual switch planned, and why the core is one machine per process |
 | `docs/hostcmd.md` | HostCmd: drive the RISC OS command line from the host (`rpcemu-run`/`rpcemu-shell`) |
-| `docs/prminxml/network-swi.xml` | The network interface (SWI `&56AC4`) the guest driver calls, in PRM-in-XML: reason codes, the mbuf and receive-header layouts, and the interrupt cycle — enough to write an alternative host implementation. Rendered to HTML by CI and published with each release |
+| `docs/prminxml/` | **The host interfaces manual**, in PRM-in-XML: HostFS, HostCmd, the clipboard and the network SWI — every operation, its registers, and how each reports failure. Written for someone implementing the host half rather than for someone using the emulator. Rendered to HTML by CI and published with each release; `make` in that directory builds it locally |
 | `tools/mcp/README.md` | MCP server: drive a RISC OS machine from Claude / an agent (commands, files, screen, debugger). Setup + tool reference. |
 | `docs/debugcmd.md` | DebugCmd: control the emulated CPU over a socket (`rpcemu-debug`) — registers, memory, disassembly, conditional breakpoints, stepping over and out, backtraces, symbols |
 | `docs/disassembly.md` | The ARM disassembler: what it covers, the FPA and RISC OS SWI names, and why it is not a library |

--- a/docs/prminxml/01-overview.xml
+++ b/docs/prminxml/01-overview.xml
@@ -1,0 +1,260 @@
+<?xml version="1.0"?>
+<!DOCTYPE riscos-prm PUBLIC "-//Gerph//DTD PRM documentation 1.03//EN"
+                            "http://gerph.org/dtd/103/prm.dtd">
+
+<riscos-prm>
+<chapter title="The emulator host interfaces">
+
+<section title="Introduction">
+<p>
+RPCEmu emulates a Risc PC faithfully enough that RISC OS does not know it is
+being emulated. Several of the things people want from an emulator, though, are
+not things a Risc PC could do at all: reading a folder on the machine the
+emulator is running on, pasting text copied from a web browser, or running a
+command from a script on the host and seeing what it printed.
+</p>
+<p>
+Those are provided by a small number of interfaces which the emulator exposes to
+software running inside the emulated machine. Each is a SWI that the emulator
+intercepts in its instruction decoder, before RISC OS is given the chance to
+handle it, and each has a module running in the guest which calls it and
+presents the result to RISC OS in whatever form RISC OS expects - a filing
+system, a network driver, a Wimp task.
+</p>
+<p>
+This manual describes those interfaces. It is written for somebody implementing
+the host half rather than for somebody using RPCEmu: another emulator that wants
+to run the same guest modules, a test harness that wants to stand in for the
+emulator, or anyone maintaining RPCEmu itself who needs to know what the guest
+is entitled to rely on.
+</p>
+</section>
+
+<section title="Overview">
+<p>
+Every interface here follows the same broad shape. A module inside the emulated
+machine issues a SWI whose number the real RISC OS knows nothing about. The
+emulator recognises the number as its own, performs the operation on the host,
+writes any results back into the emulated machine's registers and memory, and
+returns without RISC OS ever seeing the instruction. Nothing is emulated at the
+hardware level, and there is no device for RISC OS to find.
+</p>
+<p>
+The guest module is the part that makes this look like RISC OS. HostFS presents
+a filing system, so applications open and read files without knowing where they
+are; the network driver presents a DCI4 interface, so the Internet stack sends
+frames without knowing there is no card. The interfaces in this manual are
+therefore not APIs for applications. They are the private contract between one
+module and the emulator hosting it.
+</p>
+</section>
+
+<section title="Technical details">
+
+<subsection title="The SWI chunk">
+<p>
+The interfaces occupy a block of SWI numbers based at &hex;56AC0, which RPCEmu
+inherits from ArcEm. The numbers are not registered with RISC OS Open, have no
+names known to <reference type="swi" name="OS_SWINumberFromString"/>, and are
+issued numerically.
+</p>
+<p>
+<value-table head-number="Number" head-value="Interface">
+<value number="56AC0">Shutdown. Allocated but not implemented; see the appendix</value>
+<value number="56AC1">HostFS - files and directories on the host</value>
+<value number="56AC2">Debug. Allocated but not implemented; see the appendix</value>
+<value number="56AC3">Reserved, and never used</value>
+<value number="56AC4">Network - Ethernet frames to and from the host</value>
+<value number="56AC5">HostCmd - running commands from the host</value>
+<value number="56AD0">Clipboard - the shared clipboard</value>
+</value-table>
+</p>
+<p>
+The emulator masks the SWI operand to its bottom 20 bits, which includes the X
+bit, so a call made in either form reaches the same handler. It also resolves
+<reference type="swi" name="OS_CallASWI"/> and
+<reference type="swi" name="OS_CallASWIR12"/> to the number held in R10 or R12
+before comparing, so the interfaces are reachable through those as well.
+</p>
+</subsection>
+
+<subsection title="Where the reason code lives">
+<p>
+The interfaces do not agree on this, and it is the single most common thing to
+get wrong when implementing one of them. HostFS and HostCmd were derived from
+ArcEm, where the operation was passed in R9 so that R0 upwards could carry the
+filing system's own arguments unaltered. The network and clipboard interfaces
+were written later and put the reason code in R0.
+</p>
+<p>
+<definition-table head-name="Interface" head-extra="Reason in" head-value="Notes">
+ <definition name="HostFS" extra="R9">R0 onwards carry the FileSwitch entry point's own registers</definition>
+ <definition name="HostCmd" extra="R9">R0 onwards carry the operation's arguments</definition>
+ <definition name="Network" extra="R0">R1 is an error buffer</definition>
+ <definition name="Clipboard" extra="R0">R1 onwards carry the operation's arguments</definition>
+</definition-table>
+</p>
+</subsection>
+
+<subsection title="How failures are reported">
+<p>
+None of these interfaces uses the standard RISC OS error convention of setting
+V and returning a pointer to an error block. Each reports failure its own way,
+and a host implementation must follow whichever applies:
+</p>
+<p>
+<definition-table head-name="Interface" head-value="Failure is reported by">
+ <definition name="HostFS">A FileCore error number in R9. The guest module turns that into a RISC OS error. R9 is left alone when the operation succeeded</definition>
+ <definition name="HostCmd">Nothing fails. Every operation returns a status in R0 which the caller interprets</definition>
+ <definition name="Network">A non-zero R0, with the message written into a buffer the caller supplied</definition>
+ <definition name="Clipboard">Nothing fails. An operation that cannot be carried out returns zero in R0 and does nothing</definition>
+</definition-table>
+</p>
+<p>
+The V flag is untouched throughout. The emulator does clear V after the
+clipboard and HostCmd interfaces, so that a guest calling them in the X form
+sees success, but it never sets V to report an error.
+</p>
+</subsection>
+
+<subsection title="When an interface is switched off">
+<p>
+Each interface can be disabled in the emulator's configuration, and what happens
+then differs in a way that matters to the guest module.
+</p>
+<p>
+The clipboard and HostCmd interfaces fall through to RISC OS when disabled, so
+the SWI is reported as unknown and the guest module can detect that it is not
+available and withdraw. That is deliberate: both are optional conveniences whose
+guest modules should not be running at all if the host is not offering them.
+</p>
+<p>
+The network interface behaves differently. When networking is off the emulator
+swallows the SWI and returns with every register unchanged, so it reports
+neither success nor an unknown SWI. See the network chapter for why that is
+awkward and what a caller can conclude from it.
+</p>
+</subsection>
+
+<subsection title="Registration">
+<p>
+HostFS and HostCmd both require the guest module to register before anything
+else will work, and both use &hex;FFFFFFFF as the operation for it, answering
+with &hex;FFFFFFFF in R0 to acknowledge. HostFS additionally checks a protocol
+version and refuses a guest asking for one it does not implement.
+</p>
+<p>
+Registration exists so the host knows the guest half is present. Its absence is
+what lets the emulator refuse work that nothing would collect, rather than
+queueing it for a module that is not there. The clipboard has an equivalent in
+its setup operation, and the network interface in its readiness reason code,
+though neither calls it registration.
+</p>
+</subsection>
+
+<subsection title="Reading and writing the emulated machine's memory">
+<p>
+Every interface passes addresses in the emulated machine's address space, and a
+host implementation reads and writes them through the emulator's own memory
+access path rather than by any direct mapping. Two consequences are worth
+stating, because both have caused defects here:
+</p>
+<p>
+<list>
+<item>
+Addresses and lengths come from the guest and must be treated as hostile. A
+length is not bounded by anything the host controls, and a structure the guest
+builds may contain a cycle. Every copy into a fixed host buffer needs its own
+check, and every chain needs a limit.
+</item>
+<item>
+Guest memory is little-endian, and a multi-byte value read from it needs
+assembling accordingly. Data that travels onward to a network or a file may have
+its own byte order, which is not the same question.
+</item>
+</list>
+</p>
+</subsection>
+
+<subsection title="Suspend and resume">
+<p>
+The emulator can snapshot a running machine and restore it later, and each
+interface has state that must travel with the snapshot or the resumed machine
+will misbehave in ways that are hard to diagnose. HostFS must restore its
+registration state and its open file handles; the network interface must restore
+whether the driver declared itself ready, or the resumed machine never receives
+another frame. A host implementation that does not support snapshots need not do
+any of this, but one that does should treat these as part of the machine state
+rather than as host-side bookkeeping.
+</p>
+</subsection>
+</section>
+
+<section title="Examples">
+<p>
+The emulator's instruction decoder recognises its own SWI numbers before
+raising the exception that would let RISC OS see them:
+</p>
+
+<extended-example type='pseudo'>
+execute_swi(opcode):
+
+    swinum = opcode AND 0xdffff              /* 20 bits, including the X bit */
+
+    if swinum == OS_CallASWI then
+        swinum = R10 AND 0xdffff
+    else if swinum == OS_CallASWIR12 then
+        swinum = R12 AND 0xdffff
+
+    case swinum of
+
+    HOSTFS:                                  /* &hex;56AC1 */
+        hostfs_handler()                     /* reason in R9 */
+
+    NETWORK:                                 /* &hex;56AC4 */
+        if networking is configured then
+            network_handler()                /* reason in R0 */
+        /* else: fall through, registers untouched, no error */
+
+    HOSTCMD:                                 /* &hex;56AC5 */
+        if hostcmd is enabled then
+            hostcmd_handler()                /* reason in R9 */
+            clear V                          /* X-form: report success */
+        else
+            goto real_swi                    /* guest detects absence */
+
+    CLIPBOARD:                               /* &hex;56AD0 */
+        if clipboard is enabled then
+            clipboard_handler()              /* reason in R0 */
+            clear V
+        else
+            goto real_swi
+
+    otherwise:
+    real_swi:
+        raise the SWI exception               /* RISC OS handles it */
+</extended-example>
+</section>
+
+</chapter>
+
+<!-- MetaData -->
+<meta>
+ <maintainer>
+  <email name="Charles Ferguson" address="gerph@gerph.org" />
+ </maintainer>
+ <disclaimer>
+    <p>
+        This documentation describes the interfaces between the RPCEmu emulator
+        and the modules which run inside the machine it emulates. RPCEmu is
+        distributed under the GNU General Public License, version 2.
+    </p>
+ </disclaimer>
+
+ <history>
+  <revision number="1" author="Charles Ferguson" date="11 Aug 2026" title="Initial version">
+    <change>Described the emulator SWI chunk and the conventions common to its interfaces.</change>
+  </revision>
+ </history>
+</meta>
+</riscos-prm>

--- a/docs/prminxml/02-hostfs.xml
+++ b/docs/prminxml/02-hostfs.xml
@@ -1,0 +1,791 @@
+<?xml version="1.0"?>
+<!DOCTYPE riscos-prm PUBLIC "-//Gerph//DTD PRM documentation 1.03//EN"
+                            "http://gerph.org/dtd/103/prm.dtd">
+
+<riscos-prm>
+<chapter title="HostFS">
+
+<section title="Introduction">
+<p>
+HostFS gives the emulated machine access to a folder on the machine the emulator
+is running on. From inside RISC OS it is an ordinary filing system: applications
+open, read, write and enumerate through it without knowing that the objects they
+are working on are files in a folder belonging to some other operating system.
+</p>
+<p>
+It is what makes the emulator usable for development. Source can be edited with
+the host's tools and compiled inside RISC OS, and a file saved by a RISC OS
+application appears on the host immediately, with no image to mount and nothing
+to transfer.
+</p>
+</section>
+
+<section title="Overview">
+<p>
+The guest half is a RISC OS filing system module which registers with FileSwitch
+in the ordinary way. FileSwitch calls it through the standard filing system
+entry points, and it forwards each of those calls almost unaltered to the host
+through SWI &hex;56AC1.
+</p>
+<p>
+That is the shape of this interface, and the thing to hold on to when reading
+the rest of this chapter: <em>the operations are the FileSwitch entry points</em>.
+Reason code 0 is <function>FSEntry_Open</function>, reason code 5 is
+<function>FSEntry_File</function>, and the registers each carries are the registers
+FileSwitch defined for it. Where this chapter is silent about what a register
+means, the filing system documentation in the RISC OS Programmer's Reference
+Manual is the reference, because the guest module passes them straight through.
+</p>
+<p>
+This is not a FileCore filing system, and the distinction matters to anyone
+implementing the host half. A FileCore-based filing system such as ADFS presents
+a block device - sectors, disc records, a free space map - and FileCore builds
+the directory structure on top of it. HostFS presents no blocks at all. The host
+implements the file operations directly, on whatever storage it has, and there
+is no disc structure anywhere in the interface. The only trace of FileCore is in
+the error numbers, which are borrowed because RISC OS already knows what they
+mean.
+</p>
+<p>
+The consequence is that a host implementation needs a filesystem-like backing
+store with named files, not a disc image. It also means the guest cannot do
+anything FileSwitch does not ask for: there is no way to read a raw sector, and
+nothing that depends on FileCore's disc format will work through HostFS.
+</p>
+</section>
+
+<section title="Technical details">
+
+<subsection title="Calling convention">
+<p>
+The operation is in <em>R9</em>, not R0. R0 onwards carry the FileSwitch entry
+point's own registers, which is the reason for the unusual choice: it lets the
+guest module pass the call through without shuffling registers.
+</p>
+<p>
+<value-table head-number="R9" head-value="Operation">
+<value number="0">FSEntry_Open</value>
+<value number="1">FSEntry_GetBytes</value>
+<value number="2">FSEntry_PutBytes</value>
+<value number="3">FSEntry_Args</value>
+<value number="4">FSEntry_Close</value>
+<value number="5">FSEntry_File</value>
+<value number="6">FSEntry_Func</value>
+<value number="7">FSEntry_GBPB</value>
+<value number="FFFFFFFF">Register with the host</value>
+</value-table>
+</p>
+<p>
+FSEntry_Args, FSEntry_File and FSEntry_Func each take a further reason code in
+R0, again as FileSwitch defines it. Those are listed in the sections below.
+</p>
+</subsection>
+
+<subsection title="Registration and protocol version">
+<p>
+Nothing works until the guest has registered. The module calls with
+R9 = &hex;FFFFFFFF and R0 holding the protocol version it implements; the host
+answers with R0 = &hex;FFFFFFFF if it supports that version.
+</p>
+<p>
+The current protocol version is 3. A host receiving a version it does not
+implement must refuse, and must then ignore every subsequent operation rather
+than attempt to serve a guest expecting a different contract.
+</p>
+<p>
+A call arriving before registration is also ignored, and a host implementation
+should log that once rather than on every call: an unregistered guest that keeps
+calling would otherwise fill the log. Registration is attempted regardless of
+the current state, so a guest that has been refused can try again with a
+different version.
+</p>
+</subsection>
+
+<subsection title="Object types and catalogue information">
+<p>
+Objects are described by the same four values RISC OS uses throughout its filing
+system interfaces, and the host fills them in from whatever its own storage can
+tell it.
+</p>
+<p>
+<definition-table head-name="Value" head-value="Meaning">
+ <definition name="Type">0 for an object that does not exist, 1 for a file, 2 for a directory</definition>
+ <definition name="Load address">The filetype and the top of the timestamp, or a load address for an untyped file</definition>
+ <definition name="Exec address">The rest of the timestamp, or an execution address</definition>
+ <definition name="Length">The size of the file in bytes</definition>
+ <definition name="Attributes">The RISC OS access attributes</definition>
+</definition-table>
+</p>
+</subsection>
+
+<subsection title="How filetypes are carried">
+<p>
+The host has nowhere to keep a RISC OS filetype, so it is carried in the
+filename, using the convention RISC OS users already know from other systems: a
+file's name ends with a comma and three hexadecimal digits giving the type.
+</p>
+<p>
+A file whose type is &hex;FFF - Text, the default - carries no suffix, so
+ordinary host files appear in RISC OS as text files and text files created in
+RISC OS appear on the host under their plain name. That is what makes the folder
+usable from both sides: a source file edited on the host does not acquire a
+suffix, and does not need one.
+</p>
+<p>
+When the type or timestamp of a file changes, the host renames the underlying
+file to match. An implementation must therefore expect the name of a file to
+change as a consequence of an operation that RISC OS thinks of as setting
+metadata.
+</p>
+<p>
+The timestamp is carried by the host file's own modification time rather than in
+the name, and is converted to and from the RISC OS load and exec address form.
+</p>
+</subsection>
+
+<subsection title="Reporting errors">
+<p>
+An operation that fails returns a FileCore error number in R9. The guest module
+turns that into a RISC OS error for FileSwitch. R9 is left alone when the
+operation succeeded, so a host implementation must write it only on the failing
+paths.
+</p>
+<p>
+<value-table head-number="Number" head-value="Error">
+<value number="B0">Bad rename</value>
+<value number="B4">Directory not empty</value>
+<value number="C0">Too many open files</value>
+<value number="C2">File open</value>
+<value number="C3">Locked</value>
+<value number="C4">Already exists</value>
+<value number="C6">Disc full</value>
+<value number="D4">Disc not found</value>
+<value number="D6">Not found</value>
+<value number="FF">Not implemented</value>
+</value-table>
+</p>
+<p>
+Not every failure has an error number to report. A file that cannot be opened is
+reported as not found, by returning zero as the handle, because that is what
+FileSwitch expects of the entry point; and several operations simply do nothing
+when they cannot proceed. Where that is the case it is stated in the operation's
+description.
+</p>
+</subsection>
+
+<subsection title="File handles">
+<p>
+The host allocates its own handle for each open file and returns it to
+FileSwitch, which passes it back on every subsequent operation. Handles run from
+1 to 255; zero is never a valid handle and is what the open operation returns to
+report that the file was not found.
+</p>
+<p>
+A handle arriving from the guest is entirely under the guest's control and must
+be validated before it is used to index anything. RISC OS constrains the number
+of open files, so a well behaved guest will not exceed the range, but a host
+implementation cannot rely on that: an out-of-range or stale handle used as an
+index reads host memory the guest chose. Every operation taking a handle checks
+it, and ignores the call if it does not name an open file.
+</p>
+</subsection>
+
+<subsection title="Directory enumeration">
+<p>
+The three directory-reading operations differ only in how much they return per
+entry. Each takes an offset into the directory and returns a count of entries
+read together with the offset to resume from, so FileSwitch can walk a large
+directory in pieces.
+</p>
+<p>
+Because the host's directory ordering is not RISC OS's, the host sorts the
+entries and holds the sorted result while an enumeration is in progress. That
+cache is refreshed when the enumeration restarts from offset zero or when a
+different directory is asked for. A host implementation needs something
+equivalent, or entries will be repeated or skipped when a directory changes
+during a walk.
+</p>
+<p>
+An offset of &hex;FFFFFFFF returned to the caller means the enumeration is
+complete. That value is also returned when the object named is not a directory.
+</p>
+</subsection>
+</section>
+
+<section title="SWI calls">
+
+<swi-definition name="RPCEmu_HostFS"
+                number="56AC1"
+                description="Performs a filing system operation on the host"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="9">Operation:
+  <p>
+  <value-table head-number="R9" head-value="Operation">
+   <value number="0"><reference type='swi' name='RPCEmu_HostFS' reason='0' use-description='yes'/></value>
+   <value number="1"><reference type='swi' name='RPCEmu_HostFS' reason='1' use-description='yes'/></value>
+   <value number="2"><reference type='swi' name='RPCEmu_HostFS' reason='2' use-description='yes'/></value>
+   <value number="3"><reference type='swi' name='RPCEmu_HostFS' reason='3' use-description='yes'/></value>
+   <value number="4"><reference type='swi' name='RPCEmu_HostFS' reason='4' use-description='yes'/></value>
+   <value number="5"><reference type='swi' name='RPCEmu_HostFS' reason='5' use-description='yes'/></value>
+   <value number="6"><reference type='swi' name='RPCEmu_HostFS' reason='6' use-description='yes'/></value>
+   <value number="7"><reference type='swi' name='RPCEmu_HostFS' reason='7' use-description='yes'/></value>
+   <value number="FFFFFFFF"><reference type='swi' name='RPCEmu_HostFS' reason='FFFFFFFF' use-description='yes'/></value>
+  </value-table>
+  </p>
+ </register-use>
+ <register-use number="0-8">As the corresponding FileSwitch entry point defines them</register-use>
+</entry>
+<exit>
+ <register-use number="9">A FileCore error number if the operation failed, otherwise preserved</register-use>
+ <register-use number="0-8">As the corresponding FileSwitch entry point defines them</register-use>
+</exit>
+
+<use>
+<p>
+Carries out a filing system operation on the host's storage on behalf of the
+guest's HostFS module. The operation is selected by R9, and the remaining
+registers are those of the FileSwitch entry point of the same name.
+</p>
+<p>
+Every operation except registration is ignored until the guest has registered.
+</p>
+</use>
+</swi-definition>
+
+<swi-definition name="RPCEmu_HostFS"
+                number="56AC1"
+                reason="FFFFFFFF" reasonname="Register"
+                description="Registers the guest filing system with the host"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="0">Protocol version the guest implements (currently 3)</register-use>
+ <register-use number="9">&hex;FFFFFFFF (operation)</register-use>
+</entry>
+<exit>
+ <register-use number="0">&hex;FFFFFFFF if the host accepted the registration, otherwise preserved</register-use>
+</exit>
+
+<use>
+<p>
+Declares the guest's HostFS module to the host and agrees the protocol version.
+The host answers with &hex;FFFFFFFF in R0 if it implements the version asked
+for.
+</p>
+<p>
+A registration for an unsupported version is refused, and the host then ignores
+every subsequent operation. A guest must not proceed on a refusal.
+</p>
+<p>
+This is the only operation accepted before registration, so a guest whose first
+attempt was refused may call again with a different version.
+</p>
+</use>
+</swi-definition>
+
+<swi-definition name="RPCEmu_HostFS"
+                number="56AC1"
+                reason="0" reasonname="Open"
+                description="Opens a file, as FSEntry_Open"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="0">Open mode:
+  <p>
+  <value-table head-number="Mode" head-value="Meaning">
+   <value number="0">Open for reading</value>
+   <value number="1">Create and open for update (RISC OS 2 only; not implemented)</value>
+   <value number="2">Open for update</value>
+  </value-table>
+  </p>
+ </register-use>
+ <register-use number="1">Pointer to the pathname, terminated by a control character</register-use>
+ <register-use number="3">The handle FileSwitch will use for this file</register-use>
+ <register-use number="6">Pointer to the special field, or 0 if there is none</register-use>
+ <register-use number="9">0 (operation)</register-use>
+</entry>
+<exit>
+ <register-use number="0">Information word:
+  <p>
+  <bitfield-table>
+   <bit number="31" state='set'>The file may be written to</bit>
+   <bit number="30" state='set'>The file may be read from</bit>
+   <bit number="29" state='set'>The object is a directory</bit>
+   <bit number="28" state='set'>Unbuffered access is allowed</bit>
+   <bit number="27" state='set'>The stream is interactive</bit>
+   <bit number="0-26" state="reserved" />
+  </bitfield-table>
+  </p>
+ </register-use>
+ <register-use number="1">The host's handle for the file, or 0 if it could not be opened</register-use>
+ <register-use number="2">Recommended buffer size; a power of two between 64 and 1024</register-use>
+ <register-use number="3">Extent of the file in bytes</register-use>
+ <register-use number="4">Space allocated to the file, in bytes</register-use>
+</exit>
+
+<use>
+<p>
+Opens an existing file and allocates a handle for it.
+</p>
+<p>
+A handle of zero returned in R1 means the file could not be opened, which
+FileSwitch reads as "not found". That is the only failure this operation
+reports: a file that exists but cannot be opened for any other reason is
+reported the same way, and no error number is returned in R9.
+</p>
+<p>
+Mode 1 is not implemented, since only RISC OS 2 used it. The call returns
+without opening anything and without reporting an error.
+</p>
+</use>
+
+<related>
+<reference type='swi' name='RPCEmu_HostFS' reason='4'/>
+</related>
+</swi-definition>
+
+<swi-definition name="RPCEmu_HostFS"
+                number="56AC1"
+                reason="1" reasonname="GetBytes"
+                description="Reads bytes from an open file, as FSEntry_GetBytes"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="1">The host's handle for the file</register-use>
+ <register-use number="2">Address of the buffer to read into</register-use>
+ <register-use number="3">Number of bytes to read</register-use>
+ <register-use number="4">Offset in the file to read from</register-use>
+ <register-use number="9">1 (operation)</register-use>
+</entry>
+<exit>
+ <register-use number="0-8" state="preserved" />
+</exit>
+
+<use>
+<p>
+Reads from an absolute position in the file, rather than from a current
+position: FileSwitch tracks the file pointer itself and supplies the offset on
+every call.
+</p>
+<p>
+A call naming a handle that is not open is ignored.
+</p>
+</use>
+
+<related>
+<reference type='swi' name='RPCEmu_HostFS' reason='2'/>
+</related>
+</swi-definition>
+
+<swi-definition name="RPCEmu_HostFS"
+                number="56AC1"
+                reason="2" reasonname="PutBytes"
+                description="Writes bytes to an open file, as FSEntry_PutBytes"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="1">The host's handle for the file</register-use>
+ <register-use number="2">Address of the buffer to write from</register-use>
+ <register-use number="3">Number of bytes to write</register-use>
+ <register-use number="4">Offset in the file to write at</register-use>
+ <register-use number="9">2 (operation)</register-use>
+</entry>
+<exit>
+ <register-use number="0-8" state="preserved" />
+</exit>
+
+<use>
+<p>
+Writes at an absolute position in the file. As with reading, FileSwitch supplies
+the offset on every call.
+</p>
+<p>
+A call naming a handle that is not open is ignored.
+</p>
+</use>
+
+<related>
+<reference type='swi' name='RPCEmu_HostFS' reason='1'/>
+</related>
+</swi-definition>
+
+<swi-definition name="RPCEmu_HostFS"
+                number="56AC1"
+                reason="3" reasonname="Args"
+                description="Reads and sets attributes of an open file, as FSEntry_Args"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="0">Reason code:
+  <p>
+  <value-table head-number="Reason" head-value="Action">
+   <value number="3">Write the file extent; R2 holds the new extent</value>
+   <value number="7">Ensure the file is at least a given size; R2 holds the size wanted</value>
+   <value number="8">Write zeros to the file; R2 holds the offset, R3 the count</value>
+   <value number="9">Read the file datestamp</value>
+  </value-table>
+  </p>
+ </register-use>
+ <register-use number="1">The host's handle for the file</register-use>
+ <register-use number="2-3">Dependent on the reason code</register-use>
+ <register-use number="9">3 (operation)</register-use>
+</entry>
+<exit>
+ <register-use number="2">For reason 7, the resulting size of the file</register-use>
+</exit>
+
+<use>
+<p>
+Reason 3 truncates or extends the file to the given extent. Extending a file
+this way does not define what the new bytes contain.
+</p>
+<p>
+Reason 7 returns the file's current size rather than changing it, so a host
+implementation should treat it as a query.
+</p>
+<p>
+Reason 8 writes a run of zero bytes at the given offset, which is how RISC OS
+extends a file with defined contents.
+</p>
+<p>
+Reason 9 is accepted and does nothing. The datestamp is carried by the host
+file's modification time and is reported through the catalogue information
+operations instead.
+</p>
+<p>
+Any other reason code is not implemented. A call naming a handle that is not
+open is ignored.
+</p>
+</use>
+</swi-definition>
+
+<swi-definition name="RPCEmu_HostFS"
+                number="56AC1"
+                reason="4" reasonname="Close"
+                description="Closes an open file, as FSEntry_Close"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="1">The host's handle for the file</register-use>
+ <register-use number="2">New load address, or 0 to leave it alone</register-use>
+ <register-use number="3">New exec address, or 0 to leave it alone</register-use>
+ <register-use number="9">4 (operation)</register-use>
+</entry>
+<exit>
+ <register-use number="0-8" state="preserved" />
+</exit>
+
+<use>
+<p>
+Closes the file and releases its handle. If both R2 and R3 are zero there is
+nothing further to do; otherwise they give the load and exec addresses to record
+against the file.
+</p>
+<p>
+A call naming a handle that is not open is ignored.
+</p>
+</use>
+
+<related>
+<reference type='swi' name='RPCEmu_HostFS' reason='0'/>
+</related>
+</swi-definition>
+
+<swi-definition name="RPCEmu_HostFS"
+                number="56AC1"
+                reason="5" reasonname="File"
+                description="Operates on a whole file by name, as FSEntry_File"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="0">Reason code:
+  <p>
+  <value-table head-number="Reason" head-value="Action">
+   <value number="0">Save a block of memory as a file</value>
+   <value number="1">Write catalogue information</value>
+   <value number="5">Read catalogue information</value>
+   <value number="6">Delete an object</value>
+   <value number="7">Create an empty file</value>
+   <value number="8">Create a directory</value>
+   <value number="FF">Load a file into memory</value>
+  </value-table>
+  </p>
+ </register-use>
+ <register-use number="1">Pointer to the pathname</register-use>
+ <register-use number="2">Load address, or for reason &hex;FF the address to load at</register-use>
+ <register-use number="3">Exec address</register-use>
+ <register-use number="4">For reasons 0 and 7, the start of the data; for reason 8, the number of entries wanted</register-use>
+ <register-use number="5">For reasons 0 and 7, the end of the data; for reason 1, the new attributes</register-use>
+ <register-use number="6">Pointer to the special field, or 0 if there is none</register-use>
+ <register-use number="9">5 (operation)</register-use>
+</entry>
+<exit>
+ <register-use number="0">For reasons 5, 6 and &hex;FF, the object type: 0 not found, 1 file, 2 directory</register-use>
+ <register-use number="2">Load address</register-use>
+ <register-use number="3">Exec address</register-use>
+ <register-use number="4">Length of the file in bytes</register-use>
+ <register-use number="5">Object attributes</register-use>
+</exit>
+
+<use>
+<p>
+Reason 0 writes the block of memory between R4 and R5 to a new file. Reason 7 is
+the same operation without data, creating a file of that length filled with
+zeros. Both will rename an existing file of that name to match the new filetype
+rather than refusing.
+</p>
+<p>
+Reason 1 sets the load address, exec address and attributes of an existing
+object, which for a file means renaming it to carry the new filetype and setting
+the host file's modification time. An object that does not exist is not an error
+and the call does nothing. Directories are not altered.
+</p>
+<p>
+Reason 5 returns the object's type and catalogue information. It is the
+operation behind <command>*FileInfo</command> and everything else that asks what an
+object is.
+</p>
+<p>
+Reason 6 returns the object's information and then deletes it. Deleting a
+directory that is not empty returns error &hex;B4.
+</p>
+<p>
+Reason 8 creates a directory. The number of entries in R4 is advisory and is not
+used. An attempt to create the root directory is ignored.
+</p>
+<p>
+Reason &hex;FF loads the whole file to the address in R2 and returns its
+catalogue information. A file that cannot be opened returns its information
+with nothing loaded.
+</p>
+<p>
+Any other reason code is not implemented.
+</p>
+</use>
+</swi-definition>
+
+<swi-definition name="RPCEmu_HostFS"
+                number="56AC1"
+                reason="6" reasonname="Func"
+                description="Performs a filing system function, as FSEntry_Func"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="0">Reason code:
+  <p>
+  <value-table head-number="Reason" head-value="Action">
+   <value number="0">Set the current directory</value>
+   <value number="8">Rename an object</value>
+   <value number="B">Read the disc name and boot option (not implemented)</value>
+   <value number="E">Read directory entries</value>
+   <value number="F">Read directory entries and information</value>
+   <value number="13">Read directory entries, information and timestamps</value>
+   <value number="17">Canonicalise the special field and disc name</value>
+   <value number="18">Resolve a wildcarded name</value>
+   <value number="1B">Read the boot option</value>
+   <value number="1E">Read free space, 32-bit</value>
+   <value number="23">Read free space, 64-bit</value>
+  </value-table>
+  </p>
+ </register-use>
+ <register-use number="1-6">Dependent on the reason code</register-use>
+ <register-use number="9">6 (operation)</register-use>
+</entry>
+<exit>
+ <register-use number="0-6">Dependent on the reason code</register-use>
+ <register-use number="9">A FileCore error number if the operation failed, otherwise preserved</register-use>
+</exit>
+
+<use>
+<p>
+Reason 0 sets the current directory. A name that does not resolve to an existing
+directory is ignored.
+</p>
+<p>
+Reason 8 renames an object, with R1 pointing at the old name and R2 at the new
+one.
+</p>
+<p>
+Reasons &hex;E, &hex;F and &hex;13 read directory entries, returning
+progressively more per entry: names alone, names with catalogue information, and
+names with catalogue information and timestamps. All three take the directory in
+R1, a buffer in R2, the number of entries wanted in R3, the offset to start at
+in R4 and the buffer length in R5; they return the number of entries read in R3
+and the offset to resume from in R4. An offset of &hex;FFFFFFFF means there are
+no more, and is also returned when the named object is not a directory.
+</p>
+<p>
+Reason &hex;17 canonicalises a disc name. With R4 = 0 it returns the length of
+buffer required in R4; otherwise it writes the canonical name to the buffer R4
+points at, whose length is given in R6. A disc name that is not valid returns
+error &hex;D4.
+</p>
+<p>
+Reason &hex;18 resolves a wildcarded name and returns &hex;FFFFFFFF in R4.
+</p>
+<p>
+Reason &hex;1B returns a boot option of 2 in R2.
+</p>
+<p>
+Reason &hex;1E returns the free space as a 32-bit value in R0, the largest
+creatable object in R1, and the disc size in R2. Reason &hex;23 returns the same
+as 64-bit values, free space across R0 and R1, the largest object in R2, and the
+size across R3 and R4. Both are capped at what the host reports for the storage
+holding the folder.
+</p>
+<p>
+Reason &hex;B is not implemented and returns &hex;FF in R9. Any other reason
+code is not implemented.
+</p>
+</use>
+</swi-definition>
+
+<swi-definition name="RPCEmu_HostFS"
+                number="56AC1"
+                reason="7" reasonname="GBPB"
+                description="Multiple byte transfer, as FSEntry_GBPB"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="9">7 (operation)</register-use>
+</entry>
+<exit>
+ <register-use number="0-8" state="preserved" />
+</exit>
+
+<use>
+<p>
+Accepted and does nothing. FileSwitch is able to carry out multiple byte
+transfers itself using the byte-level operations, and does so, since this entry
+point is optional for a filing system.
+</p>
+<p>
+A host implementation need do no more than accept the call.
+</p>
+</use>
+</swi-definition>
+
+</section>
+
+<section title="Examples">
+<p>
+Dispatching an operation, with the registration state that guards it:
+</p>
+
+<extended-example type='pseudo'>
+hostfs_handler():
+
+    if R9 == 0xffffffff then                 /* always allowed */
+        if R0 == PROTOCOL_VERSION then
+            R0 = 0xffffffff                  /* accepted */
+            state = REGISTERED
+        else
+            state = IGNORE                   /* wrong version: refuse for good */
+        return
+
+    if state != REGISTERED then
+        if state == UNREGISTERED then
+            log("used before registration")  /* once only */
+            state = IGNORE
+        return
+
+    case R9 of
+    0: open()          1: get_bytes()      2: put_bytes()     3: args()
+    4: close()         5: file()           6: func()          7: gbpb()
+    otherwise: log("unknown operation")
+</extended-example>
+
+<p>
+Opening a file, which shows both the handle validation every later operation
+depends on and the way "not found" is reported:
+</p>
+
+<extended-example type='pseudo'>
+open():
+
+    path = string_from_guest(R1)
+    host_path, info = resolve(path)          /* applies the ,xxx convention */
+
+    if info.type == NOT_FOUND then
+        R1 = 0                               /* FileSwitch reads this as not found */
+        return
+
+    handle = allocate_handle()               /* 1..255, or 0 if none free */
+    if handle == 0 then
+        fail("RISC OS should have stopped this")
+
+    case R0 of
+    0:  file = host_open(host_path, read only)
+        R0 = READ_OK
+    2:  file = host_open(host_path, read and write)
+        R0 = READ_OK or WRITE_OK
+    1:  return                               /* RISC OS 2 only; not implemented */
+
+    if file could not be opened then
+        R1 = 0                               /* same answer as not found */
+        return
+
+    R1 = handle
+    R2 = 1024                                /* buffer size: power of 2, 64..1024 */
+    R3 = size of file
+    R4 = 0                                   /* allocated space */
+
+
+get_bytes():
+
+    file = handle_to_file(R1)                /* R1 is guest-controlled */
+    if file is invalid then
+        log("bad handle")
+        return                               /* never index with it */
+
+    seek(file, R4)                           /* absolute: FileSwitch tracks position */
+    data = read(file, R3)
+    write_to_guest(R2, data)
+</extended-example>
+</section>
+
+</chapter>
+
+<!-- MetaData -->
+<meta>
+ <maintainer>
+  <email name="Charles Ferguson" address="gerph@gerph.org" />
+ </maintainer>
+ <disclaimer>
+    <p>
+        This documentation describes the interface between the RPCEmu emulator
+        and the HostFS filing system module which runs inside the emulated
+        machine. RPCEmu is distributed under the GNU General Public License,
+        version 2.
+    </p>
+ </disclaimer>
+
+ <history>
+  <revision number="1" author="Charles Ferguson" date="11 Aug 2026" title="Initial version">
+    <change>Documented the &hex;56AC1 filing system interface, protocol version 3.</change>
+  </revision>
+ </history>
+</meta>
+</riscos-prm>

--- a/docs/prminxml/03-hostcmd.xml
+++ b/docs/prminxml/03-hostcmd.xml
@@ -1,0 +1,498 @@
+<?xml version="1.0"?>
+<!DOCTYPE riscos-prm PUBLIC "-//Gerph//DTD PRM documentation 1.03//EN"
+                            "http://gerph.org/dtd/103/prm.dtd">
+
+<riscos-prm>
+<chapter title="HostCmd">
+
+<section title="Introduction">
+<p>
+HostCmd lets a program on the host run a command inside the emulated machine and
+read what it printed, together with the return code. It is what turns the
+emulator from something a person sits in front of into something a script or a
+build system can drive.
+</p>
+<p>
+The intended use is development. Source is edited on the host, reaches the
+machine through HostFS, and is compiled by a command sent through this interface,
+with the compiler's output coming back to the host's terminal. Nothing has to be
+typed into the emulated machine, and nothing has to be read off its screen.
+</p>
+</section>
+
+<section title="Overview">
+<p>
+The direction of travel is the opposite of every other interface in this manual.
+Elsewhere the guest asks the host to do something; here the host has work for the
+guest, and the guest must come and collect it.
+</p>
+<p>
+That is forced by how the emulator works. The host cannot call into RISC OS: it
+has no way to enter the emulated machine except by letting it run, and no safe
+moment at which to disturb whatever it is doing. So the guest module polls. It
+runs from a ticker event, asks the host on each tick whether there is a command
+waiting, and if there is, runs it and reports back.
+</p>
+<p>
+A complete transaction is therefore:
+</p>
+<p>
+<list>
+<item>the host accepts a command from a client and holds it;</item>
+<item>the guest polls, is given the command, and starts running it;</item>
+<item>the guest reports that the command has started;</item>
+<item>the guest passes output to the host as it is produced, in as many calls as
+it takes;</item>
+<item>the guest reports that the command has finished, with its return code.</item>
+</list>
+</p>
+<p>
+The host's own client - whatever asked for the command - sees this as a stream of
+framed messages on a socket. That socket protocol is not part of this interface
+and a reimplementation may do whatever it likes with the output; only the guest
+side is described here.
+</p>
+</section>
+
+<section title="Technical details">
+
+<subsection title="Calling convention">
+<p>
+The operation is in <em>R9</em>, as it is for HostFS. R0 onwards carry the
+operation's arguments.
+</p>
+<p>
+<value-table head-number="R9" head-value="Operation">
+<value number="0">Poll for a command</value>
+<value number="1">Send output</value>
+<value number="2">Report status</value>
+<value number="3">Read the display target</value>
+<value number="FFFFFFFF">Register with the host</value>
+</value-table>
+</p>
+<p>
+Nothing here reports failure. Every operation returns a status in R0 which the
+caller acts on, and an unrecognised operation returns zero in R0 so that a guest
+module asking about something the host does not implement reads a definite
+answer rather than whatever it passed in.
+</p>
+<p>
+When the interface is disabled in the emulator's configuration the SWI is not
+handled at all and falls through to RISC OS, which reports it as unknown. A
+guest module can use that to detect that the host is not offering the service.
+</p>
+</subsection>
+
+<subsection title="Liveness">
+<p>
+The host needs to know not merely that a guest module once registered but that it
+is still running, because a command handed to a module that has since stopped
+would never be collected and never complete. Both the registration and the poll
+operations refresh that knowledge, and since the module polls from a ticker the
+host sees it regularly for as long as it is alive.
+</p>
+<p>
+A host implementation should use this to refuse work up front rather than let a
+caller wait for a reply that cannot come.
+</p>
+</subsection>
+
+<subsection title="Backpressure">
+<p>
+Output is buffered on the host, and the buffer is finite. Rather than block the
+emulated machine or throw output away, the send operation reports how many bytes
+it actually took, which may be fewer than were offered and may be none. The guest
+is expected to keep the remainder and offer it again on a later call.
+</p>
+<p>
+Two cases deliberately break that rule and claim to have accepted everything.
+When there is no client connected there is nowhere for output to go, and when the
+output belongs to a command that has been abandoned there is no longer anyone
+interested in it. In both cases the output is discarded but reported as taken, so
+that the guest never stalls waiting to flush output that nothing will ever read.
+</p>
+</subsection>
+
+<subsection title="Abandoned commands">
+<p>
+A client may disconnect while its command is still running. The command cannot be
+stopped - RISC OS is running it and the host has no way to interrupt it - so it
+runs to completion and then reports a status for a command nobody is waiting for.
+</p>
+<p>
+The host counts these. A completion arriving when no command is in flight is
+matched against that count and discarded, so it neither closes whatever command
+is current nor reaches a client. A host implementation that does not do this will
+eventually attribute one command's return code to another.
+</p>
+</subsection>
+
+<subsection title="Following the host's display">
+<p>
+The display operation is unrelated to running commands and is here because the
+guest module was already polling. It reports the screen mode the guest should
+adopt to match the host's window, so that resizing the window can change the
+RISC OS screen mode to suit.
+</p>
+<p>
+It carries a generation number rather than a change flag. The guest compares it
+against the one it last acted on, which means the host does not have to track
+what any particular guest has seen, and a guest that misses several changes
+still ends up in the right mode.
+</p>
+</subsection>
+</section>
+
+<section title="SWI calls">
+
+<swi-definition name="RPCEmu_HostCmd"
+                number="56AC5"
+                description="Runs commands sent from the host inside the emulated machine"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="9">Operation:
+  <p>
+  <value-table head-number="R9" head-value="Operation">
+   <value number="0"><reference type='swi' name='RPCEmu_HostCmd' reason='0' use-description='yes'/></value>
+   <value number="1"><reference type='swi' name='RPCEmu_HostCmd' reason='1' use-description='yes'/></value>
+   <value number="2"><reference type='swi' name='RPCEmu_HostCmd' reason='2' use-description='yes'/></value>
+   <value number="3"><reference type='swi' name='RPCEmu_HostCmd' reason='3' use-description='yes'/></value>
+   <value number="FFFFFFFF"><reference type='swi' name='RPCEmu_HostCmd' reason='FFFFFFFF' use-description='yes'/></value>
+  </value-table>
+  </p>
+ </register-use>
+ <register-use number="0-5">Dependent on the operation</register-use>
+</entry>
+<exit>
+ <register-use number="0">Dependent on the operation; 0 for an operation the host does not implement</register-use>
+ <register-use number="1-5">Dependent on the operation</register-use>
+</exit>
+
+<use>
+<p>
+Provides the guest half of the host command interface. The operation is selected
+by R9.
+</p>
+<p>
+When the interface is disabled the SWI is not intercepted and RISC OS reports it
+as unknown, which a guest module may use to detect that the host is not offering
+the service.
+</p>
+</use>
+</swi-definition>
+
+<swi-definition name="RPCEmu_HostCmd"
+                number="56AC5"
+                reason="FFFFFFFF" reasonname="Register"
+                description="Declares the guest module to the host"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="9">&hex;FFFFFFFF (operation)</register-use>
+</entry>
+<exit>
+ <register-use number="0">&hex;FFFFFFFF</register-use>
+ <register-use number="1">1 if a client is connected to the host, otherwise 0</register-use>
+</exit>
+
+<use>
+<p>
+Tells the host that the guest module is present, and reports whether anything is
+currently connected to the host waiting to send commands.
+</p>
+<p>
+This is the host's only proof that the guest half exists, which is what lets it
+refuse a command straight away rather than accept one that nothing would collect.
+</p>
+</use>
+
+<related>
+<reference type='swi' name='RPCEmu_HostCmd' reason='0'/>
+</related>
+</swi-definition>
+
+<swi-definition name="RPCEmu_HostCmd"
+                number="56AC5"
+                reason="0" reasonname="Poll"
+                description="Asks the host whether a command is waiting"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="0">Address of a buffer to receive the command</register-use>
+ <register-use number="1">Size of the buffer in bytes</register-use>
+ <register-use number="9">0 (operation)</register-use>
+</entry>
+<exit>
+ <register-use number="0">Result:
+  <p>
+  <value-table head-number="Value" head-value="Meaning">
+   <value number="0">No command is waiting</value>
+   <value number="1">A command has been placed in the buffer</value>
+   <value number="2">A command is waiting but the buffer is too small</value>
+  </value-table>
+  </p>
+ </register-use>
+ <register-use number="1">Length of the command, excluding its terminator, when R0 is 1 or 2</register-use>
+</exit>
+
+<use>
+<p>
+Collects a command from the host, if there is one. The command is written to the
+buffer and terminated with a zero byte, so the buffer must be at least one byte
+longer than the length reported.
+</p>
+<p>
+A result of 2 means the command was left where it was, and the guest should call
+again with a buffer of at least the size reported in R1 plus one.
+</p>
+<p>
+Calling this also tells the host that the guest module is still running. The
+module is expected to poll regularly - from a ticker event - so that the host
+can tell a live module from one that has stopped.
+</p>
+<p>
+Only one command is in flight at a time. Once a command has been collected, no
+further command is offered until its completion has been reported.
+</p>
+</use>
+
+<related>
+<reference type='swi' name='RPCEmu_HostCmd' reason='1'/>
+<reference type='swi' name='RPCEmu_HostCmd' reason='2'/>
+</related>
+</swi-definition>
+
+<swi-definition name="RPCEmu_HostCmd"
+                number="56AC5"
+                reason="1" reasonname="Output"
+                description="Passes command output back to the host"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="0">Address of the output</register-use>
+ <register-use number="1">Number of bytes of output</register-use>
+ <register-use number="9">1 (operation)</register-use>
+</entry>
+<exit>
+ <register-use number="0">Number of bytes the host accepted, which may be fewer than were offered, and may be zero</register-use>
+</exit>
+
+<use>
+<p>
+Offers output produced by the running command to the host. The host takes as much
+as it has room for and reports how much that was; the guest must retain the
+remainder and offer it again later.
+</p>
+<p>
+The count returned is the whole of what was offered, without it necessarily
+having been kept, in two cases: when no client is connected, and when the output
+belongs to a command whose client has since disconnected. Both discard the
+output, and both report it as accepted so that the guest is never left waiting to
+flush output that nothing will read.
+</p>
+</use>
+
+<related>
+<reference type='swi' name='RPCEmu_HostCmd' reason='2'/>
+</related>
+</swi-definition>
+
+<swi-definition name="RPCEmu_HostCmd"
+                number="56AC5"
+                reason="2" reasonname="Status"
+                description="Reports that a command has started or finished"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="0">Marker:
+  <p>
+  <value-table head-number="Value" head-value="Meaning">
+   <value number="0">The command has started</value>
+   <value number="1">The command has finished</value>
+  </value-table>
+  </p>
+ </register-use>
+ <register-use number="1">The command's return code, when the marker is 1</register-use>
+ <register-use number="2">Flags:
+  <p>
+  <bitfield-table>
+   <bit number="0" state='set'>The output was truncated</bit>
+   <bit number="1-31" state="reserved" />
+  </bitfield-table>
+  </p>
+ </register-use>
+ <register-use number="9">2 (operation)</register-use>
+</entry>
+<exit>
+ <register-use number="0">0</register-use>
+</exit>
+
+<use>
+<p>
+Delimits the command. The start marker requires nothing of the host, since the
+framing of the output already says where it begins; the finish marker carries the
+return code and releases the host to offer the next command.
+</p>
+<p>
+A finish marker arriving when no command is in flight belongs to a command whose
+client disconnected while it was still running. The host discards it: it is not
+the current command's status, and must neither close the current command nor
+reach any client.
+</p>
+</use>
+
+<related>
+<reference type='swi' name='RPCEmu_HostCmd' reason='0'/>
+<reference type='swi' name='RPCEmu_HostCmd' reason='1'/>
+</related>
+</swi-definition>
+
+<swi-definition name="RPCEmu_HostCmd"
+                number="56AC5"
+                reason="3" reasonname="Display"
+                description="Reads the display mode the host would like the guest to adopt"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="9">3 (operation)</register-use>
+</entry>
+<exit>
+ <register-use number="0">1 if a display target is being reported, otherwise 0</register-use>
+ <register-use number="1">Generation number, which changes whenever the host's display changes</register-use>
+ <register-use number="2">Width in pixels</register-use>
+ <register-use number="3">Height in pixels</register-use>
+ <register-use number="4">Refresh rate in Hz, or 0 if the host did not supply one</register-use>
+</exit>
+
+<use>
+<p>
+Reports the screen mode the guest should adopt to follow the host's window.
+</p>
+<p>
+The generation number is what the guest should test, rather than the dimensions:
+it changes whenever the host's display changes, so a module compares it against
+the one it last acted on and changes mode only when they differ. That way the
+host does not have to know what any guest has already seen.
+</p>
+<p>
+The dimensions returned have already been bounded by both the host display and
+the emulated machine's video memory, so a guest may use them as they stand
+without further checking.
+</p>
+</use>
+</swi-definition>
+
+</section>
+
+<section title="Examples">
+<p>
+The guest module's ticker, which is the whole of its side of the protocol:
+</p>
+
+<extended-example type='pseudo'>
+on_ticker():                                 /* called regularly */
+
+    if there is output still to flush then
+        taken = host_cmd(OUTPUT, buffer, length)
+        discard the first `taken` bytes
+        if anything remains then
+            return                           /* try again next tick */
+
+    if a command is running then
+        return
+
+    result, length = host_cmd(POLL, buffer, sizeof(buffer))
+
+    if result == 0 then                      /* nothing waiting */
+        return
+
+    if result == 2 then                      /* buffer too small */
+        enlarge buffer to length + 1
+        return                               /* collect it next tick */
+
+    host_cmd(STATUS, STARTED)
+    rc = run the command, sending its output through OUTPUT
+    host_cmd(STATUS, FINISHED, rc, flags)
+</extended-example>
+
+<p>
+The host side of a command's life, showing where an abandoned command is
+absorbed:
+</p>
+
+<extended-example type='pseudo'>
+client_sent_a_command(command):
+
+    if the guest has not been seen recently then
+        refuse("no guest module is running")  /* rather than wait for nothing */
+        return
+    hold the command as pending
+
+
+handle_poll(bufptr, bufsize):
+    remember that the guest is alive
+
+    if no command is pending or one is already in flight then
+        R0 = 0
+        return
+    if length of command + 1 > bufsize then
+        R0 = 2 ; R1 = length
+        return
+
+    write_to_guest(bufptr, command with a zero terminator)
+    mark the command in flight
+    R0 = 1 ; R1 = length
+
+
+handle_status(marker, rc):
+
+    if marker == FINISHED and nothing is in flight and abandoned > 0 then
+        abandoned = abandoned - 1            /* a disconnected client's command */
+        return                               /* never reaches a client */
+
+    if marker == FINISHED then
+        send the return code to the client
+        nothing is in flight
+
+
+client_disconnected():
+    if a command is in flight then
+        abandoned = abandoned + 1            /* it will report in eventually */
+</extended-example>
+</section>
+
+</chapter>
+
+<!-- MetaData -->
+<meta>
+ <maintainer>
+  <email name="Charles Ferguson" address="gerph@gerph.org" />
+ </maintainer>
+ <disclaimer>
+    <p>
+        This documentation describes the interface between the RPCEmu emulator
+        and the HostCmd module which runs inside the emulated machine. RPCEmu is
+        distributed under the GNU General Public License, version 2.
+    </p>
+ </disclaimer>
+
+ <history>
+  <revision number="1" author="Charles Ferguson" date="11 Aug 2026" title="Initial version">
+    <change>Documented the &hex;56AC5 host command interface.</change>
+  </revision>
+ </history>
+</meta>
+</riscos-prm>

--- a/docs/prminxml/04-clipboard.xml
+++ b/docs/prminxml/04-clipboard.xml
@@ -1,0 +1,456 @@
+<?xml version="1.0"?>
+<!DOCTYPE riscos-prm PUBLIC "-//Gerph//DTD PRM documentation 1.03//EN"
+                            "http://gerph.org/dtd/103/prm.dtd">
+
+<riscos-prm>
+<chapter title="Clipboard">
+
+<section title="Introduction">
+<p>
+The clipboard interface joins the host's clipboard to the emulated machine's, so
+that text or an image copied in one can be pasted in the other. Text copied from
+a browser on the host pastes into StrongEd; a paragraph copied in Edit pastes
+into whatever the host was doing.
+</p>
+<p>
+It is off by default, and that is a deliberate choice rather than caution about
+the implementation: turning it on puts the host's clipboard within reach of
+anything running in the emulated machine.
+</p>
+</section>
+
+<section title="Overview">
+<p>
+The interface and its guest module come from RiscOS Cloverleaf's fork of RPCEmu,
+and both the SWI number and the reason codes are kept as Cloverleaf defined them
+so that a guest module built for Cloverleaf works here unaltered. The number
+sits apart from the rest of the emulator's chunk, at &hex;56AD0.
+</p>
+<p>
+The guest half is a Wimp task, which is what the RISC OS clipboard conventions
+require: the clipboard is owned by a task, which offers its contents when another
+task asks for them. The task claims the RISC OS clipboard on the host's behalf
+and answers requests for it, and offers the host's clipboard whatever a RISC OS
+application has copied.
+</p>
+<p>
+Both directions are polled rather than pushed, but only one of them needs to be.
+When a RISC OS application copies something, the guest task knows immediately and
+calls the host. When the host's clipboard changes there is no way to call into
+RISC OS, so the host sets a bit in a word of guest memory that the task gave it
+at setup, and the task - which is passing that word to the Wimp as a pollword -
+is woken by the Wimp and comes to collect.
+</p>
+</section>
+
+<section title="Technical details">
+
+<subsection title="Calling convention">
+<p>
+The reason code is in R0, with arguments from R1 onwards.
+</p>
+<p>
+<value-table head-number="R0" head-value="Operation">
+<value number="1">Setup - declare the task, its alphabet and its pollword</value>
+<value number="2">Set - the guest is putting something on the clipboard</value>
+<value number="3">Get - the guest is fetching what the host has</value>
+<value number="4">Check - what is on the host's clipboard, and how much</value>
+</value-table>
+</p>
+<p>
+Nothing reports failure. An operation that cannot be carried out - because there
+is nothing on the clipboard, or the type is not one that is carried - returns
+zero in R0 and does nothing.
+</p>
+<p>
+When the clipboard is disabled in the emulator's configuration the SWI is not
+intercepted and RISC OS reports it as unknown, which is how the guest module
+detects that it should not be running.
+</p>
+</subsection>
+
+<subsection title="What is carried">
+<p>
+Three RISC OS filetypes travel through this interface, and the type travels with
+the data rather than being implied by the operation. That is what allowed images
+to be added without changing the interface or the guest module.
+</p>
+<p>
+<value-table head-number="Type" head-value="Contents">
+<value number="FFF">Text</value>
+<value number="B60">PNG image</value>
+<value number="C85">JPEG image</value>
+</value-table>
+</p>
+<p>
+Anything else offered by the guest is ignored. Only one thing is on the clipboard
+at a time: setting text discards a held image and the reverse.
+</p>
+<p>
+Images pass through unaltered, as the encoded file rather than as pixels, since
+neither side gains from decoding and re-encoding them. Text does not: see below.
+</p>
+</subsection>
+
+<subsection title="Text and alphabets">
+<p>
+Text cannot pass through unaltered, because the two sides do not agree on what a
+byte means. RISC OS uses a single-byte alphabet which depends on the configured
+territory; hosts use Unicode.
+</p>
+<p>
+Rather than assume which RISC OS alphabet is in use, the interface has the guest
+say. At setup the task hands over its alphabet number and a 256-entry table
+giving the UCS-4 value of each character in it. The host holds clipboard text as
+UCS-4 and converts through that table in both directions, so a character the
+guest's alphabet cannot represent is simply dropped rather than mistranslated.
+</p>
+<p>
+A host implementation therefore needs to keep text in a form that can be
+converted both ways, and must not assume Latin-1 merely because it is the most
+common case.
+</p>
+</subsection>
+
+<subsection title="Lengths and terminators">
+<p>
+The length reported by the check operation is exactly what the guest will
+receive, with no terminator counted, for both text and images. The guest uses
+that figure as the clipboard's length and hands it to the application asking for
+the clipboard, so anything added to it is delivered to the application as data.
+</p>
+<p>
+This is worth stating plainly because getting it wrong is not obviously a defect
+on the host side. Reporting one more than the text's length - to leave room for
+the terminator the guest does need - meant every paste into RISC OS arrived with
+a trailing zero byte, which Edit and StrongEd both displayed at the end of the
+text.
+</p>
+<p>
+The get operation writes a terminator after the text, one byte beyond the length
+the caller asked for. The guest allocates beyond what it asks for, so that byte
+is within its buffer, but a host implementation should know that it is writing
+it.
+</p>
+</subsection>
+
+<subsection title="The pollword">
+<p>
+The host announces a change to its clipboard by setting bit 0 of the word in
+guest memory whose address it was given at setup. It does not clear the bit; the
+guest does that when it has dealt with the change.
+</p>
+<p>
+The bit is also set at setup time if the host's clipboard already holds
+something, so a task starting up after the host has copied something is in step
+rather than believing the clipboard empty until the next change.
+</p>
+<p>
+A pollword address of zero withdraws the task, and the host must then stop
+writing to guest memory. This is how the module signals that it is shutting down.
+</p>
+</subsection>
+</section>
+
+<section title="SWI calls">
+
+<swi-definition name="RPCEmu_Clipboard"
+                number="56AD0"
+                description="Exchanges clipboard contents between the guest and the host"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="0">Reason code:
+  <p>
+  <value-table head-number="Reason" head-value="Action">
+   <value number="1"><reference type='swi' name='RPCEmu_Clipboard' reason='1' use-description='yes'/></value>
+   <value number="2"><reference type='swi' name='RPCEmu_Clipboard' reason='2' use-description='yes'/></value>
+   <value number="3"><reference type='swi' name='RPCEmu_Clipboard' reason='3' use-description='yes'/></value>
+   <value number="4"><reference type='swi' name='RPCEmu_Clipboard' reason='4' use-description='yes'/></value>
+  </value-table>
+  </p>
+ </register-use>
+ <register-use number="1-3">Dependent on the reason code</register-use>
+</entry>
+<exit>
+ <register-use number="0">Dependent on the reason code; 0 if the operation did nothing</register-use>
+ <register-use number="1">Dependent on the reason code</register-use>
+</exit>
+
+<use>
+<p>
+Provides the guest half of the shared clipboard. The reason code is in R0.
+</p>
+<p>
+No reason code reports an error. When the clipboard is disabled the SWI is not
+intercepted at all and RISC OS reports it as unknown.
+</p>
+</use>
+</swi-definition>
+
+<swi-definition name="RPCEmu_Clipboard"
+                number="56AD0"
+                reason="1" reasonname="Setup"
+                description="Declares the guest task, its alphabet and its pollword"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="0">1 (reason code)</register-use>
+ <register-use number="1">Address of the task's pollword, or 0 to withdraw</register-use>
+ <register-use number="2">The alphabet number the guest is using</register-use>
+ <register-use number="3">Address of a 256-entry table giving the UCS-4 value of each character in that alphabet</register-use>
+</entry>
+<exit>
+ <register-use number="0">0</register-use>
+ <register-use number="1">0</register-use>
+</exit>
+
+<use>
+<p>
+Declares the guest clipboard task to the host, and gives the host what it needs
+to convert text: the word to poke when the host's clipboard changes, and the
+table describing the guest's alphabet.
+</p>
+<p>
+The conversion table is read once, here. A guest whose alphabet changes must call
+again with the new table.
+</p>
+<p>
+If the host's clipboard already holds text at this point, the pollword bit is set
+straight away, so a task starting after the host has copied something does not
+have to wait for a further change to notice.
+</p>
+<p>
+Calling with R1 = 0 withdraws the task. The host discards the conversion table
+and stops writing to guest memory. A guest module must do this before it exits.
+</p>
+</use>
+
+<related>
+<reference type='swi' name='RPCEmu_Clipboard' reason='4'/>
+</related>
+</swi-definition>
+
+<swi-definition name="RPCEmu_Clipboard"
+                number="56AD0"
+                reason="2" reasonname="Set"
+                description="Puts guest data onto the host's clipboard"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="0">2 (reason code)</register-use>
+ <register-use number="1">Address of the data</register-use>
+ <register-use number="2">Length of the data in bytes</register-use>
+ <register-use number="3">RISC OS filetype of the data: &hex;FFF, &hex;B60 or &hex;C85</register-use>
+</entry>
+<exit>
+ <register-use number="0">0</register-use>
+ <register-use number="1">0</register-use>
+</exit>
+
+<use>
+<p>
+Places what a RISC OS application has copied onto the host's clipboard.
+</p>
+<p>
+Text is converted from the guest's alphabet through the table supplied at setup;
+characters with no equivalent are dropped. Images are taken as the encoded file
+and stored unaltered.
+</p>
+<p>
+Whatever was previously held is discarded, whichever form it was in. A length of
+zero, or a filetype that is not one of the three carried, does nothing.
+</p>
+</use>
+
+<related>
+<reference type='swi' name='RPCEmu_Clipboard' reason='3'/>
+</related>
+</swi-definition>
+
+<swi-definition name="RPCEmu_Clipboard"
+                number="56AD0"
+                reason="3" reasonname="Get"
+                description="Fetches the host's clipboard into guest memory"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="0">3 (reason code)</register-use>
+ <register-use number="1">Address of a buffer to receive the data</register-use>
+ <register-use number="2">Number of bytes of room in the buffer</register-use>
+</entry>
+<exit>
+ <register-use number="0">Number of bytes written, excluding any terminator; 0 if nothing was written</register-use>
+ <register-use number="1">0</register-use>
+</exit>
+
+<use>
+<p>
+Copies what the host holds into the guest's buffer.
+</p>
+<p>
+Text is converted into the guest's alphabet through the table supplied at setup,
+characters with no equivalent being dropped, and a zero terminator is written
+after it - one byte beyond the count in R2, which the guest is expected to have
+allowed for. Images are copied through unaltered with no terminator.
+</p>
+<p>
+The room in R2 should be the length reported by
+<reference type='swi' name='RPCEmu_Clipboard' reason='4'/>. Because dropped
+characters shorten the result, the count returned may be less than that; it is
+never more.
+</p>
+<p>
+A buffer with no room, or nothing held, writes nothing and returns zero.
+</p>
+</use>
+
+<related>
+<reference type='swi' name='RPCEmu_Clipboard' reason='4'/>
+</related>
+</swi-definition>
+
+<swi-definition name="RPCEmu_Clipboard"
+                number="56AD0"
+                reason="4" reasonname="Check"
+                description="Reports what the host's clipboard holds"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="0">4 (reason code)</register-use>
+</entry>
+<exit>
+ <register-use number="0">Length in bytes of what would be delivered, or 0 if the clipboard is empty</register-use>
+ <register-use number="1">RISC OS filetype of what is held, when R0 is non-zero</register-use>
+</exit>
+
+<use>
+<p>
+Reports how much there is to fetch and what type it is, so the guest can allocate
+a buffer and tell an application asking for the clipboard what it is being
+offered.
+</p>
+<p>
+The length is exactly what will be delivered, with no terminator counted. For
+text it is the length after conversion into the guest's alphabet, so it accounts
+for any characters that will be dropped. The guest uses this figure as the
+clipboard's length when it answers the application, so a host implementation must
+not add anything to it.
+</p>
+</use>
+
+<related>
+<reference type='swi' name='RPCEmu_Clipboard' reason='3'/>
+</related>
+</swi-definition>
+
+</section>
+
+<section title="Examples">
+<p>
+The host side, in full. Text is held as UCS-4 so it can be converted to either
+side's encoding; an image is held as the file it arrived as.
+</p>
+
+<extended-example type='pseudo'>
+clipboard_handler():
+
+    R0 = 0 ; R1 = 0
+    if the clipboard is not enabled then
+        return
+
+    case R0 of
+
+    1:  /* Setup */
+        pollword = R1
+        alphabet = R2
+        if R1 != 0 and R3 != 0 then
+            ucstable = read_words_from_guest(R3, 256)
+            if something is already held then
+                write_word_to_guest(pollword, HOST_CHANGED)
+        else
+            forget the table                 /* the task is going away */
+
+    2:  /* Set */
+        if R2 == 0 then
+            return
+        if R3 is an image type then
+            discard whatever is held
+            hold the bytes at R1 as an image of type R3
+            offer it to the host's clipboard
+        else if R3 == TEXT then
+            discard whatever is held
+            hold guest_text_to_ucs(bytes at R1, length R2)
+            offer it to the host's clipboard as UTF-8
+        /* anything else: ignored */
+
+    3:  /* Get */
+        if R2 == 0 or nothing is held then
+            return
+        if an image is held then
+            n = min(image length, R2)
+            write_to_guest(R1, first n bytes of the image)
+            R0 = n
+        else
+            out = ""
+            for each character in the held text, while length(out) &lt; R2
+                c = ucs_to_guest(character)
+                if c != 0 then append c to out /* no equivalent: drop it */
+            write_to_guest(R1, out followed by a zero byte)
+            R0 = length(out)
+
+    4:  /* Check */
+        if an image is held then
+            R0 = image length ; R1 = its filetype
+        else if text is held then
+            R0 = length after conversion to the guest's alphabet
+            R1 = TEXT
+        /* else both stay 0 */
+</extended-example>
+
+<p>
+And the one thing the host does without being asked:
+</p>
+
+<extended-example type='pseudo'>
+host_clipboard_changed(type, data):
+
+    hold the data, converting text to UCS-4
+    if pollword != 0 then
+        write_word_to_guest(pollword, HOST_CHANGED)   /* the Wimp wakes the task */
+</extended-example>
+</section>
+
+</chapter>
+
+<!-- MetaData -->
+<meta>
+ <maintainer>
+  <email name="Charles Ferguson" address="gerph@gerph.org" />
+ </maintainer>
+ <disclaimer>
+    <p>
+        This documentation describes the interface between the RPCEmu emulator
+        and the clipboard task which runs inside the emulated machine. The
+        interface originated in RiscOS Cloverleaf's fork of RPCEmu. RPCEmu is
+        distributed under the GNU General Public License, version 2.
+    </p>
+ </disclaimer>
+
+ <history>
+  <revision number="1" author="Charles Ferguson" date="11 Aug 2026" title="Initial version">
+    <change>Documented the &hex;56AD0 clipboard interface and its four reason codes.</change>
+  </revision>
+ </history>
+</meta>
+</riscos-prm>

--- a/docs/prminxml/05-network.xml
+++ b/docs/prminxml/05-network.xml
@@ -50,10 +50,12 @@ module. RISC OS finds and starts the module during expansion card enumeration,
 exactly as it would from a real card.
 </item>
 <item>
+<p>
 The <em>guest driver</em>, <filename>EtherRPCEm</filename>. A DCI4 driver that registers
 itself with the Internet stack under the interface name <filename>rpcem</filename>. It
 implements the DCI4 SWIs the stack calls, and turns them into the calls
 described in this chapter. It owns no hardware.
+</p>
 </item>
 <item>
 The <em>host implementation</em>. The emulator's SWI handler, which converts

--- a/docs/prminxml/05-network.xml
+++ b/docs/prminxml/05-network.xml
@@ -9,7 +9,7 @@
 <p>
 RPCEmu presents an Ethernet interface to the emulated machine. There is no
 emulated network chip behind it. Instead the guest is given an expansion card
-whose ROM contains a DCI4 network driver, <code>EtherRPCEm</code>, and that
+whose ROM contains a DCI4 network driver, <filename>EtherRPCEm</filename>, and that
 driver moves frames by calling a single SWI which the emulator intercepts
 before RISC OS ever sees it.
 </p>
@@ -50,8 +50,8 @@ module. RISC OS finds and starts the module during expansion card enumeration,
 exactly as it would from a real card.
 </item>
 <item>
-The <em>guest driver</em>, <code>EtherRPCEm</code>. A DCI4 driver that registers
-itself with the Internet stack under the interface name <code>rpcem</code>. It
+The <em>guest driver</em>, <filename>EtherRPCEm</filename>. A DCI4 driver that registers
+itself with the Internet stack under the interface name <filename>rpcem</filename>. It
 implements the DCI4 SWIs the stack calls, and turns them into the calls
 described in this chapter. It owns no hardware.
 </item>
@@ -179,18 +179,18 @@ words of each mbuf, and ignores the rest of the structure:
 </p>
 <p>
 All six are 32-bit little-endian words. The payload of an mbuf begins at the
-mbuf's own address plus <code>m_off</code>, not at a separately stored pointer.
+mbuf's own address plus <variable>m_off</variable>, not at a separately stored pointer.
 </p>
 <p>
-On transmission the chain is followed through <code>m_next</code> and each
-segment's <code>m_len</code> bytes are appended to the frame in turn.
-<code>m_list</code> is not followed: the driver walks that itself and calls once
+On transmission the chain is followed through <variable>m_next</variable> and each
+segment's <variable>m_len</variable> bytes are appended to the frame in turn.
+<variable>m_list</variable> is not followed: the driver walks that itself and calls once
 per chain.
 </p>
 <p>
-On reception a single mbuf is filled in. The host sets <code>m_off</code> to
-<code>m_inioff</code>, copies the payload to that offset, sets
-<code>m_len</code> to the payload length, and writes all six words back.
+On reception a single mbuf is filled in. The host sets <variable>m_off</variable> to
+<variable>m_inioff</variable>, copies the payload to that offset, sets
+<variable>m_len</variable> to the payload length, and writes all six words back.
 </p>
 <p>
 Both chain and contents are guest-controlled, and a host implementation must
@@ -199,7 +199,7 @@ followed forever, and a segment length taken at face value will overrun a fixed
 host buffer - neither of which the total-length check catches on its own,
 since a cycle of zero-length segments never grows the total. RPCEmu bounds both:
 it abandons a chain after 1024 segments with the message
-<code>RPCEmu: mbuf chain too long</code>, and checks each segment's length
+<systemoutput>RPCEmu: mbuf chain too long</systemoutput>, and checks each segment's length
 against the buffer size in its own right as well as against the running total.
 </p>
 </subsection>
@@ -345,7 +345,7 @@ larger than 1514 bytes should not arise from the guest in normal use.
 
 <use>
 <p>
-This SWI is the whole of the interface between the <code>EtherRPCEm</code>
+This SWI is the whole of the interface between the <filename>EtherRPCEm</filename>
 driver running in the emulated machine and the emulator hosting it. The reason
 code in R0 selects the operation.
 </p>
@@ -355,7 +355,7 @@ the technical details above before writing a caller.
 </p>
 <p>
 An unrecognised reason code writes the message
-<code>Unknown RPCEmu network SWI</code> to the buffer addressed by R1 and
+<systemoutput>Unknown RPCEmu network SWI</systemoutput> to the buffer addressed by R1 and
 returns that address in R0. R1 must therefore address a writable buffer of at
 least 27 bytes whenever a reason code that might not be recognised is used.
 </p>
@@ -450,7 +450,7 @@ the host chose to drop return R0 = 0 with R1 = 0.
 Frames that cannot be delivered are dropped rather than reported. A frame is
 undeliverable if no mbuf was supplied, if it has no payload beyond the
 Ethernet header, or if its payload is larger than the supplied mbuf's
-<code>m_inilen</code>. In each case the frame is consumed, the guest's receive
+<variable>m_inilen</variable>. In each case the frame is consumed, the guest's receive
 header is left untouched, and the next queued frame is promoted.
 </p>
 <p>
@@ -736,7 +736,7 @@ afresh when it is promoted out of the queue.
  <disclaimer>
     <p>
         This documentation describes the interface between the RPCEmu emulator
-        and the <code>EtherRPCEm</code> network driver which runs inside the
+        and the <filename>EtherRPCEm</filename> network driver which runs inside the
         emulated machine. RPCEmu is distributed under the GNU General Public
         License, version 2.
     </p>

--- a/docs/prminxml/Makefile
+++ b/docs/prminxml/Makefile
@@ -1,55 +1,63 @@
 # Build the RPCEmu host interfaces manual.
 #
-# The sources are PRM-in-XML; riscos-prminxml renders them. CI does the same
-# thing through gerph/riscos-prminxml-action and publishes the result with each
-# release, so this Makefile is for working on the manual locally.
+# The sources are PRM-in-XML; riscos-prminxml renders them. CI builds the same
+# manual through gerph/riscos-prminxml-action and publishes it with each
+# release, so this is for working on it locally.
 #
 #   make lint      check every chapter
 #   make html      render each chapter on its own
-#   make indexed   render the whole thing as one navigable manual
+#   make indexed   render the whole manual, with contents and the SWI index
 #   make           all three
+#   make pdf       and a PDF, if Prince is installed
 #
 # Output goes to prm-output/ at the top of the tree, which is gitignored.
+#
+# Chapters are found by wildcard, so adding one means adding the file and
+# listing it in index.xml - nothing here needs changing. The numeric prefixes
+# are for the reader; index.xml is what actually fixes the order.
 
 OUTPUT = ../../prm-output
 
-# Explicit, and in reading order: the index lists these chapters in this
-# sequence and the manual is meant to be read that way.
-XMLS = \
-	front/title-page.xml \
-	01-overview.xml \
-	02-hostfs.xml \
-	03-hostcmd.xml \
-	04-clipboard.xml \
-	05-network.xml \
-	appendix/a1-reserved.xml
+# Every document except index.xml, which is the manifest rather than a chapter.
+CHAPTERS = $(filter-out index.xml, \
+             $(wildcard *.xml) $(wildcard front/*.xml) $(wildcard appendix/*.xml))
+
+# riscos-prminxml flattens its output, so front/title-page.xml becomes
+# title-page.html at the top of the output directory.
+HTML   = $(patsubst %.xml,$(OUTPUT)/%.html,$(notdir $(CHAPTERS)))
+STAMPS = $(patsubst %.xml,$(OUTPUT)/lint/%.stamp,$(notdir $(CHAPTERS)))
+
+# So the pattern rules can find a chapter without caring which directory it
+# lives in.
+vpath %.xml . front appendix
 
 .PHONY: all lint html lint-indexed indexed pdf clean
 
 all: lint html indexed
 
-lint:
-	@for file in $(XMLS); do \
-		echo "Linting $$file"; \
-		riscos-prminxml -f lint "$$file" || exit 1; \
-	done
+lint: $(STAMPS)
 
-html:
+html: $(HTML)
+
+$(OUTPUT)/lint/%.stamp: %.xml
+	@mkdir -p $(dir $@)
+	riscos-prminxml -f lint $<
+	@touch $@
+
+$(OUTPUT)/%.html: %.xml
 	@mkdir -p $(OUTPUT)
-	@for file in $(XMLS); do \
-		echo "Building $$file"; \
-		riscos-prminxml -f html5+xml -O $(OUTPUT) "$$file" || exit 1; \
-	done
+	riscos-prminxml -f html5+xml -O $(OUTPUT) $<
 
-lint-indexed:
+# The indexed build takes its paths from index.xml, and depends on every
+# chapter because any of them can change what the contents and the SWI index
+# contain.
+lint-indexed: $(CHAPTERS) index.xml
 	@mkdir -p $(OUTPUT)/indexed/logs
-	@echo "Linting the indexed manual"
-	@riscos-prminxml --lint -f index -L $(OUTPUT)/indexed/logs index.xml
+	riscos-prminxml --lint -f index -L $(OUTPUT)/indexed/logs index.xml
 
-indexed:
+indexed: $(CHAPTERS) index.xml
 	@mkdir -p $(OUTPUT)/indexed/logs
-	@echo "Building the indexed manual"
-	@riscos-prminxml -f index -L $(OUTPUT)/indexed/logs index.xml
+	riscos-prminxml -f index -L $(OUTPUT)/indexed/logs index.xml
 
 # Prince is not assumed to be installed: it is a commercial tool and nothing
 # else here needs it.

--- a/docs/prminxml/Makefile
+++ b/docs/prminxml/Makefile
@@ -1,0 +1,64 @@
+# Build the RPCEmu host interfaces manual.
+#
+# The sources are PRM-in-XML; riscos-prminxml renders them. CI does the same
+# thing through gerph/riscos-prminxml-action and publishes the result with each
+# release, so this Makefile is for working on the manual locally.
+#
+#   make lint      check every chapter
+#   make html      render each chapter on its own
+#   make indexed   render the whole thing as one navigable manual
+#   make           all three
+#
+# Output goes to prm-output/ at the top of the tree, which is gitignored.
+
+OUTPUT = ../../prm-output
+
+# Explicit, and in reading order: the index lists these chapters in this
+# sequence and the manual is meant to be read that way.
+XMLS = \
+	front/title-page.xml \
+	01-overview.xml \
+	02-hostfs.xml \
+	03-hostcmd.xml \
+	04-clipboard.xml \
+	05-network.xml \
+	appendix/a1-reserved.xml
+
+.PHONY: all lint html lint-indexed indexed pdf clean
+
+all: lint html indexed
+
+lint:
+	@for file in $(XMLS); do \
+		echo "Linting $$file"; \
+		riscos-prminxml -f lint "$$file" || exit 1; \
+	done
+
+html:
+	@mkdir -p $(OUTPUT)
+	@for file in $(XMLS); do \
+		echo "Building $$file"; \
+		riscos-prminxml -f html5+xml -O $(OUTPUT) "$$file" || exit 1; \
+	done
+
+lint-indexed:
+	@mkdir -p $(OUTPUT)/indexed/logs
+	@echo "Linting the indexed manual"
+	@riscos-prminxml --lint -f index -L $(OUTPUT)/indexed/logs index.xml
+
+indexed:
+	@mkdir -p $(OUTPUT)/indexed/logs
+	@echo "Building the indexed manual"
+	@riscos-prminxml -f index -L $(OUTPUT)/indexed/logs index.xml
+
+# Prince is not assumed to be installed: it is a commercial tool and nothing
+# else here needs it.
+pdf: indexed
+	@if command -v prince >/dev/null 2>&1; then \
+		cd $(OUTPUT)/indexed/pages && prince -l filelist.txt -o RPCEmuHostInterfaces.pdf; \
+	else \
+		echo "Prince is not installed; skipping PDF generation"; \
+	fi
+
+clean:
+	rm -rf $(OUTPUT)

--- a/docs/prminxml/appendix/a1-reserved.xml
+++ b/docs/prminxml/appendix/a1-reserved.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+<!DOCTYPE riscos-prm PUBLIC "-//Gerph//DTD PRM documentation 1.03//EN"
+                            "http://gerph.org/dtd/103/prm.dtd">
+
+<riscos-prm>
+<chapter title="Reserved SWI numbers">
+
+<section title="Overview">
+<p>
+Three numbers in the emulator's SWI chunk are allocated but are not implemented.
+They are recorded here so that a host implementation knows not to expect them,
+and so that nobody reuses a number for something else and then finds a guest
+built against the original meaning.
+</p>
+<p>
+None of the three is intercepted. A guest issuing one of them reaches RISC OS,
+which reports an unknown SWI, exactly as it would for any other unallocated
+number.
+</p>
+</section>
+
+<section title="Technical details">
+
+<subsection title="The numbers">
+<p>
+<value-table head-number="Number" head-value="Allocation">
+<value number="56AC0">Shutdown. Inherited from ArcEm, where it stopped the emulator from inside the emulated machine. Not implemented here</value>
+<value number="56AC2">Debug. Inherited from ArcEm, where it wrote diagnostics to the emulator's own output. Not implemented here</value>
+<value number="56AC3">Reserved. Never allocated a meaning in either emulator, and never used</value>
+</value-table>
+</p>
+</subsection>
+
+<subsection title="Shutdown">
+<p>
+&hex;56AC0 stopped the emulator when called from inside the emulated machine.
+RPCEmu reaches the same end differently and without a SWI of its own: the RISC OS
+Switcher is patched at run time to advertise that the machine supports power
+control, so the desktop's Shutdown finishes by calling
+<reference type="swi" name="OS_Reset"/> with the documented request to power the
+machine off. The emulator recognises that and closes itself. Any other
+<reference type="swi" name="OS_Reset"/> is a genuine reset and is passed through
+untouched.
+</p>
+<p>
+The effect is that shutting the machine down from the desktop closes the
+emulator, with nothing needed inside the machine to arrange it. A host
+implementation wanting the same behaviour should follow the same route rather
+than implement this SWI.
+</p>
+</subsection>
+
+<subsection title="Debug">
+<p>
+&hex;56AC2 wrote diagnostics from the emulated machine to the emulator's output.
+RPCEmu has its own debugging facilities which do not need the guest's
+cooperation - a debugger driven over a socket, exception trapping, SWI tracing
+and logging watchpoints - so nothing has required this.
+</p>
+</subsection>
+
+<subsection title="Reusing them">
+<p>
+Both numbers should be treated as spent rather than free. Guest software built
+for ArcEm may still issue them, and a number given a new meaning here would be
+called with the old one's registers by anything that had not been rebuilt. A new
+interface should take a new number in the chunk instead; &hex;56AC6 onwards are
+unused, as is everything between &hex;56AC6 and &hex;56AD0 aside from the
+clipboard's number itself.
+</p>
+</subsection>
+</section>
+
+</chapter>
+
+<!-- MetaData -->
+<meta>
+ <maintainer>
+  <email name="Charles Ferguson" address="gerph@gerph.org" />
+ </maintainer>
+ <disclaimer>
+    <p>
+        RPCEmu is distributed under the GNU General Public License, version 2.
+    </p>
+ </disclaimer>
+
+ <history>
+  <revision number="1" author="Charles Ferguson" date="11 Aug 2026" title="Initial version">
+    <change>Recorded the allocated but unimplemented numbers in the emulator SWI chunk.</change>
+  </revision>
+ </history>
+</meta>
+</riscos-prm>

--- a/docs/prminxml/front/title-page.xml
+++ b/docs/prminxml/front/title-page.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<!DOCTYPE riscos-prm PUBLIC "-//Gerph//DTD PRM documentation 1.03//EN"
+                            "http://gerph.org/dtd/103/prm.dtd">
+
+<riscos-prm>
+<chapter title="RPCEmu host interfaces">
+
+<section title="About this manual">
+<p>
+This manual describes the interfaces between the RPCEmu emulator and the modules
+which run inside the machine it emulates: the filing system that reaches the
+host's storage, the network driver that has no network card, the shared
+clipboard, and the channel that lets the host run commands inside RISC OS.
+</p>
+<p>
+It is written for somebody implementing the host half of one of these
+interfaces - another emulator wanting to run the same guest modules, a test
+harness standing in for the emulator, or anyone maintaining RPCEmu who needs to
+know what the guest is entitled to rely on. It is not a guide to using RPCEmu;
+the emulator's own documentation covers that.
+</p>
+<p>
+The interfaces are private contracts between one module and the emulator hosting
+it. They are not RISC OS APIs, they are not registered with RISC OS Open, and
+software running on real hardware will not find them.
+</p>
+</section>
+
+<section title="How this manual is arranged">
+<p>
+Read the first chapter before any of the others. It describes the SWI chunk the
+interfaces occupy and the conventions they share - and, more usefully, the
+several places where they do not share one, such as which register carries the
+reason code and how each reports a failure.
+</p>
+<p>
+The remaining chapters are independent of each other and may be read in any
+order. Each describes one interface, giving the reason it exists, the technical
+detail needed to implement it, a definition of every operation, and worked
+pseudo-code for the host side.
+</p>
+</section>
+
+</chapter>
+
+<!-- MetaData -->
+<meta>
+ <maintainer>
+  <email name="Charles Ferguson" address="gerph@gerph.org" />
+ </maintainer>
+ <disclaimer>
+    <p>
+        RPCEmu is distributed under the GNU General Public License, version 2.
+    </p>
+ </disclaimer>
+
+ <history>
+  <revision number="1" author="Charles Ferguson" date="11 Aug 2026" title="Initial version">
+    <change>Created the manual.</change>
+  </revision>
+ </history>
+</meta>
+</riscos-prm>

--- a/docs/prminxml/index.xml
+++ b/docs/prminxml/index.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<index>
+<dirs output="../../prm-output/indexed/pages"
+      index="../../prm-output/indexed"
+      help="../../prm-output/indexed/help"
+      header="../../prm-output/indexed/header"
+      input="."
+      temp="../../prm-output/indexed/tmp" />
+<options
+    hide-empty="no"
+    include-source="no"
+    make-contents="no"
+    include-sections="no"
+    include-sections-depth="1"
+    catalog-version="103"
+    page-format="html5"
+    page-css-base="standard"
+    page-css-variant="prm body-fraunces heading-raleway webfont-fraunces webfont-raleway large-bullets"
+    page-css-file="none"
+    index-css-base="standard"
+    index-css-variant="prm body-fraunces heading-raleway webfont-fraunces webfont-raleway large-bullets no-edge-index"
+    index-css-file="none"
+    docgroup-name="RPCEmu host interfaces"
+    docgroup-part=""
+    chapter-numbers="yes"
+    chapter-contents="no"
+    edgeindex-max="4"
+    />
+
+<make-index type="swi" />
+<make-indexdata/>
+<make-filelist/>
+
+<footer>
+Copyright (c) the RPCEmu contributors. RPCEmu is distributed under the GNU
+General Public License, version 2. These interfaces are private to the emulator
+and are not part of RISC OS; they are documented as implemented, and an
+operation not described here is not implemented.
+</footer>
+
+<front-matter type="title" href="front/title-page"/>
+
+<section title="Host interfaces">
+    <page href="01-overview">The emulator host interfaces</page>
+    <page href="02-hostfs">HostFS</page>
+    <page href="03-hostcmd">HostCmd</page>
+    <page href="04-clipboard">Clipboard</page>
+    <page href="05-network">The RPCEmu network interface</page>
+</section>
+
+<section title="Appendices" dir="appendix">
+    <page href="a1-reserved">Reserved SWI numbers</page>
+</section>
+</index>

--- a/docs/prminxml/network-swi.xml
+++ b/docs/prminxml/network-swi.xml
@@ -1,0 +1,755 @@
+<?xml version="1.0"?>
+<!DOCTYPE riscos-prm PUBLIC "-//Gerph//DTD PRM documentation 1.03//EN"
+                            "http://gerph.org/dtd/103/prm.dtd">
+
+<riscos-prm>
+<chapter title="The RPCEmu network interface">
+
+<section title="Introduction">
+<p>
+RPCEmu presents an Ethernet interface to the emulated machine. There is no
+emulated network chip behind it. Instead the guest is given an expansion card
+whose ROM contains a DCI4 network driver, <code>EtherRPCEm</code>, and that
+driver moves frames by calling a single SWI which the emulator intercepts
+before RISC OS ever sees it.
+</p>
+<p>
+The reason for that arrangement is the amount of work avoided by it. A faithful
+emulation of a real network card - the i82596 of an Acorn AEH62, say, or
+the LAN91C96 of a Castle EtherY - means emulating descriptor rings, DMA
+into emulated memory, a MII register file and the card's own interrupt logic,
+all so that an unmodified driver can be persuaded to hand over an Ethernet
+frame it was always going to hand over. None of that detail is visible to the
+user, and none of it makes the emulated machine behave any more like a Risc PC.
+Replacing the chip with a SWI reduces the whole transaction to "here is a frame,
+send it" and "have you a frame for me", which is all the DCI4 layer above
+actually wants.
+</p>
+<p>
+The cost is that the driver is specific to RPCEmu. That is the trade this
+interface represents, and it is the reason the interface is worth writing down:
+anything that wants to run the stock RISC OS networking stack the way RPCEmu
+does - another emulator, a test harness, a replacement host-side
+implementation - has to provide this SWI, and there is otherwise nothing
+that says what it must do.
+</p>
+</section>
+
+<section title="Overview">
+<p>
+Three pieces cooperate, and the interface described here is the boundary
+between the second and the third.
+</p>
+<p>
+<list>
+<item>
+The <em>expansion card</em>. RPCEmu registers a podule whose ROM it builds at run
+time. The ROM holds an Acorn-conformant expansion card header, a description
+string, and a chunk of type &hex;81 (RISC OS, ROM) containing the driver
+module. RISC OS finds and starts the module during expansion card enumeration,
+exactly as it would from a real card.
+</item>
+<item>
+The <em>guest driver</em>, <code>EtherRPCEm</code>. A DCI4 driver that registers
+itself with the Internet stack under the interface name <code>rpcem</code>. It
+implements the DCI4 SWIs the stack calls, and turns them into the calls
+described in this chapter. It owns no hardware.
+</item>
+<item>
+The <em>host implementation</em>. The emulator's SWI handler, which converts
+between the guest's mbuf chains and flat Ethernet frames, and passes them to
+whichever backend the user has configured.
+</item>
+</list>
+</p>
+
+<p>
+Frames travel in both directions, but only one of those directions is driven by
+the guest alone. Transmission is synchronous: the driver calls, the host takes
+the frame, the call returns. Reception is interrupt-driven, because the guest
+has no way to know a frame has arrived. When the host has a frame it raises the
+expansion card's interrupt request; RISC OS dispatches that to the driver's
+device vector claimant, and the driver then calls the receive reason repeatedly
+until it is told there is nothing left.
+</p>
+<p>
+A host implementation therefore needs to do two things beyond answering the SWI:
+build an expansion card the guest will enumerate, and be able to assert the
+card's interrupt.
+</p>
+</section>
+
+<section title="Technical details">
+<p>
+The whole interface is one SWI, <reference type='swi' name='RPCEmu_Network'/>, numbered
+&hex;56AC4. It is not a registered RISC OS SWI and has no name known to
+<reference type='swi' name='OS_SWINumberFromString'/>; it is issued numerically, and the name used
+in this chapter is a convenience for documentation.
+</p>
+
+<subsection title="The emulator SWI chunk">
+<p>
+&hex;56AC4 falls inside a block of SWI numbers, based at &hex;56AC0, which
+RPCEmu inherits from ArcEm and uses for all of its host interfaces. The
+allocation is:
+</p>
+<p>
+<value-table head-number="Number" head-value="Interface">
+<value number="56AC0">Shutdown</value>
+<value number="56AC1">HostFS</value>
+<value number="56AC2">Debug</value>
+<value number="56AC3">Reserved</value>
+<value number="56AC4">Network (this chapter)</value>
+<value number="56AC5">HostCmd</value>
+<value number="56AD0">Clipboard</value>
+</value-table>
+</p>
+<p>
+An implementation that intends to be a drop-in replacement should decode the
+SWI number in full. The emulator masks the SWI operand to its bottom 20 bits
+(including the X bit) before comparing, and resolves
+<reference type='swi' name='OS_CallASWI'/> and <reference type='swi' name='OS_CallASWIR12'/> to the number held in R10
+or R12 first, so the interface is reachable through those as well as directly.
+</p>
+</subsection>
+
+<subsection title="How results are reported">
+<p>
+This SWI does not use the usual RISC OS error convention. The V flag is not
+touched on any path, and the value returned in R0 is not an error block:
+</p>
+<p>
+<list>
+<item>R0 = 0 on success.</item>
+<item>R0 &ne; 0 on failure.</item>
+</list>
+</p>
+<p>
+On failure the emulator normally returns the value it was passed in R1, having
+first written a null-terminated explanatory string to the buffer R1 points at.
+A caller must not depend on that: some backends return a bare non-zero value
+that is not a pointer to anything. Treat R0 strictly as a boolean, and read the
+message from the buffer that was passed in rather than from the address
+returned.
+</p>
+<p>
+The guest driver does exactly this. It keeps a private 256-byte message buffer
+and a static error block, passes the buffer in R1, and on a non-zero R0
+substitutes the address of its own error block - whose message text is
+that buffer - before returning to RISC OS.
+</p>
+<p>
+There is no mechanism for reporting an error number. The error block the driver
+builds carries a fixed number, so every failure of this interface reaches RISC OS
+as the same error with different text.
+</p>
+</subsection>
+
+<subsection title="Behaviour when networking is disabled">
+<p>
+If the user has configured networking off, the emulator does not handle the SWI
+at all: it returns to the guest with every register unchanged and the V flag as
+it was found. It does not report an unknown SWI.
+</p>
+<p>
+That is worth being careful about in a reimplementation, because "registers
+unchanged" is not the same as "success" for every reason code. R0 still holds
+the reason code on return, so a call that passed 0 (transmit) appears to have
+succeeded, while a call that passed 2, 3 or 4 appears to have failed and to have
+returned a pointer whose value is the reason code. A caller cannot distinguish
+"networking is switched off" from "the frame was sent", and must not try.
+</p>
+</subsection>
+
+<subsection title="The mbuf chain">
+<p>
+RISC OS network drivers exchange data with the stack as chains of mbufs
+allocated by the Mbuf Manager. The emulator reads and writes only the first six
+words of each mbuf, and ignores the rest of the structure:
+</p>
+<p>
+<offset-table head-number="Offset" head-name="Field" head-data-size="Size" head-value="Meaning">
+ <offset number="0" name="m_next" data-size="4">Address of the next mbuf in this chain, or 0 to end it</offset>
+ <offset number="4" name="m_list" data-size="4">Address of the next chain; not read or written by the emulator</offset>
+ <offset number="8" name="m_off" data-size="4">Offset from the start of the mbuf to its data</offset>
+ <offset number="12" name="m_len" data-size="4">Number of bytes of data</offset>
+ <offset number="16" name="m_inioff" data-size="4">Offset the data started at when the mbuf was allocated</offset>
+ <offset number="20" name="m_inilen" data-size="4">Capacity in bytes of the underlying block</offset>
+</offset-table>
+</p>
+<p>
+All six are 32-bit little-endian words. The payload of an mbuf begins at the
+mbuf's own address plus <code>m_off</code>, not at a separately stored pointer.
+</p>
+<p>
+On transmission the chain is followed through <code>m_next</code> and each
+segment's <code>m_len</code> bytes are appended to the frame in turn.
+<code>m_list</code> is not followed: the driver walks that itself and calls once
+per chain.
+</p>
+<p>
+On reception a single mbuf is filled in. The host sets <code>m_off</code> to
+<code>m_inioff</code>, copies the payload to that offset, sets
+<code>m_len</code> to the payload length, and writes all six words back.
+</p>
+<p>
+Both chain and contents are guest-controlled, and a host implementation must
+treat them as hostile. A chain built with a cycle in it will otherwise be
+followed forever, and a segment length taken at face value will overrun a fixed
+host buffer - neither of which the total-length check catches on its own,
+since a cycle of zero-length segments never grows the total. RPCEmu bounds both:
+it abandons a chain after 1024 segments with the message
+<code>RPCEmu: mbuf chain too long</code>, and checks each segment's length
+against the buffer size in its own right as well as against the running total.
+</p>
+</subsection>
+
+<subsection title="The receive header">
+<p>
+The receive reason fills in a 36-byte structure describing the frame, separately
+from the mbuf holding its payload. The driver passes this to the protocol module
+as the head of a two-mbuf chain.
+</p>
+<p>
+<offset-table head-number="Offset" head-name="Field" head-data-size="Size" head-value="Meaning">
+ <offset number="0" name="rx_ptr" data-size="4" state="reserved">Reserved; set to zero</offset>
+ <offset number="4" name="rx_tag" data-size="4" state="reserved">Reserved; set to zero</offset>
+ <offset number="8" name="rx_src_addr" data-size="6">Source MAC address</offset>
+ <offset number="14" data-size="2" state="reserved">Padding; set to zero</offset>
+ <offset number="16" name="rx_dst_addr" data-size="6">Destination MAC address</offset>
+ <offset number="22" data-size="2" state="reserved">Padding; set to zero</offset>
+ <offset number="24" name="rx_frame_type" data-size="4">EtherType, or length for an IEEE 802.3 frame</offset>
+ <offset number="28" name="rx_error_level" data-size="4">Error level; always zero</offset>
+ <offset number="32" name="rx_cksum" data-size="4" state="reserved">Reserved; set to zero</offset>
+</offset-table>
+</p>
+<p>
+The whole structure is cleared before the fields that carry information are
+filled in, so a reimplementation should zero the reserved and padding words
+rather than leave them holding whatever the guest last put there.
+</p>
+<p>
+Note that the frame type is delivered as a 32-bit host-endian word here, having
+been assembled from the two big-endian bytes on the wire. It is the driver, not
+the host, that decides whether a value of 1500 or less means an IEEE length
+rather than an EtherType.
+</p>
+</subsection>
+
+<subsection title="Frame layout on the wire">
+<p>
+The host builds a complete Ethernet II frame from the registers and the mbuf
+chain: six bytes of destination address, six of source address, then the frame
+type as two big-endian bytes, then the concatenated mbuf payloads. No CRC is
+appended, and no padding to the 60-byte Ethernet minimum is applied -
+both belong to the transport the frame is handed to.
+</p>
+<p>
+On reception the same 14-byte header is stripped, its three fields going into
+the receive header structure and the remainder becoming the mbuf payload.
+</p>
+<p>
+A host transport may need its own framing in front of that, and if it does, that
+framing is its own business and is not visible through this interface. RPCEmu's
+IP tunnelling backend, for instance, prepends four zero bytes to everything it
+writes to the tunnel device and skips them again on the way back.
+</p>
+</subsection>
+
+<subsection title="Interrupts and the receive cycle">
+<p>
+Reason 2 exists so that the host knows the driver is present and ready. The
+driver calls it once during initialisation, with a non-zero value, and again
+with zero as it shuts down. RPCEmu stores the value but never dereferences it:
+what matters is only whether it is zero. A host implementation that has nowhere
+to deliver a frame - because the driver has not called reason 2, or has
+called it with zero - should drop arriving frames rather than queue them.
+</p>
+<p>
+The name of the reason reflects an older design in which the value was the
+address of a word in guest memory to be used as an interrupt status register.
+That is no longer how it works, and a reimplementation should not write to the
+address it is given.
+</p>
+<p>
+When a frame arrives, the host raises the expansion card's interrupt request.
+The driver's interrupt handler then:
+</p>
+<p>
+<list>
+<item>calls reason 3 with R2 = 0 to lower the request;</item>
+<item>calls reason 1 repeatedly, taking one frame per call;</item>
+<item>stops when a call returns with the data-available flag clear.</item>
+</list>
+</p>
+<p>
+Because the request is cleared before the frames are collected, a host that
+receives a frame while the guest is still draining the queue must raise the
+request again. RPCEmu queues up to 32 frames of up to 2048 bytes each behind
+the one currently being offered, and promotes the next one as each is taken.
+</p>
+<p>
+Reason 3 also allows the driver to raise the request itself, with a non-zero
+R2. Nothing in the shipped driver does so.
+</p>
+</subsection>
+
+<subsection title="Size limits">
+<p>
+The limits are properties of the host implementation rather than of the
+interface, and a reimplementation may choose its own. RPCEmu's are:
+</p>
+<p>
+<definition-table head-name="Limit" head-value="Value">
+ <definition name="Largest frame">2048 bytes, including the 14-byte Ethernet header</definition>
+ <definition name="Chain length">1024 mbuf segments followed in one chain</definition>
+ <definition name="Receive queue">32 frames held awaiting collection</definition>
+</definition-table>
+</p>
+<p>
+The driver advertises an MTU of 1500 and refuses to change it, so a frame
+larger than 1514 bytes should not arise from the guest in normal use.
+</p>
+</subsection>
+</section>
+
+<section title="SWI calls">
+
+<swi-definition name="RPCEmu_Network"
+                number="56AC4"
+                description="Moves Ethernet frames between the guest and the host"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="0">Reason code:
+  <p>
+  <value-table head-number="Reason" head-value="Action">
+   <value number="0"><reference type='swi' name='RPCEmu_Network' reason='0' use-description='yes'/></value>
+   <value number="1"><reference type='swi' name='RPCEmu_Network' reason='1' use-description='yes'/></value>
+   <value number="2"><reference type='swi' name='RPCEmu_Network' reason='2' use-description='yes'/></value>
+   <value number="3"><reference type='swi' name='RPCEmu_Network' reason='3' use-description='yes'/></value>
+   <value number="4"><reference type='swi' name='RPCEmu_Network' reason='4' use-description='yes'/></value>
+  </value-table>
+  </p>
+ </register-use>
+ <register-use number="1">Address of a buffer to receive an error message, or 0 if the reason code cannot fail</register-use>
+ <register-use number="2-5">Dependent on reason code</register-use>
+</entry>
+<exit>
+ <register-use number="0">0 if the operation succeeded, non-zero if it failed</register-use>
+ <register-use number="1">Dependent on reason code</register-use>
+ <register-use number="2-5" state="preserved" />
+</exit>
+
+<use>
+<p>
+This SWI is the whole of the interface between the <code>EtherRPCEm</code>
+driver running in the emulated machine and the emulator hosting it. The reason
+code in R0 selects the operation.
+</p>
+<p>
+The V flag is not set on failure and the value in R0 is not an error block; see
+the technical details above before writing a caller.
+</p>
+<p>
+An unrecognised reason code writes the message
+<code>Unknown RPCEmu network SWI</code> to the buffer addressed by R1 and
+returns that address in R0. R1 must therefore address a writable buffer of at
+least 27 bytes whenever a reason code that might not be recognised is used.
+</p>
+</use>
+</swi-definition>
+
+<swi-definition name="RPCEmu_Network"
+                number="56AC4"
+                reason="0" reasonname="Transmit"
+                description="Sends an Ethernet frame to the host network"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="0">0 (reason code)</register-use>
+ <register-use number="1">Address of a buffer to receive an error message</register-use>
+ <register-use number="2">Address of the mbuf chain holding the frame payload, or 0 to send a frame with no payload</register-use>
+ <register-use number="3">Address of the 6-byte destination MAC address</register-use>
+ <register-use number="4">Address of the 6-byte source MAC address, or 0 to use the emulated machine's own</register-use>
+ <register-use number="5">Frame type (EtherType), or the payload length for an IEEE 802.3 frame</register-use>
+</entry>
+<exit>
+ <register-use number="0">0 if the frame was sent, non-zero if it was not</register-use>
+ <register-use number="1-5" state="preserved" />
+</exit>
+
+<use>
+<p>
+Builds an Ethernet frame from the addresses and frame type given, followed by
+the concatenated contents of the mbuf chain, and hands it to the host network.
+</p>
+<p>
+The addresses in R3 and R4 are byte-aligned pointers into guest memory, not
+values. R4 may be zero, in which case the host substitutes the MAC address it
+reports through <reference type='swi' name='RPCEmu_Network' reason='4'/>.
+</p>
+<p>
+Only the low 16 bits of R5 reach the wire, most significant byte first.
+</p>
+<p>
+The call is synchronous and the frame has been passed to the host transport by
+the time it returns. Ownership of the mbuf chain is unaffected: the caller still
+owns it, and is responsible for freeing it if the DCI4 client asked the driver
+to take ownership.
+</p>
+<p>
+The call fails if the frame does not fit the host's buffer, or if the mbuf chain
+is longer than the host is prepared to follow. It may also fail for reasons
+belonging to the host transport, such as a write error on a tunnel device.
+</p>
+</use>
+
+<related>
+<reference type='swi' name='RPCEmu_Network' reason='1'/>
+<reference type='swi' name='RPCEmu_Network' reason='4'/>
+</related>
+</swi-definition>
+
+<swi-definition name="RPCEmu_Network"
+                number="56AC4"
+                reason="1" reasonname="Receive"
+                description="Collects a received Ethernet frame from the host"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="0">1 (reason code)</register-use>
+ <register-use number="1">Address of a buffer to receive an error message</register-use>
+ <register-use number="2">Address of an mbuf to hold the payload, or 0 if none is available</register-use>
+ <register-use number="3">Address of a 36-byte block to hold the receive header</register-use>
+</entry>
+<exit>
+ <register-use number="0">0 if the call succeeded, non-zero if it failed</register-use>
+ <register-use number="1">1 if a frame was collected, 0 if none was waiting</register-use>
+ <register-use number="2-5" state="preserved" />
+</exit>
+
+<use>
+<p>
+Takes at most one frame from the host and delivers it to the guest, stripping
+the 14-byte Ethernet header into the block addressed by R3 and copying the
+payload into the mbuf addressed by R2.
+</p>
+<p>
+The flag returned in R1 is the one to test, not R0. R0 reports whether the call
+worked; R1 reports whether it produced a frame. Both an empty queue and a frame
+the host chose to drop return R0 = 0 with R1 = 0.
+</p>
+<p>
+Frames that cannot be delivered are dropped rather than reported. A frame is
+undeliverable if no mbuf was supplied, if it has no payload beyond the
+Ethernet header, or if its payload is larger than the supplied mbuf's
+<code>m_inilen</code>. In each case the frame is consumed, the guest's receive
+header is left untouched, and the next queued frame is promoted.
+</p>
+<p>
+Dropping rather than reporting is deliberate. A host implementation that leaves
+an undeliverable frame in place, and returns an error, will never accept another
+frame from its transport, and the emulated machine's networking stops for the
+rest of the session with no way back short of a reset. The cost of dropping the
+frame is one retransmission.
+</p>
+<p>
+Callers should repeat the call until R1 returns 0, since more than one frame may
+be waiting behind a single interrupt.
+</p>
+</use>
+
+<related>
+<reference type='swi' name='RPCEmu_Network' reason='0'/>
+<reference type='swi' name='RPCEmu_Network' reason='3'/>
+</related>
+</swi-definition>
+
+<swi-definition name="RPCEmu_Network"
+                number="56AC4"
+                reason="2" reasonname="SetIRQStatus"
+                description="Registers the driver as ready to receive frames"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="0">2 (reason code)</register-use>
+ <register-use number="1">0 (this reason code cannot fail)</register-use>
+ <register-use number="2">Non-zero to declare the driver ready to receive frames, or 0 to declare it no longer ready</register-use>
+</entry>
+<exit>
+ <register-use number="0">0</register-use>
+ <register-use number="1-5" state="preserved" />
+</exit>
+
+<use>
+<p>
+Tells the host whether there is a driver able to accept received frames. The
+host should discard arriving frames, rather than queue them, at any time when
+the most recent call passed zero or no call has been made.
+</p>
+<p>
+The value passed in R2 is not interpreted beyond being zero or non-zero. The
+name of the reason code, and the driver's habit of passing an address, are
+inherited from an earlier design in which R2 gave the address of a word in guest
+memory to be used as an interrupt status register. A host implementation must
+not write to it.
+</p>
+<p>
+The driver calls this with a non-zero value at the end of its initialisation,
+once it has claimed its device vector and enabled the expansion card's
+interrupt, and with zero at the start of its finalisation.
+</p>
+<p>
+This state is part of the machine's suspended state. An implementation
+supporting snapshots must save and restore it, or a machine resumed from a
+snapshot will never receive another frame.
+</p>
+</use>
+
+<related>
+<reference type='swi' name='RPCEmu_Network' reason='1'/>
+<reference type='swi' name='RPCEmu_Network' reason='3'/>
+</related>
+</swi-definition>
+
+<swi-definition name="RPCEmu_Network"
+                number="56AC4"
+                reason="3" reasonname="SetIRQRequest"
+                description="Raises or lowers the expansion card's interrupt request"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="0">3 (reason code)</register-use>
+ <register-use number="1">0 (this reason code cannot fail)</register-use>
+ <register-use number="2">Non-zero to raise the interrupt request, or 0 to lower it</register-use>
+</entry>
+<exit>
+ <register-use number="0">0</register-use>
+ <register-use number="1-5" state="preserved" />
+</exit>
+
+<use>
+<p>
+Sets the state of the interrupt request from the network expansion card.
+</p>
+<p>
+The driver calls this with R2 = 0 as the first action of its interrupt handler,
+to acknowledge the interrupt before collecting the frames that caused it. This
+is the guest's only way to clear the request: the card presents its interrupt
+status through the expansion card's IOC space, which is read-only.
+</p>
+<p>
+A host implementation raises the request itself when a frame arrives, and must
+raise it again if further frames arrive after the guest has cleared it but
+before the guest has drained the queue.
+</p>
+</use>
+
+<related>
+<reference type='swi' name='RPCEmu_Network' reason='1'/>
+<reference type='swi' name='RPCEmu_Network' reason='2'/>
+</related>
+</swi-definition>
+
+<swi-definition name="RPCEmu_Network"
+                number="56AC4"
+                reason="4" reasonname="ReadHardwareAddress"
+                description="Reads the emulated machine's MAC address"
+                irqs="undefined"
+                fiqs="undefined"
+                processor-mode="SVC"
+                re-entrant="no">
+<entry>
+ <register-use number="0">4 (reason code)</register-use>
+ <register-use number="1">0 (this reason code cannot fail)</register-use>
+ <register-use number="2">Address of a 6-byte buffer to hold the MAC address</register-use>
+</entry>
+<exit>
+ <register-use number="0">0</register-use>
+ <register-use number="1-5" state="preserved" />
+</exit>
+
+<use>
+<p>
+Writes the MAC address of the emulated Ethernet interface to the buffer
+addressed by R2, most significant byte first, as it would appear on the wire.
+</p>
+<p>
+This is the address the host substitutes when
+<reference type='swi' name='RPCEmu_Network' reason='0'/> is called with R4 = 0,
+and the address a host implementation should filter received frames against if
+it filters at all.
+</p>
+<p>
+The driver calls this once, at the very start of its initialisation, and
+publishes the result through the DCI4 device information block. It does not
+check the result, so a host implementation that cannot supply an address must
+still leave the buffer in a defined state.
+</p>
+</use>
+
+<related>
+<reference type='swi' name='RPCEmu_Network' reason='0'/>
+</related>
+</swi-definition>
+
+</section>
+
+<section title="Examples">
+<p>
+The minimum a host implementation must do to satisfy the driver, expressed as
+the handler for the intercepted SWI. Frames are exchanged with whatever
+transport the implementation provides; the parts that matter here are the
+register contract, the mbuf walk and the treatment of failures.
+</p>
+
+<extended-example type='pseudo'>
+handle_swi(r0, r1, r2, r3, r4, r5):
+
+    case r0 of
+
+    0:  /* Transmit */
+        frame = bytes_from_guest(r3, 6)                 /* destination */
+        if r4 != 0 then
+            frame += bytes_from_guest(r4, 6)            /* source */
+        else
+            frame += our_mac_address
+        frame += big_endian_16(r5)                      /* frame type */
+
+        mbuf = r2
+        hops = 0
+        while mbuf != 0
+            hops = hops + 1
+            if hops > MAX_HOPS then                     /* a cycle: give up */
+                string_to_guest(r1, "mbuf chain too long")
+                return r1
+            m = read_words_from_guest(mbuf, 6)          /* the six-word subset */
+            if m.m_len > MAX_FRAME or
+               length(frame) + m.m_len > MAX_FRAME then
+                string_to_guest(r1, "Packet too large to send")
+                return r1
+            frame += bytes_from_guest(mbuf + m.m_off, m.m_len)
+            mbuf = m.m_next
+
+        transmit(frame)
+        return 0
+
+    1:  /* Receive */
+        if no frame waiting then
+            set_r1(0)
+            return 0
+
+        frame = take_next_waiting_frame()               /* consumed either way */
+
+        if r2 == 0 or length(frame) &lt;= 14 then
+            log("dropped a received frame")             /* never an error */
+            set_r1(0)
+            return 0
+
+        m = read_words_from_guest(r2, 6)
+        payload_len = length(frame) - 14
+        if payload_len > m.m_inilen then
+            log("dropped a received frame: too big for the guest's mbuf")
+            set_r1(0)
+            return 0
+
+        hdr = zeroed(36)
+        hdr.rx_dst_addr  = frame[0..5]
+        hdr.rx_src_addr  = frame[6..11]
+        hdr.rx_frame_type = (frame[12] &lt;&lt; 8) or frame[13]
+        write_to_guest(r3, hdr)                         /* only once deliverable */
+
+        m.m_off = m.m_inioff
+        m.m_len = payload_len
+        write_to_guest(r2 + m.m_off, frame[14..])
+        write_words_to_guest(r2, m)
+
+        set_r1(1)
+        return 0
+
+    2:  /* SetIRQStatus */
+        driver_is_ready = (r2 != 0)                     /* the value, not the address */
+        return 0
+
+    3:  /* SetIRQRequest */
+        if r2 != 0 then
+            raise_podule_interrupt()
+        else
+            lower_podule_interrupt()
+        return 0
+
+    4:  /* ReadHardwareAddress */
+        write_to_guest(r2, our_mac_address)
+        return 0
+
+    otherwise:
+        string_to_guest(r1, "Unknown RPCEmu network SWI")
+        return r1
+</extended-example>
+
+<p>
+A frame arriving from the transport is offered to the guest like this:
+</p>
+
+<extended-example type='pseudo'>
+frame_arrived(frame):
+
+    if not driver_is_ready then
+        return                                          /* nowhere to put it */
+
+    if nothing is currently being offered then
+        offer(frame)
+        raise_podule_interrupt()                        /* the guest is idle */
+    else
+        if queue is full then
+            return                                      /* drop it */
+        enqueue(frame)
+</extended-example>
+
+<p>
+Note that the interrupt is raised only when the guest is not already working
+through frames. The guest lowers the request itself before it starts collecting,
+so a frame arriving during that window is picked up by the loop the guest is
+already running, and one arriving after it has finished raises the request
+afresh when it is promoted out of the queue.
+</p>
+</section>
+
+</chapter>
+
+<!-- MetaData -->
+<meta>
+ <maintainer>
+  <email name="Charles Ferguson" address="gerph@gerph.org" />
+ </maintainer>
+ <disclaimer>
+    <p>
+        This documentation describes the interface between the RPCEmu emulator
+        and the <code>EtherRPCEm</code> network driver which runs inside the
+        emulated machine. RPCEmu is distributed under the GNU General Public
+        License, version 2.
+    </p>
+ </disclaimer>
+
+ <history>
+  <revision number="1" author="Charles Ferguson" date="11 Aug 2026" title="Initial version">
+    <change>Documented the &hex;56AC4 network interface and its five reason codes.</change>
+  </revision>
+ </history>
+
+ <related>
+    <reference type='link' href="https://www.marutan.net/rpcemu/" />
+ </related>
+</meta>
+</riscos-prm>


### PR DESCRIPTION
> **This will conflict with #125.** Both add a job to the same region of
> `.github/workflows/build.yml` — that one an `etherrpcem-riscos` job, this one a
> `docs` job — and both extend `notify`'s `needs`. Whichever merges second needs a
> rebase; the resolution is to keep both jobs and both entries. Nothing else in
> the two PRs overlaps.

# Summary

RPCEmu exposes four interfaces to modules running inside the machine it emulates:
a filing system reaching the host's storage, a network driver with no network
card, the shared clipboard, and a channel letting the host run commands inside
RISC OS. None of them were documented. Their shape could only be recovered by
reading the emulator's C against each guest module's assembler, and the two
halves are in different languages in different repositories.

This documents all four as PRM-in-XML — the format the RISC OS Programmer's
Reference Manuals are written in, and the right one for an interface somebody
else has to implement against, because it fixes the register contract
structurally rather than in prose — and publishes the rendered manual with each
release.

It is written for somebody implementing a host half: another emulator wanting to
run the same guest modules, a test harness standing in for the emulator, or
anyone maintaining RPCEmu who needs to know what the guest is entitled to rely
on.

# Changes

Four commits, each reviewable on its own.

## What the manual says

The overview chapter carries what the four interfaces have in common and, more
usefully, where they differ — because **no two of them agree on a convention**:

- **Reason code register.** HostFS and HostCmd take it in R9, inherited from
  ArcEm so that R0 upwards can carry FileSwitch's own registers untouched. The
  network and clipboard interfaces take it in R0.
- **Failure.** Reported four different ways — a FileCore number in R9, a status
  in R0, a non-zero R0 with a message buffer, or nothing at all. None of them
  uses the RISC OS V-flag convention.
- **Being switched off.** Three fall through to RISC OS as an unknown SWI, which
  a guest module can detect. The network SWI is instead swallowed with every
  register untouched — which reads as success for transmit and as failure for
  every other reason code, and cannot be told apart from either.

**HostFS is a FileSwitch filing system, not a FileCore one**, and the chapter is
explicit about it because the distinction changes what an implementation must
provide. A FileCore filing system presents a block device and FileCore builds the
file structure on it; HostFS has no block access at all, so a host needs
named-file storage rather than a disc image. Its operations *are* the `FSEntry_*`
entry points, passed through almost unaltered. The only trace of FileCore is the
borrowed error numbers.

Also recorded, because each is easy to get wrong and none is obvious from one
side alone:

- HostCmd's backpressure rule, and the two cases that report having accepted
  output they actually discarded — both there to stop the guest stalling on a
  flush nothing will ever read.
- How a command whose client disconnected mid-run is absorbed, rather than having
  its return code attributed to the next command.
- The clipboard's alphabet conversion table, and its length convention: exactly
  what will be delivered, no terminator counted. Adding one for the terminator is
  what put a visible `[00]` at the end of every paste (#81).
- In the network chapter, that the mbuf chain is guest-built and may contain a
  cycle, where the 1024-hop cap and the per-segment length check are both
  load-bearing — a cycle of zero-length segments never grows the running total.

An appendix records `&56AC0` and `&56AC2` as allocated but never dispatched, and
why they should be treated as spent rather than free: guest software built for
ArcEm may still issue them.

## CI

A `docs` job renders the manual through
[`gerph/riscos-prminxml-action@v1`](https://github.com/gerph/riscos-prminxml-action)
with `format: index`, and publishes the HTML as a release asset — somebody
writing a host implementation is not necessarily building the emulator, and
should not need a toolchain to read what an interface does.

The job names one file, `docs/prminxml/index.xml`. That file fixes the chapter
list, their order and the output paths, so adding a chapter is a change to it
alone: neither the workflow nor the Makefile needs to know any filenames.

It is in `release`'s `needs`, so the archive — named from `VERSION`, matching the
binaries beside it — is picked up by the existing `upload/**/*.zip` glob. It is
also in `notify`'s, so a documentation build that breaks is announced.

`docs/prminxml/Makefile` builds the same manual locally, finding chapters by
wildcard and rendering them through pattern rules, so per-chapter builds are
incremental.

# Testing

The workflow was run on a fork before this PR was raised
([gerph/andrewtimmins-rpcemu-extended#1](https://github.com/gerph/andrewtimmins-rpcemu-extended/pull/1),
now closed), and the published artifact was downloaded and inspected rather than
the green tick being taken at face value.

- `docs` passed, ~15s, most of it the tool download.
- The archive is **20 files, 154KB**: seven chapters, the contents page, both
  generated SWI indexes, and the XML sources beside their HTML. Styles are
  inline, so the pages are self-contained.
- All four interfaces appear in the generated SWI index, so a call can be found
  without knowing which interface owns it.
- Checking the artifact caught a real defect the passing job had hidden: the
  first run packaged the whole of `prm-output`, including the indexed build's
  logs, temporary files and index data. Fixed in 1a06cd3 and confirmed against
  the re-run.
- Locally: `make` from clean lints and builds every chapter and the indexed
  manual; incremental rebuild verified; the action's exact command sequence
  simulated to confirm the output lands where the packaging step looks.

No source or emulator behaviour is changed by this PR.
