### PR TITLE
Pin mcp below 2.0, and add setup scripts the CI can exercise

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,12 +313,67 @@ jobs:
   #
   # Not in notify's needs: it reports which job failed, and would say build-gate
   # where it currently names the check that actually broke.
+  # Does what the README tells a user to run still work, and does the server
+  # start afterwards. Its own job because it needs nothing the builds produce,
+  # and because a Python packaging change turning a platform build red would
+  # name the wrong culprit.
+  #
+  # fail-fast is off because the three legs answer different questions - bash
+  # against PowerShell, three Pythons, two venv layouts. Letting them all report
+  # separates "a package changed under us" from "one script broke".
+  mcp-server:
+    needs: release-preflight
+    if: always() && needs.release-preflight.result != 'failure'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v7
+
+      # The runner's own Python, not a pinned one: what a user has is what this
+      # should be testing.
+      - name: Which Python
+        shell: bash
+        run: python3 --version || python --version
+
+      # Windows drives the PowerShell script, because that is what a Windows
+      # user runs: a python.org install and PowerShell, not the MSYS2 shell the
+      # Windows *build* job uses.
+      - name: Set up and start (Linux and macOS)
+        if: runner.os != 'Windows'
+        run: bash tests/mcp_smoke.sh
+
+      - name: Set up and start (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $env:RPCEMU_MCP_VENV = Join-Path $env:RUNNER_TEMP 'mcp-smoke-venv'
+
+          & .\tools\mcp\setup-mcp-env.ps1
+          if ($LASTEXITCODE -ne 0) { throw "the setup script failed" }
+
+          $py = Join-Path $env:RPCEMU_MCP_VENV 'Scripts\python.exe'
+          if (-not (Test-Path $py)) { throw "no interpreter at $py" }
+
+          # The same probe the shell script runs, from a file rather than -c:
+          # quoting Python through YAML and PowerShell both is a way to break
+          # this without touching it.
+          & $py tests/mcp_probe.py tools/mcp/rpcemu_mcp.py
+          if ($LASTEXITCODE -ne 0) { throw "the server did not load" }
+
+  # The MCP server is in here because the releases ship it (build.sh and the
+  # other two stage tools/mcp into every package): a broken one is a broken
+  # release, and this is the gate that stops one going out.
   build-gate:
-    needs: [sanitisers, interface-docs]
-    if: always() && needs.sanitisers.result == 'success' && needs['interface-docs'].result == 'success'
+    needs: [sanitisers, interface-docs, mcp-server]
+    if: always() && needs.sanitisers.result == 'success' && needs['interface-docs'].result == 'success' && needs['mcp-server'].result == 'success'
     runs-on: ubuntu-slim
     steps:
-      - run: echo "The sanitisers and the interface documentation are clear."
+      - run: echo "The sanitisers, the interface documentation and the MCP server are clear."
 
   # The two Linux builds are written out as two jobs rather than folded into one
   # matrix. They are nearly the same job and a matrix does remove the
@@ -761,7 +816,6 @@ jobs:
           # a new platform.
           bash tests/cli_smoke.sh "$exe"
 
-
       # The ROM the boot test needs, fetched with the emulator's own downloader -
       # which on Windows means WinHTTP, and this is the first time that has run on
       # ARM64. Cached so RISC OS Open are not asked for the same file every push;
@@ -1168,6 +1222,7 @@ jobs:
       - release-preflight
       - sanitisers
       - interface-docs
+      - mcp-server
       - linux-amd64
       - linux-arm64
       - windows-amd64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,8 @@ endif()
 # MCP server (Python): drive a RISC OS machine from an MCP client, including
 # the debugger control socket. See tools/mcp/README.md.
 install(DIRECTORY tools/mcp/ DESTINATION share/rpcemu/mcp
-        PATTERN "__pycache__" EXCLUDE)
+        PATTERN "__pycache__" EXCLUDE
+        PATTERN "setup-mcp-env.ps1" EXCLUDE)
 install(FILES README.md COPYING COMPILE.md DESTINATION share/doc/rpcemu)
 install(DIRECTORY docs/ DESTINATION share/doc/rpcemu)
 # The .desktop launcher's Exec must match the actual binary (rpcemu-recompiler

