### PR TITLE
Stop test_hostcmd failing where the checkout path is long

### DIFF
--- a/tests/test_hostcmd.c
+++ b/tests/test_hostcmd.c
@@ -41,6 +41,7 @@
 #include "socket-compat.h"
 #ifndef _WIN32
 #include <sys/un.h>
+#include <unistd.h>
 #endif
 
 #include "rpcemu.h"
@@ -280,6 +281,30 @@ main(int argc, char **argv)
 	snprintf(spec, sizeof(spec), "15597");
 #else
 	snprintf(spec, sizeof(spec), "%s/test_hostcmd.sock", dir);
+
+	/* AF_UNIX paths are limited by the kernel to the size of sun_path: 104
+	   bytes on macOS, 108 on Linux. hostcmd_init() refuses a path longer
+	   than that rather than binding a truncated one - see hostcmd_listen_unix()
+	   - so the socket is never created and the connect below fails, reporting
+	   this as a broken socket when it is really a path that was too long.
+
+	   The build directory is deep enough for that to be reachable. A checkout
+	   on a GitHub runner is ".../work/<repo>/<repo>/...", spending the
+	   repository name twice: this repository's own path comes to 90 bytes,
+	   13 short of the macOS limit, and a fork whose name is 14 characters
+	   longer overruns it by 14.
+
+	   Fall back to a short path rather than fail a test that is not about
+	   paths. test_debugcmd does the same, for the same reason. */
+	{
+		struct sockaddr_un sa;
+
+		if (strlen(spec) >= sizeof(sa.sun_path)) {
+			snprintf(spec, sizeof(spec),
+			    "/tmp/rpcemu-test-hostcmd-%ld.sock", (long) getpid());
+		}
+	}
+
 	remove(spec);
 #endif
 


### PR DESCRIPTION
# Summary

`test_hostcmd` fails on any checkout whose path is long enough to push its
AF_UNIX socket past `sun_path`. It reports

```
FAIL: a client can connect to the command socket
```

which reads as a broken socket, but the socket was never created: the path was
too long and `hostcmd_init()` declined to bind it.

The production code is not at fault. `hostcmd_listen_unix()` checks the length
and refuses rather than binding a truncated path, which is the right thing to do:

```c
if (strlen(path) >= sizeof(addr.sun_path)) {
    rpclog("HostCmd: socket path too long: %s\n", path);
    return -1;
}
```

The test simply never anticipated being refused.

# Why it shows up now

`sun_path` holds 104 bytes on macOS and 108 on Linux, and the test builds its
path from the CMake binary directory, which is deep. A checkout on a GitHub
runner is `.../work/<repo>/<repo>/...`, so the repository name is spent **twice**:

| checkout | socket path | length | outcome |
|---|---|---|---|
| this repository | `/Users/runner/work/rpcemu-extended/rpcemu-extended/build-mac-arm64/tests/test_hostcmd.sock` | 90 | binds, 13 bytes spare |
| a fork named 14 characters longer | same with `andrewtimmins-rpcemu-extended` | 118 | **refused, over by 14** |

So this repository passes today with 13 bytes of headroom — two characters of
build-directory name away from breaking on its own — and any fork with a longer
name fails. It is not macOS-specific either: the same test fails under
`sanitisers` on Linux, where the limit is 108.

# Changes

One file. When the constructed path will not fit, fall back to a short path in
`/tmp` rather than fail a test that is not about paths.

`tests/test_debugcmd.c` already does exactly this, with the same reasoning and
almost the same comment; this brings `test_hostcmd` into line with its neighbour.

Measured against the check in `hostcmd_listen_unix()`: this repository's path is
unchanged at 90 bytes, and a fork's drops from 118 to 34. The short case is not
touched at all — the fallback only triggers where the test would otherwise fail.

# Testing

Verified on a fork whose name is long enough to reproduce the bug, which is the
only environment where the change makes any difference:

- Before: `test_hostcmd` failed on both `macos-arm64` and `sanitisers`.
- After: `12/39 Test #12: test_hostcmd ..... Passed`, `100% tests passed out of
  39`, and `sanitisers` green.

Locally, the length arithmetic was checked against a copy of the server's own
test for both checkout paths, before and after.

Independent of #130; touches no emulator code.
