### PR TITLE
EtherRPCEm: build the guest network driver on the RISC OS build service

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -869,6 +869,76 @@ jobs:
           name: rpcemu-interface-docs
           path: ${{ steps.package.outputs.leafname }}
           if-no-files-found: error
+  # The guest side of the emulated network card. riscos-progs/EtherRPCEm is a
+  # RISC OS relocatable module written in C and ARM assembler, so nothing on a
+  # GitHub runner can compile it; it is built by build.riscos.online, which runs
+  # the Acorn toolchain (cc, objasm, cmunge, link) under emulation and hands back
+  # the linked module. riscos-progs/EtherRPCEm/.robuild.yaml says what to run
+  # there, and MakefileROBS is the makefile it drives.
+  #
+  # This does not gate the release, and that is deliberate rather than an
+  # oversight. What the emulator ships is the assembled module committed as
+  # netroms/EtherRPCEm,ffa - src/network.c builds a podule ROM around that file
+  # at run time - so a rebuild here is a check that the sources still compile,
+  # not the thing being packaged. Gating a tag on a third-party build service
+  # being reachable would block releases for a reason that has nothing to do
+  # with what is in them. It does report to Slack through 'notify', so a driver
+  # that stops compiling is still noticed.
+  #
+  # The two binaries also will not match byte for byte, which is expected: the
+  # committed one was linked against the stubsg C library variant and this links
+  # stubsGS. README.md in that directory has the detail.
+  #
+  # The concurrency group is the build service itself, which is a single shared
+  # instance. Without it, two pushes in quick succession queue against each
+  # other inside the service rather than here, where the wait is visible.
+  etherrpcem-riscos:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: riscos-build-server
+    steps:
+      - uses: actions/checkout@v7
+
+      # The action wraps the riscos-build-online client: it fetches the client,
+      # zips the directory up with its .robuild.yaml, submits it, and leaves the
+      # returned archive at 'output'. An absolute path is given for that,
+      # because 'directory' is applied with a cd and everything relative is
+      # resolved inside it.
+      - name: Build EtherRPCEm on the RISC OS Build Service
+        uses: gerph/riscos-build-service-action@v1
+        with:
+          directory: riscos-progs/EtherRPCEm
+          architecture: aarch32
+          timeout: 120
+          colour: 'no'
+          output: /tmp/built
+
+      - name: Unpack the built module
+        run: |
+          # The service returns a RISC OS Zip of whatever .robuild.yaml named as
+          # its artifact, filetyped &a91. A build can succeed and still return
+          # nothing if that path is wrong, so the archive is checked rather than
+          # only the exit code.
+          if [ ! -s /tmp/built,a91 ]; then
+            echo "::error::the build service returned no archive"
+            exit 1
+          fi
+          mkdir -p riscos-build-output
+          unzip -o -q /tmp/built,a91 -d riscos-build-output
+          # The module's filetype travels in the archive's Acorn extra field,
+          # which unzip drops, so restore it as the ,ffa suffix the host side
+          # uses. That is also the name it takes in netroms/, so anybody using
+          # this artifact to update the committed module need not guess.
+          mv riscos-build-output/EtherRPCEm 'riscos-build-output/EtherRPCEm,ffa'
+          ls -l riscos-build-output
+
+      - name: Upload the built module
+        uses: actions/upload-artifact@v7
+        with:
+          name: etherrpcem-riscos
+          path: riscos-build-output/EtherRPCEm,ffa
+          if-no-files-found: error
 
   release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
@@ -918,7 +988,7 @@ jobs:
   # unreachable would be reporting on itself rather than on the emulator.
   notify:
     if: always() && github.event_name == 'push'
-    needs: [version-matches-tag, linux-amd64, linux-arm64, windows-amd64, macos-universal, sanitisers, docs, release]
+    needs: [version-matches-tag, linux-amd64, linux-arm64, windows-amd64, macos-universal, sanitisers, docs, etherrpcem-riscos, release]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -905,8 +905,15 @@ jobs:
       # returned archive at 'output'. An absolute path is given for that,
       # because 'directory' is applied with a cd and everything relative is
       # resolved inside it.