--- a/build-macos.sh
+++ b/build-macos.sh
@@ -627,6 +627,7 @@ if [ "$DO_FUSE" = true ]; then
 		mkdir -p "$RESD/tools/mcp"
 		cp -f tools/mcp/rpcemu_mcp.py tools/mcp/requirements.txt \
 		      tools/mcp/README.md tools/mcp/mcp.json.example \
+		      tools/mcp/setup-mcp-env.sh \
 		      "$RESD/tools/mcp/" 2>/dev/null || true
 	fi
 

--- a/build-windows.sh
+++ b/build-windows.sh
@@ -222,6 +222,7 @@ if [ -d tools/mcp ]; then
 	mkdir -p "$WIN_RELEASE/tools/mcp"
 	cp -f tools/mcp/rpcemu_mcp.py tools/mcp/requirements.txt \
 	      tools/mcp/README.md tools/mcp/mcp.json.example \
+	      tools/mcp/setup-mcp-env.ps1 \
 	      "$WIN_RELEASE/tools/mcp/" 2>/dev/null || true
 fi
 [ -d docs ] && cp -a docs "$WIN_RELEASE/" 2>/dev/null || true

--- a/build.sh
+++ b/build.sh
@@ -272,6 +272,7 @@ stage_linux_release() {
 		mkdir -p "$LINUX_RELEASE/tools/mcp"
 		cp -f tools/mcp/rpcemu_mcp.py tools/mcp/requirements.txt \
 		      tools/mcp/README.md tools/mcp/mcp.json.example \
+		      tools/mcp/setup-mcp-env.sh \
 		      "$LINUX_RELEASE/tools/mcp/" 2>/dev/null || true
 	fi
 

--- a/tests/mcp_probe.py
+++ b/tests/mcp_probe.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Load the MCP server and report how many tools it registered.
+
+Separate from mcp_smoke.sh so Windows can run the same check: PowerShell drives
+it directly, rather than the shell script it has no shell for.
+
+Installing the dependencies and importing them are different questions. A
+version range can resolve to a release that installs perfectly well and has
+moved the module the server asks for - which is what mcp 2.0 did with FastMCP.
+Registering the tools is the part that needs them to be the right ones, because
+the decorator runs at import: a FastMCP that has moved fails here rather than at
+the first call, by which time it is a client reporting "cannot connect".
+
+    python mcp_probe.py path/to/rpcemu_mcp.py
+"""
+import importlib.util
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} path/to/rpcemu_mcp.py", file=sys.stderr)
+        return 2
+
+    path = sys.argv[1]
+    spec = importlib.util.spec_from_file_location("rpcemu_mcp", path)
+    if spec is None or spec.loader is None:
+        print(f"cannot load {path}", file=sys.stderr)
+        return 1
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    tools = [name for name in dir(module) if name.startswith("riscos_")]
+    print(f"{len(tools)} tools registered")
+
+    if not tools:
+        print("the server imported but registered no tools", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/mcp_smoke.sh
+++ b/tests/mcp_smoke.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# The MCP server sets up and starts.
+#
+# Two questions, and they are not the same one. The setup script installs the
+# dependencies; loading the server proves they are the ones it imports. A
+# version range can resolve to a release that installs perfectly and has moved
+# the module the server asks for, which is a failure a client reports as "cannot
+# connect" with nothing about why.
+#
+# Runs what the README tells a user to run, rather than something like it, so a
+# setup script that stops working is a failing build rather than a bug report.
+#
+# Linux and macOS. The Windows equivalent drives setup-mcp-env.ps1, which needs
+# PowerShell and a different path to the interpreter.
+
+set -e
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV="${RPCEMU_MCP_VENV:-${RUNNER_TEMP:-/tmp}/mcp-smoke-venv}"
+
+rm -rf "$VENV"
+
+echo "== setup script =="
+RPCEMU_MCP_VENV="$VENV" "$REPO/tools/mcp/setup-mcp-env.sh"
+
+PY="$VENV/bin/python"
+if [ ! -x "$PY" ]; then
+	echo "FAIL: the setup script did not leave an interpreter at $PY"
+	exit 1
+fi
+
+echo
+echo "== server loads =="
+"$PY" "$REPO/tests/mcp_probe.py" "$REPO/tools/mcp/rpcemu_mcp.py"
+
+echo
+echo "== config it prints is usable =="
+RPCEMU_MCP_VENV="$VENV" "$REPO/tools/mcp/setup-mcp-env.sh" 2>/dev/null |
+    sed -n '/^{/,/^}/p' > "$VENV/printed.json"
+
+"$PY" - "$VENV/printed.json" <<'EOF'
+import json
+import os
+import sys
+
+with open(sys.argv[1]) as f:
+    doc = json.load(f)          # invalid JSON is a failure in itself
+
+server = doc["mcpServers"]["rpcemu"]
+
+# The two the script knows for certain, as opposed to the data directory and
+# machine name it suggests - those depend on the machine it is printed on and
+# are not the script's to be sure about.
+for label, path in (("command", server["command"]), ("server", server["args"][0])):
+    if not os.path.exists(path):
+        sys.exit(f"FAIL: printed {label} does not exist: {path}")
+
+print("printed config is valid JSON and its paths exist")
+EOF
+
+rm -rf "$VENV"
+echo
+echo "MCP server smoke test passed"

--- a/tools/mcp/README.md
+++ b/tools/mcp/README.md
@@ -100,9 +100,64 @@ the CPU registers — pass `physical=True` for raw physical addresses. Pausing t
 CPU (directly, or via a breakpoint/watchpoint hit) freezes the whole machine
 (guest OS, HostCmd, screen) until you resume.
 
+## Installing
+
+The server is Python, and it needs two packages that are not in the standard
+library. Where RPCEmu put it depends on how it was installed:
+
+| Installed from | Server directory |
+| --- | --- |
+| a source or `.tar.gz` tree | `tools/mcp/` |
+| the `.deb` | `/usr/share/rpcemu/mcp/` |
+
+Install into a virtual environment rather than the system Python. Not
+fastidiousness: most current distributions mark the system Python as externally
+managed and refuse a plain `pip install` outright (PEP 668), some ship no `pip`
+at all, and the `.deb`'s copy is root-owned and not somewhere to be writing
+anyway.
+
+There is a script for it. Linux and macOS:
+
+```bash
+cd tools/mcp                       # or /usr/share/rpcemu/mcp from the .deb
+./setup-mcp-env.sh
+```
+
+Windows, in PowerShell:
+
+```powershell
+cd tools\mcp
+powershell -ExecutionPolicy Bypass -File setup-mcp-env.ps1
+```
+
+(Windows refuses unsigned scripts by default, hence the argument; the script is
+not signed.)
+
+Either one makes a virtual environment in `~/.rpcemu-mcp`
+(`%USERPROFILE%\.rpcemu-mcp` on Windows), installs into it, and checks the
+server can actually import what it needs rather than assuming it did. Set
+`RPCEMU_MCP_VENV` first to put the environment somewhere else.
+
+It then prints an `.mcp.json` block to paste into your project, with the
+interpreter and the server filled in — the two that have to be right and are
+easiest to get wrong. The rest of the block says which machine to talk to: the
+script suggests your data directory and the first machine it finds there, which
+is worth a glance rather than trust.
+
+By hand, if you would rather:
+
+```bash
+python3 -m venv ~/.rpcemu-mcp
+~/.rpcemu-mcp/bin/pip install -r requirements.txt
+```
+
+**Whichever way, the server runs under that venv's interpreter** —
+`~/.rpcemu-mcp/bin/python`, or `%USERPROFILE%\.rpcemu-mcp\Scripts\python.exe`
+on Windows — and not under a bare `python3`, which will not have the
+dependencies in it.
+
 ## Requirements
 
-- The MCP Python SDK: `pip install -r requirements.txt` (installs `mcp[cli]`).
 - A running RPCEmu machine with **HostCmd enabled** (on by default) and, for the
   screen/input tools, the **VNC server enabled** (`vnc_enabled=1` in the
   machine's `.cfg`). A `--headless` machine works out of the box: headless
@@ -125,27 +180,32 @@ CPU (directly, or via a breakpoint/watchpoint hit) freezes the whole machine
 
 ## Wiring into Claude Code
 
-Copy `mcp.json.example` to `.mcp.json` in your project (or merge it into an
-existing one) and fill in the paths for your machine. Claude Code discovers
-project-scoped servers from `.mcp.json`. Alternatively:
+Claude Code discovers project-scoped servers from `.mcp.json`. The setup script
+prints one ready to paste; `mcp.json.example` is the same thing to fill in by
+hand, and is what to look at if you would rather not run the script or are
+merging into an existing file.
+
+Note `"command"` either way: it is the venv's interpreter, with an absolute
+path, because the client does not run this from your shell and has no reason to
+find the environment on its own.
+
+Alternatively, without a config file at all:
 
 ```bash
-claude mcp add rpcemu -- python3 /path/to/tools/mcp/rpcemu_mcp.py
+claude mcp add rpcemu -- ~/.rpcemu-mcp/bin/python /path/to/rpcemu_mcp.py
 # then set the RPCEMU_* env vars in your shell or the .mcp.json "env" block
 ```
 
-The script path depends on how RPCEmu was installed: `tools/mcp/rpcemu_mcp.py` in
-a source or `.tar.gz` release tree, or `/usr/share/rpcemu/mcp/rpcemu_mcp.py` from
-the `.deb`.
-
-Run standalone (stdio transport) for testing:
+Run standalone (stdio transport) for testing. It waits on stdin and says
+nothing, which is what a working server looks like; Ctrl-D ends it. A missing
+dependency or an unreachable socket shows here rather than inside the client:
 
 ```bash
 RPCEMU_HOSTCMD_SOCKET=/path/hostcmd.sock \
 RPCEMU_HOSTFS_DIR=/path/machines/Default/hostfs \
 RPCEMU_VNC_PORT=5900 \
 RPCEMU_VNC_PASSWORD=control-password \
-python3 rpcemu_mcp.py
+~/.rpcemu-mcp/bin/python /path/to/rpcemu_mcp.py
 ```
 
 ## Limitations & tips

--- a/tools/mcp/mcp.json.example
+++ b/tools/mcp/mcp.json.example
@@ -1,14 +1,15 @@
 {
   "//": "Copy to .mcp.json in your project and edit the paths for your machine.",
+  "//command": "The venv's interpreter, absolute, as setup-mcp-env.sh or .ps1 prints it. The client does not run this from your shell, so a bare python3 will not have the dependencies. Windows: C:\\Users\\YOU\\.rpcemu-mcp\\Scripts\\python.exe, with the backslashes doubled as JSON requires.",
+  "//script-path": "Absolute, and it depends on the install: <tree>/tools/mcp/rpcemu_mcp.py from a source or .tar.gz tree, /usr/share/rpcemu/mcp/rpcemu_mcp.py from the .deb.",
   "//data-dir": "Under a portable build, the data dir is the release folder; under an installed build it is ~/RPCEmu.",
-  "//script-path": "From a source/release tree use tools/mcp/rpcemu_mcp.py; from a .deb install use /usr/share/rpcemu/mcp/rpcemu_mcp.py.",
   "mcpServers": {
     "rpcemu": {
-      "command": "python3",
-      "args": ["tools/mcp/rpcemu_mcp.py"],
+      "command": "/ABSOLUTE/PATH/TO/HOME/.rpcemu-mcp/bin/python",
+      "args": ["/ABSOLUTE/PATH/TO/rpcemu_mcp.py"],
       "env": {
         "RPCEMU_HOSTCMD_SOCKET": "/ABSOLUTE/PATH/TO/DATA-DIR/hostcmd.sock",
-        "RPCEMU_HOSTFS_DIR": "/ABSOLUTE/PATH/TO/DATA-DIR/machines/Default/hostfs",
+        "RPCEMU_HOSTFS_DIR": "/ABSOLUTE/PATH/TO/DATA-DIR/machines/MACHINE-NAME-HERE/hostfs",
         "RPCEMU_VNC_HOST": "127.0.0.1",
         "RPCEMU_VNC_PORT": "5900",
         "RPCEMU_VNC_PASSWORD": "",

--- a/tools/mcp/requirements.txt
+++ b/tools/mcp/requirements.txt
@@ -1,2 +1,3 @@
-mcp[cli]>=1.0
+# Below 2.0: it moved FastMCP out of mcp.server.fastmcp, where we import it from.
+mcp[cli]>=1.0,<2
 pycryptodome>=3.20

--- a/tools/mcp/setup-mcp-env.ps1
+++ b/tools/mcp/setup-mcp-env.ps1
@@ -1,0 +1,130 @@
+# RPCEmu (Extended Edition) - MCP server dependency setup (Windows)
+#
+# Run this ONCE to install what the MCP server needs, then point your MCP client
+# at the interpreter it prints. See README.md for what the server does.
+#
+# The PowerShell counterpart of setup-mcp-env.sh, which needs bash and so is for
+# Linux and macOS. Same job, two differences that Windows forces: the venv keeps
+# its interpreter in Scripts rather than bin, and the launcher is "py" or
+# "python" rather than "python3".
+#
+#   powershell -ExecutionPolicy Bypass -File setup-mcp-env.ps1
+#
+# The -ExecutionPolicy argument is not a warning sign: Windows refuses unsigned
+# scripts by default, and this one is not signed.
+
+$ErrorActionPreference = 'Stop'
+
+$venv = if ($env:RPCEMU_MCP_VENV) { $env:RPCEMU_MCP_VENV }
+        else { Join-Path $env:USERPROFILE '.rpcemu-mcp' }
+
+$here   = Split-Path -Parent $MyInvocation.MyCommand.Path
+$reqs   = Join-Path $here 'requirements.txt'
+$server = Join-Path $here 'rpcemu_mcp.py'
+
+if (-not (Test-Path $reqs) -or -not (Test-Path $server)) {
+    Write-Host "Cannot find the server next to this script ($here)."
+    Write-Host "Run it from where RPCEmu installed it, which on Windows is the"
+    Write-Host "tools\mcp folder of the release you unpacked."
+    exit 1
+}
+
+# The Windows launcher is "py"; a python.org install also puts "python" on the
+# PATH, and the Store's stub is "python" too. Prefer py, which picks the newest.
+$launcher = $null
+foreach ($c in @('py', 'python')) {
+    if (Get-Command $c -ErrorAction SilentlyContinue) { $launcher = $c; break }
+}
+if (-not $launcher) {
+    Write-Host "Python is not installed, or is not on PATH."
+    Write-Host ""
+    Write-Host "Install it from https://www.python.org/downloads/windows/ and tick"
+    Write-Host '"Add python.exe to PATH" in the installer, or: winget install Python.Python.3'
+    exit 1
+}
+
+Write-Host "Creating a virtual environment in $venv"
+& $launcher -m venv $venv
+if ($LASTEXITCODE -ne 0) { exit 1 }
+
+$py  = Join-Path $venv 'Scripts\python.exe'
+$pip = Join-Path $venv 'Scripts\pip.exe'
+
+Write-Host "Installing the server's dependencies"
+& $pip install --quiet --upgrade pip
+& $pip install --quiet -r $reqs
+if ($LASTEXITCODE -ne 0) { exit 1 }
+
+# Proves the install rather than assuming it: an MCP client reports a server
+# that will not start as a connection failure, with the real reason buried. The
+# exact symbols, not just the packages - mcp 2.0 kept the package name and moved
+# FastMCP out of it, which "import mcp" alone would not have noticed.
+& $py -c "from mcp.server.fastmcp import FastMCP; from Crypto.Cipher import DES" 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Host ""
+    Write-Host "The dependencies installed but will not import. Try again with the"
+    Write-Host "output shown:"
+    Write-Host "  $pip install -r $reqs"
+    exit 1
+}
+
+Write-Host ""
+Write-Host "Done. The MCP server is ready."
+Write-Host ""
+Write-Host "  interpreter : $py"
+Write-Host "  server      : $server"
+Write-Host ""
+Write-Host 'Point your MCP client at both - the interpreter matters, because a bare'
+Write-Host '"python" is a different Python without these dependencies in it.'
+Write-Host ""
+Write-Host "  claude mcp add rpcemu -- `"$py`" `"$server`""
+# Where the data directory is, for the block printed below. RPCEmu records it
+# only when the user has chosen one, and the file is absent for anyone who kept
+# the default - so: the recorded answer if there is one, %USERPROFILE%\RPCEmu
+# otherwise. Both are a suggestion to check rather than something verified here.
+$datadir = Join-Path $env:USERPROFILE 'RPCEmu'
+$store = Join-Path $env:APPDATA 'RPCEmu\datadir'
+if (Test-Path $store) {
+    $found = (Get-Content $store -Raw).Trim()
+    if ($found) { $datadir = $found }
+}
+
+# A machine that is actually there, rather than one the reader must invent.
+$machine = 'MACHINE-NAME-HERE'
+$configs = Join-Path $datadir 'configs'
+if (Test-Path $configs) {
+    $first = Get-ChildItem -Path $configs -Filter *.cfg -ErrorAction SilentlyContinue |
+             Select-Object -First 1
+    if ($first) { $machine = $first.BaseName }
+}
+
+# JSON wants its backslashes doubled, and these paths are full of them.
+$j  = { param($p) $p -replace '\\', '\\' }
+$jPy      = & $j $py
+$jServer  = & $j $server
+$jMachine = & $j (Join-Path $datadir "machines\$machine")
+
+Write-Host ""
+Write-Host "Or put this in .mcp.json in your project, which says the same thing. The"
+Write-Host "interpreter and the server are known to be right; the paths below them say"
+Write-Host "which machine to talk to and are worth a look - see the `"Configuration`""
+Write-Host "table in $here\README.md."
+Write-Host ""
+Write-Host @"
+{
+  "mcpServers": {
+    "rpcemu": {
+      "command": "$jPy",
+      "args": ["$jServer"],
+      "env": {
+        "RPCEMU_HOSTCMD_SOCKET": "$jMachine\\hostcmd.sock",
+        "RPCEMU_HOSTFS_DIR": "$jMachine\\hostfs",
+        "RPCEMU_VNC_HOST": "127.0.0.1",
+        "RPCEMU_VNC_PORT": "5900",
+        "RPCEMU_VNC_PASSWORD": "",
+        "RPCEMU_DEBUG_SOCKET": "$jMachine\\rpcemu-debug.sock"
+      }
+    }
+  }
+}
+"@

--- a/tools/mcp/setup-mcp-env.sh
+++ b/tools/mcp/setup-mcp-env.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# RPCEmu (Extended Edition) - MCP server dependency setup
+#
+# Run this ONCE to install what the MCP server needs, then point your MCP client
+# at the interpreter it prints. See README.md for what the server does.
+#
+# It installs into a virtual environment rather than the system Python, which is
+# not fastidiousness: most current distributions mark the system Python as
+# externally managed and refuse a plain "pip install" outright (PEP 668), some
+# ship no pip at all, and a .deb install's copy of the server is root-owned and
+# not somewhere to be writing anyway. A venv answers all three, and brings its
+# own pip even when the system has none.
+
+set -e
+
+VENV="${RPCEMU_MCP_VENV:-$HOME/.rpcemu-mcp}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REQS="$HERE/requirements.txt"
+SERVER="$HERE/rpcemu_mcp.py"
+
+if [ ! -f "$REQS" ] || [ ! -f "$SERVER" ]; then
+	echo "Cannot find the server next to this script ($HERE)."
+	echo "Run it from where RPCEmu installed it:"
+	echo "  a source or .tar.gz tree   tools/mcp/setup-mcp-env.sh"
+	echo "  the .deb                   /usr/share/rpcemu/mcp/setup-mcp-env.sh"
+	exit 1
+fi
+
+if ! command -v python3 &>/dev/null; then
+	echo "python3 is not installed."
+	echo ""
+	echo "Debian/Ubuntu:  sudo apt install python3 python3-venv"
+	echo "Fedora:         sudo dnf install python3"
+	echo "macOS:          brew install python3"
+	exit 1
+fi
+
+# Debian splits the venv module into its own package, and the error you get
+# without it names ensurepip rather than the package to install.
+if ! python3 -c "import venv" &>/dev/null; then
+	echo "The python3 venv module is missing."
+	echo ""
+	echo "Debian/Ubuntu:  sudo apt install python3-venv"
+	echo "Fedora:         sudo dnf install python3-libs"
+	exit 1
+fi
+
+echo "Creating a virtual environment in $VENV"
+python3 -m venv "$VENV"
+
+echo "Installing the server's dependencies"
+"$VENV/bin/pip" install --quiet --upgrade pip
+"$VENV/bin/pip" install --quiet -r "$REQS"
+
+# Proves the install rather than assuming it: an MCP client reports a server
+# that will not start as a connection failure, with the real reason buried.
+if ! "$VENV/bin/python" -c "
+from mcp.server.fastmcp import FastMCP
+from Crypto.Cipher import DES
+" 2>/dev/null; then
+	echo ""
+	echo "The dependencies installed but will not import. Try again with the"
+	echo "output shown:"
+	echo "  $VENV/bin/pip install -r $REQS"
+	exit 1
+fi
+
+# Where the data directory is, for the block printed below.
+#
+# RPCEmu records it only when the user has chosen one; the file is absent for
+# anyone who kept the default, which is most people. So: the recorded answer if
+# there is one, ~/RPCEmu otherwise, which is what an installed build uses. Both
+# are a suggestion to be checked rather than something this has verified.
+if [ "$(uname -s)" = "Darwin" ]; then
+	STORE="$HOME/Library/Preferences/RPCEmu/datadir"
+else
+	STORE="${XDG_CONFIG_HOME:-$HOME/.config}/rpcemu/datadir"
+fi
+
+DATADIR="$HOME/RPCEmu"
+if [ -r "$STORE" ]; then
+	FOUND="$(tr -d '\r\n' < "$STORE")"
+	if [ -n "$FOUND" ]; then
+		DATADIR="$FOUND"
+	fi
+fi
+
+# A machine that is actually there, so the block names one rather than leaving
+# the reader to invent it. Which machine they want is their business.
+MACHINE="MACHINE-NAME-HERE"
+for cfg in "$DATADIR"/configs/*.cfg; do
+	[ -e "$cfg" ] || break
+	MACHINE="$(basename "$cfg" .cfg)"
+	break
+done
+
+cat <<EOF
+
+Done. The MCP server is ready.
+
+  interpreter : $VENV/bin/python
+  server      : $SERVER
+
+Point your MCP client at both - the interpreter matters, because a bare
+"python3" is a different Python without these dependencies in it.
+
+  claude mcp add rpcemu -- "$VENV/bin/python" "$SERVER"
+
+Or put this in .mcp.json in your project, which says the same thing. The
+interpreter and the server are known to be right; the paths below them say
+which machine to talk to and are worth a look - see the "Configuration" table
+in $HERE/README.md.
+
+{
+  "mcpServers": {
+    "rpcemu": {
+      "command": "$VENV/bin/python",
+      "args": ["$SERVER"],
+      "env": {
+        "RPCEMU_HOSTCMD_SOCKET": "$DATADIR/machines/$MACHINE/hostcmd.sock",
+        "RPCEMU_HOSTFS_DIR": "$DATADIR/machines/$MACHINE/hostfs",
+        "RPCEMU_VNC_HOST": "127.0.0.1",
+        "RPCEMU_VNC_PORT": "5900",
+        "RPCEMU_VNC_PASSWORD": "",
+        "RPCEMU_DEBUG_SOCKET": "$DATADIR/machines/$MACHINE/rpcemu-debug.sock"
+      }
+    }
+  }
+}
+EOF


### PR DESCRIPTION
The MCP server's dependency range let in a release that breaks it, and the setup
instructions assumed more than they said. This fixes the first, makes the second
easier to follow, and puts both under CI so the next drift is a failing build
rather than a bug report.

## The one real break

`requirements.txt` asked for `mcp[cli]>=1.0`. That resolves today to 2.0, which
moved `FastMCP` out of `mcp.server.fastmcp` — where `rpcemu_mcp.py` imports it
from. So a fresh install produced a server that failed on its first import,
which an MCP client reports as a connection failure with nothing about why.

Now pinned below 2.0, with a one-line note saying what the bound is holding back
so it is revisited rather than inherited.

## Setup, made easier rather than made possible

The server worked before this if you knew how to install Python dependencies on
your platform. The README simply said `pip install -r requirements.txt`, which
is not the whole story on most current distributions: they mark the system
Python externally managed and refuse it (PEP 668), some have no `pip` at all,
and from a `.deb` install it would be writing into a root-owned directory. A
virtual environment answers all three, and now the documentation says so.

## The scripts

**One per platform** — `setup-mcp-env.sh` for Linux and macOS,
`setup-mcp-env.ps1` for Windows. Each makes a virtual environment, installs into
it, and then *proves the server can import what it needs* rather than assuming
the install implies it. That last part is the one that matters: mcp 2.0
installed perfectly well.

Each prints an `.mcp.json` block ready to paste, with the interpreter and the
server path filled in — the two that have to be right and are easiest to get
wrong. It suggests the data directory and a machine it can find, and says those
are worth checking rather than presenting them as known.

**The README's Installing section** is rewritten around them, says where the
server lives for each of the three ways RPCEmu is installed, and uses the venv's
interpreter in every example — a bare `python3` is a different Python, without
these dependencies in it.

### Shipping them

`build.sh`, `build-windows.sh` and `build-macos.sh` each copy an explicit file
list into the release, so a new file in `tools/mcp/` is not in a package until
it is added there. Each now carries the script its users can run; the `.deb`
excludes the PowerShell one it has no use for.

Nothing was lost before this — the scripts are new — but it is worth knowing CI
would not have caught the omission: it tests a git checkout, where every file
exists regardless of what the packages carry.

## Keeping it working

A new `mcp-server` job, matrix over `ubuntu-latest` / `macos-14` /
`windows-latest`. It runs the setup script a user is told to run — the `.ps1` on
Windows, under `pwsh` rather than the MSYS2 shell the Windows *build* job uses,
because a python.org install and PowerShell is what a Windows user actually has.
Then it loads the server under the environment that script built.

Its own job rather than a step inside each platform build: it needs nothing the
builds produce, and a Python packaging change turning `windows-amd64` red would
name the wrong culprit.

**It gates `build-gate`.** The packages ship the MCP server, so a broken one is
a broken release. It is also in `notify`'s needs, per the rule that file already
states — a job that can fail and is not listed there is one whose failures
nobody is told about.

`fail-fast: false`, because the three legs answer different questions: bash
against PowerShell, three Pythons, two venv layouts. Letting them all report
separates "a package changed under us" from "one script broke".

## Testing

Both scripts were run, not just read.

- **Linux** — `tests/mcp_smoke.sh` passes; forcing `mcp>=2` makes it fail with
  exit 1, so the check is real rather than decorative.
- **Windows** — the `.ps1` and the CI step were run against a real Windows host
  with Python 3.14.7: venv created, both imports resolved, 30 tools registered.
  The printed config parses as JSON with its backslashes correctly escaped.
- **macOS** — untested locally. It runs the same shell script as Linux, but
  Apple's Python and bash 3.2 are exactly where a bash-ism would surface, so the
  first CI run is the real check.

One piece of expected noise: `pydantic_settings` warns about an unresolved
forward reference on `mcp`'s own `lifespan` field. Three lines constructing
`FastMCP` reproduce it with none of this project involved — upstream, not ours,
and not a failure.