+      #
+      # v1.1 or later, not v1: v1 downloaded the client into the workspace root
+      # and then invoked it as ./riscos-build-online after changing into
+      # 'directory', so it could only ever find it when 'directory' was the
+      # default. That is what took this job - and main with it - red the first
+      # time it was merged. v1.1 keeps the client in RUNNER_TEMP and calls it by
+      # absolute path.
       - name: Build EtherRPCEm on the RISC OS Build Service
-        uses: gerph/riscos-build-service-action@v1
+        uses: gerph/riscos-build-service-action@v1.1
         with:
           directory: riscos-progs/EtherRPCEm
           architecture: aarch32

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,17 @@
 # the HTML is built by CI and published as a release asset.
 /prm-output/
 
+# Output from building EtherRPCEm with the RISC OS makefile system (riscos-amu,
+# or amu on the build service). h.ModHdr comes from cmhg.ModHdr and c.AutoSense
+# from the tokenised BASIC in AutoSense.EtherRPCEm, so neither is source.
+/riscos-progs/EtherRPCEm/o32/
+/riscos-progs/EtherRPCEm/oz32/
+/riscos-progs/EtherRPCEm/aof32/
+/riscos-progs/EtherRPCEm/rm32/
+/riscos-progs/EtherRPCEm/Artifacts/
+/riscos-progs/EtherRPCEm/c/AutoSense
+/riscos-progs/EtherRPCEm/h/ModHdr
+
 # Editor swap files / patch leftovers
 *.swp
 *~

--- a/riscos-progs/EtherRPCEm/.robuild.yaml
+++ b/riscos-progs/EtherRPCEm/.robuild.yaml
@@ -1,0 +1,41 @@
+%YAML 1.0
+---
+
+# RISC OS build file to execute on https://build.riscos.online/
+#
+# Builds the EtherRPCEm DCI4 driver from MakefileROBS and returns the module
+# in an Artifacts directory.
+#
+# Note that this deliberately does not alias AMU to HostAMU. The build has to
+# run bin2c, which is a RISC OS absolute committed in this directory, and the
+# host toolchain cannot execute it.
+
+jobs:
+  build:
+    # Env defines system variables which will be used within the environment.
+    env:
+      "Sys$Environment": ROBuild
+      "BUILD32": 1
+
+    # Commands which should be executed to perform the build.
+    # The build will terminate if any command returns a non-0 return code or an error.
+    script:
+      - echo
+      - echo *** Build EtherRPCEm ***
+      - amu -f MakefileROBS BUILD32=1
+
+      - echo
+      - echo *** Collect the module ***
+      # link -rmf types its output as Module (&FFA) already, and Copy keeps
+      # that, so the returned archive carries the right filetype in its Acorn
+      # extra field. `unzip -l` does not show it; `zipinfo -v` does.
+      - CDir Artifacts
+      - Copy rm32.EtherRPCEm Artifacts.EtherRPCEm ~C~V
+
+      # Done!
+      - echo
+      - echo *** SUCCESS ***
+
+    # Outputs from the build are defined in artifacts
+    artifacts:
+      - path: Artifacts

--- a/riscos-progs/EtherRPCEm/MakefileROBS,fe1
+++ b/riscos-progs/EtherRPCEm/MakefileROBS,fe1
@@ -1,0 +1,81 @@
+#!/usr/bin/env riscos-amu -f
+# Makefile for EtherRPCEm
+#
+# This is the makefile used by the RISC OS Build Service (and by riscos-amu
+# in the build environment). The older `Makefile` builds the same sources
+# under the desktop with !Make inside an emulated machine; see README.md.
+#
+
+#
+# Program specific options:
+#
+COMPONENT  = EtherRPCEm
+
+# Specifies additional targets for startup
+INITTARGET = inittarget
+
+# Specifies additional targets for clean
+CLEANTARGET = cleantarget
+
+# Nothing is exported: the module's SWIs are private to the emulator.
+EXPORTS    =
+
+# Comma-separated list of paths to use for includes, such as:
+#	C:LibName.
+INCLUDES   =
+
+# Space separated list of libraries to link against, eg C:LibName.o.libLibName
+# (${CLIB} is implicit, unless NOCLIB = yes)
+LIBS       =
+
+# Space separated list of defines to set, eg -DDEBUG
+CDEFINES   =
+
+# How to turn a binary file into a C array.
+#
+# bin2c is a RISC OS absolute committed in this directory, so this only runs
+# where RISC OS does - on the build service, or in an emulated machine. A host
+# build with riscos-amu must override it with something that produces the same
+# array, eg:
+#
+#   riscos-amu -f MakefileROBS,fe1 BUILD32=1 BIN2C="path/to/host/bin2c"
+#
+BIN2C     ?= Run @.bin2c
+
+# Objects to build, using the format o.<name> (will be varied for build type)
+OBJS       = o.errors \
+             o.intveneer \
+             o.ModHdr \
+             o.Module
+
+# By default we don't build Fortify in.
+# To include fortify in your module, #include "fortify.h" at the top of your C files
+# and call Fortify_EnterScope in your initialisation, and Fortify_LeaveScope in the
+# finalisation.
+FORTIFY    = no
+
+include CModule
+
+# Additional dependencies
+#
+# c.AutoSense holds the AutoSense file as a C array; it is generated from the
+# tokenised BASIC in AutoSense.EtherRPCEm, so that the BASIC remains the only
+# copy that has to be edited.
+$(OZDIR).Module: h.ModHdr c.AutoSense
+
+h.ModHdr: cmhg.ModHdr
+	${CMHG} ${BUILD_CMHGFLAGS} -d $@ cmhg.ModHdr
+
+c.AutoSense: AutoSense.EtherRPCEm
+	${BIN2C} -t "const unsigned char" -n autosense_file AutoSense.EtherRPCEm $@
+
+cleantarget:
+	${DESTROY} h.ModHdr
+	${DESTROY} c.AutoSense
+# This clean target removes the generated module header and AutoSense array.
+inittarget:
+	${MKDIR} h
+# This init target ensures that the header directory is created
+
+#---------------------------------------------------------------------------
+# Dynamic dependencies:

--- a/riscos-progs/EtherRPCEm/README.md
+++ b/riscos-progs/EtherRPCEm/README.md
@@ -16,14 +16,71 @@ builds a podule ROM around it at run time (`src/network.c`).
 
 ## Building it
 
-There is no RISC OS C toolchain on the host, so this is built **inside the
-emulator** with the Acorn DDE (`cc`, `objasm`, `cmhg`, `link`), exactly as
-`SharedClipboard` is. `build.sh` cannot rebuild it.
+There is no RISC OS C toolchain on the host, so the Acorn tools (`cc`, `objasm`,
+`cmunge`, `link`) have to run somewhere that RISC OS does. `build.sh` cannot
+rebuild this. There are two routes, and the first is the one to reach for.
+
+### Through the RISC OS Build Service (preferred)
+
+`build.riscos.online` runs the toolchain under emulation and hands back the
+linked module. It is driven by two files here: `.robuild.yaml`, which lists the
+commands to run on RISC OS, and `MakefileROBS,fe1`, the makefile those commands
+drive. This is also what CI does, as the `etherrpcem-riscos` job in
+`.github/workflows/build.yml`, which drives the service through
+[`gerph/riscos-build-service-action`](https://github.com/gerph/riscos-build-service-action)
+rather than calling the client itself.
+
+To trigger a build by hand you need the `riscos-build-online` client. Either use
+the copy in the RISC OS build environment, or fetch it:
+
+```sh
+curl -s -L -o riscos-build-online \
+    https://github.com/gerph/robuild-client/releases/download/v0.07/riscos-build-online
+chmod +x riscos-build-online
+```
+
+Then, from this directory:
+
+```sh
+# The archive must be rooted here, because .robuild.yaml and the makefile
+# expect to be at the top of it. bin2c_src is the C source of the bin2c tool,
+# kept for reference and not needed to build.
+zip -q9r /tmp/etherrpcem-src.zip . -x 'bin2c_src/*'
+
+riscos-build-online -i /tmp/etherrpcem-src.zip -a off -t 120 -o /tmp/built
+```
+
+The build log comes back on stdout. On success the module is returned as a RISC
+OS Zip archive, `/tmp/built,a91`:
+
+```sh
+unzip -o /tmp/built,a91 -d /tmp/etherrpcem
+cp /tmp/etherrpcem/EtherRPCEm ../../netroms/EtherRPCEm,ffa
+```
+
+`riscos-build-online` exits non-zero if the build fails, and prints `RC: 0` on
+a build that ran to completion. Note that a successful run can still return an
+empty archive if `.robuild.yaml`'s `artifacts.path` is wrong, so check what came
+back rather than trusting the exit code alone.
+
+`MakefileROBS,fe1` also works with `riscos-amu` in the RISC OS build
+environment, with one exception: `c.AutoSense` is produced by `bin2c`, which is
+a RISC OS absolute and cannot run on a Linux host. Override it to build there:
+
+```sh
+riscos-amu -f MakefileROBS,fe1 BUILD32=1 BIN2C="path/to/host/bin2c"
+```
+
+### Inside an emulated machine
+
+The original route, using the Acorn DDE in a running guest, exactly as
+`SharedClipboard` is built. Still works, and is the only way to build against
+the DDE actually installed in a machine.
 
 1. Copy this directory into a machine's HostFS as `$.EtherBld`. It is already in
    RISC OS layout (`c.Module`, `s.intveneer`, `h.*`, `cmhg.ModHdr`, `o.`), so no
    renaming is needed. `bin2c,ff8`, `AutoSense/` and `MkEther,feb` must come too;
-   `bin2c_src/`, `Makefile` and the `.md` files are not needed in the guest.
+   `bin2c_src/`, `MakefileROBS,fe1` and the `.md` files are not needed in the guest.
 2. With the machine running, from the host:
    `./build/bin/rpcemu-run --socket <datadir>/hostcmd.sock -- "Obey HostFS::HostFS.$.EtherBld.MkEther"`
 3. Every tool's output lands in `$.EtherBld.log.*`, never through the command
@@ -37,6 +94,13 @@ minus `-throwback` and `-depend`: those want SrcEdit and a `!Depend` file and bu
 nothing in a headless build. The `Makefile` is kept for building under the desktop
 with `!Make`, but note it names `C:o.stubsg`, which the DDE in use here does not
 have; `MkEther` links `C:o.stubs`. See below.
+
+### Which files are generated
+
+Neither `c.AutoSense` nor `h.ModHdr` is source, and neither is committed.
+`c.AutoSense` is the tokenised BASIC in `AutoSense.EtherRPCEm` turned into a C
+array by `bin2c`, so that the BASIC stays the only copy anybody has to edit;
+`h.ModHdr` comes from `cmhg.ModHdr`. Both makefiles build them.
 
 ## The stubs the module is linked against
 
@@ -79,6 +143,18 @@ Whatever is behind that predates this work.
   it fired for any non-zero flags instead of the undefined ones it meant to
   catch. It only guarded a `printf`, which is not safe from a SWI handler.
   Both are gone; the behaviour they wrapped (accept and ignore) is unchanged.
+- `c.Module`, `find_protocol`: was `static inline`. `inline` is C99, and Norcroft
+  rejects it outright rather than ignoring it, which was the one thing stopping
+  the sources compiling as C89. Dropped, not worked around: it is a small
+  single-caller function and the compiler is free to inline it anyway.
+- `cmhg.ModHdr`: the licence header used `#` for its comments. CMunge is run
+  with `-px`, which puts the file through the C preprocessor first, and every
+  one of those lines then read as an unknown preprocessor directive. Now `;`,
+  which is CMHG's own comment character, so the text is unchanged.
+
+Note that the `//` comments throughout are also not C89, but Norcroft accepts
+them, and converting them would touch nearly every line for no gain and make
+future comparison against upstream RPCEmu harder. They have been left alone.
 
 ## Known gaps
 

--- a/riscos-progs/EtherRPCEm/c/Module
+++ b/riscos-progs/EtherRPCEm/c/Module
@@ -427,7 +427,7 @@ finalise(int fatal, int podule, void *pw)
  * @param frame_type Frame type of received frame (or length if IEEE)
  * @return Pointer to Claim information, or NULL if not claimed by a Protocol Module
  */
-static inline const ClaimBuf *
+static const ClaimBuf *
 find_protocol(int frame_type)
 {
 	const ClaimBuf *c;

--- a/riscos-progs/EtherRPCEm/cmhg/ModHdr
+++ b/riscos-progs/EtherRPCEm/cmhg/ModHdr
@@ -1,21 +1,21 @@
-# cmhg.ModHdr
+; cmhg.ModHdr
 
-# free software; you can redistribute it and/or modify it 
-# under the terms of version 2 of the GNU General Public License as 
-# published by the Free Software Foundation;
-# 
-# This program is distributed in the hope that it will be useful, but WITHOUT 
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for 
-# more details.
-# 
-# You should have received a copy of the GNU General Public License along with
-# this program; if not, write to the Free Software Foundation, Inc., 59 
-# Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-# 
-# The full GNU General Public License is included in this distribution in the
-# file called LICENSE.
-# 
+; free software; you can redistribute it and/or modify it
+; under the terms of version 2 of the GNU General Public License as
+; published by the Free Software Foundation;
+;
+; This program is distributed in the hope that it will be useful, but WITHOUT
+; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+; more details.
+;
+; You should have received a copy of the GNU General Public License along with
+; this program; if not, write to the Free Software Foundation, Inc., 59
+; Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+;
+; The full GNU General Public License is included in this distribution in the
+; file called LICENSE.
+;
 
 help-string:  EtherRPCEm 1.05 © Alex Waugh and John Ballance/Castle
 


### PR DESCRIPTION
# Summary

Re-raises #125, which was merged as 03994a3 and reverted by 4b27d9b because it
took main red. The cause is understood and fixed; see **Why the first attempt
failed** below.

`riscos-progs/EtherRPCEm` is the RISC OS half of the emulated network card: a
DCI4 driver in C and ARM assembler, assembled into the podule ROM the emulator
builds at run time. It could only be built by hand inside a running machine,
driving the Acorn DDE through an Obey file over the command channel. Nothing
checked that it still compiled, and nothing could: no host toolchain builds a
RISC OS relocatable module.

This builds it on [build.riscos.online](https://build.riscos.online/), which runs
the Acorn tools (`cc`, `objasm`, `cmunge`, `link`) under emulation, and adds a CI
job that does the same on every push.

# Why the first attempt failed

Not the build, and not the module. `gerph/riscos-build-service-action@v1`
downloaded the `riscos-build-online` client into the workspace root and then
invoked it as `./riscos-build-online` *after* changing into `directory:`. With
the module in `riscos-progs/EtherRPCEm` rather than at the top of the tree, the
client was never where the action looked:

```
./riscos-build-online: No such file or directory
Process completed with exit code 127
```

It exited before contacting the build service at all. `@v1.1` keeps the client in
`RUNNER_TEMP` and calls it by absolute path, which is what this needs. The bump is
its own commit so the change is visible on its own.

# Changes

**Two C89 fixes**, the only things stopping the sources compiling:

- `c/Module`: `find_protocol` was `static inline`. `inline` is C99 and Norcroft
  rejects it rather than ignoring it. Dropped — one caller, and the compiler may
  inline it regardless.
- `cmhg/ModHdr`: the licence header used `#` comments. CMunge runs with `-px`,
  putting the file through the C preprocessor first, so all thirteen lines read as
  unknown preprocessor directives. Now `;`, CMHG's own comment character; the text
  is unchanged.

The `//` comments elsewhere are also not C89, but Norcroft accepts them, and
converting them would touch nearly every line while making comparison against
upstream RPCEmu harder. Left alone, and said so in the README.

**Build files.** `MakefileROBS,fe1` comes from `riscos-project create --type
cmodule` and drives the standard RISC OS makefile system; `.robuild.yaml` says
what to run on the service. Both generated files — `h.ModHdr` from the CMHG, and
`c.AutoSense` from the tokenised BASIC — are built rather than committed, and
gitignored.

`.robuild.yaml` deliberately does **not** alias `AMU` to `HostAMU`: `c.AutoSense`
is produced by `bin2c`, a RISC OS absolute committed in the directory, which the
host toolchain cannot execute. The makefile exposes `BIN2C` so a host build with
`riscos-amu` can override it.

The existing in-guest DDE route (`Makefile`, `MkEther,feb`) is untouched and still
documented — it remains the only way to build against the DDE actually installed
in a machine.

**CI.** A new `etherrpcem-riscos` job. It does **not** gate the release: what the
emulator ships is the assembled module committed as `netroms/EtherRPCEm,ffa`, so a
rebuild here checks that the sources compile rather than producing what is
packaged, and a tag should not be blocked by a third-party service being
unreachable. It is in `notify`'s watch list, so a driver that stops compiling is
still announced. Its `concurrency` group is the build service itself, which is a
single shared instance.

# Testing

Both the job and its input were verified before raising this.

- **The job**, on a fork with a pull request open, since the workflow's push
  trigger is `branches: [main, master]` and a branch push alone runs nothing.
  `etherrpcem-riscos` passed, and the log shows it reaching the service rather
  than passing vacuously:

  ```
  eval "$RUNNER_TEMP/riscos-build-online" -i /tmp/source-archive.zip …
    EtherRPCEm: Module built {RAM}
    *** SUCCESS ***
  Result file: filetype=&a91, 5874 bytes
  RC: 0
  -rw-r--r-- 1 runner runner 12156 …  EtherRPCEm,ffa
  ```

- **The module**, submitted to the build service by hand from this exact tree:
  `RC: 0`, 12156 bytes, matching what the job produced and what it builds to
  locally with `riscos-amu`.
- Built locally with `riscos-amu -f MakefileROBS,fe1 BUILD32=1`: clean, no
  warnings from `cc` or CMunge.

Rebased onto current main, so this carries the resolution of the conflict with
the merged documentation manual (#127): both the `docs` and `etherrpcem-riscos`
jobs are kept, `notify` watches both, and the two `.gitignore` blocks sit side by
side.

# Notes

The rebuilt module will not match the committed `netroms/EtherRPCEm,ffa` byte for
byte, and that is expected: the committed one was linked against the `stubsg` C
library variant and this links `stubsGS`. The directory's README has the detail.
This PR does not update the committed binary.

There is no runtime test. The driver's initialisation calls SWI `&56AC4`, which
only RPCEmu provides, so a module loaded anywhere else cannot get past it. The job
proves the driver compiles and links, and nothing more.

Unrelated, and not addressed here: `test_hostcmd` fails on any checkout whose path
is long enough to push its AF_UNIX socket past `sun_path` — which a fork's longer
repository name is enough to do. `tests/test_debugcmd.c` already guards against
exactly this and `tests/test_hostcmd.c` does not. Happy to fix that separately.
