### PR TITLE
Manager and machine editor: seven interface fixes

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -775,9 +775,10 @@ either the `,xxx` suffix on your side, or set the type from the filer menu.
 **macOS says it cannot open the application.** Right-click and choose Open the
 first time; the build is not notarised.
 
-**Something else.** *Help ▸ Create Support Bundle* collects the log, the
+**Something else.** *Help ▸ Create Support Bundle* collects the logs, the
 machine's settings and optionally a screenshot into one zip — that is the thing
-to attach to a report. *Help ▸ Report an Issue* opens the tracker; the template
+to attach to a report. Passwords and your home directory are taken out of
+everything in it. *Help ▸ Report an Issue* opens the tracker; the template
 asks for your operating system, which build and which RISC OS version, because
 those three answer most of what we would otherwise have to ask.
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -419,7 +419,7 @@ Both keep a list of what you have used recently.
 | **VNC Server...** | Serve this machine's screen over the network |
 | **Serial... / Parallel... / USB...** | The ports, described below |
 | **Mute Sound** | Silence without changing the machine |
-| **Full-screen Mode** | Also **Alt+Enter**, which is how you get back |
+| **Fullscreen** | Also **Alt+Enter**, which is how you get back |
 | **Pixel Perfect** | Scale only in whole multiples, so pixels stay square |
 | **Fit to Window** | Scale the picture to whatever size you drag the window |
 | **Mouse Follows Host Pointer** | On by default. Turn it off for games (see below) |
@@ -460,7 +460,7 @@ keeping the proportions right and putting black bars where they do not match.
 stay sharp squares. Better for games and anything pixel-art; costs you black
 borders when the window is not an exact multiple.
 
-**Full-screen Mode**, or **Alt+Enter**. The same key leaves.
+**Fullscreen**, or **Alt+Enter**. The same key leaves.
 
 **Follow the host display size** (in the machine's Options) tells the guest what
 your monitor can do, so RISC OS offers sensible modes rather than 1980s ones.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -73,7 +73,7 @@ applications, games, fonts and libraries from the same repositories a real
 RISC OS machine uses.
 
 **To leave full-screen**, press **Alt+Enter**. The same key gets you into it
-from **Settings ▸ Full-screen Mode**.
+from **Settings ▸ Fullscreen**.
 
 ## If something is not right
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -83,7 +83,7 @@ endif()
 set(RPCEMU_TOOLBAR_SVGS
     screenshot floppy cdrom reset mute unmute
     fullscreen settings start pause step inspector
-    power stop
+    analyser power stop
     running starting stopped)
 set(_svg_header "${CMAKE_CURRENT_BINARY_DIR}/toolbar_icons_svg.h")
 file(WRITE "${_svg_header}"

--- a/src/gui/icons/analyser.svg
+++ b/src/gui/icons/analyser.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#00A100" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-square-activity-icon lucide-square-activity"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M17 12h-2l-2 5-2-10-2 5H7"/></svg>

--- a/src/gui/machine_edit_dialog.cpp
+++ b/src/gui/machine_edit_dialog.cpp
@@ -124,6 +124,26 @@ wxString FormatModifiedTime(const wxString &path)
 	return modified.Format("Modified: %d %b %Y, %H:%M");
 }
 
+/*
+ * Re-fit a wxChoice to the strings it now holds.
+ *
+ * A choice keeps the width it was measured at, so one whose list is replaced
+ * with longer strings after the dialogue was laid out shows them cut off. The
+ * best size is right for whatever is in it; this asks for it again and re-runs
+ * the layout that used the old one.
+ */
+void RefitChoice(wxChoice *choice)
+{
+	wxWindow *const parent = choice->GetParent();
+
+	choice->InvalidateBestSize();
+	choice->SetMinSize(choice->GetBestSize());
+
+	if (parent != nullptr && parent->GetSizer() != nullptr) {
+		parent->GetSizer()->Layout();
+	}
+}
+
 } // namespace
 
 enum {
@@ -1102,6 +1122,8 @@ void MachineEditDialog::RebuildCoProcessorRamChoices(unsigned keep_kb)
 		copro_ram_choice_->Enable(true);
 		copro_ram_label_->Enable(true);
 	}
+
+	RefitChoice(copro_ram_choice_);
 }
 
 /*

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -1825,7 +1825,9 @@ void MainFrame::OnSupportBundle(wxCommandEvent &)
 
 	const SupportBundleResult result = SupportBundleWrite(dlg.GetPath(), machine,
 	    wxString::FromUTF8(rpcemu_get_machine_datadir()),
-	    wxString::FromUTF8(rpcemu_get_log_path()), screenshot);
+	    wxString::FromUTF8(rpcemu_get_log_path()), screenshot,
+	    wxFileName(wxString::FromUTF8(rpcemu_get_datadir()),
+	        "rpclog.txt").GetFullPath());
 
 	if (!screenshot.empty()) {
 		wxRemoveFile(screenshot);

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -1881,6 +1881,8 @@ void MainFrame::OnVnc(wxCommandEvent &)
 		return;
 	}
 	VncDialog dlg(this, vnc_server_, wxString::FromUTF8(config_copy_.vnc_password), &config_copy_);
+
+	PrepareMachineWindow(&dlg, "VNC Server");
 	if (dlg.ShowModal() == wxID_OK) {
 		config.vnc_enabled = config_copy_.vnc_enabled;
 		config.vnc_port = config_copy_.vnc_port;
@@ -1916,12 +1918,15 @@ void MainFrame::OnUsb(wxCommandEvent &)
 {
 	UsbDialog dialog(this);
 
+	PrepareMachineWindow(&dialog, "USB Devices");
 	dialog.ShowModal();
 }
 
 void MainFrame::OnSerial(wxCommandEvent &)
 {
 	SerialDialog dlg(this);
+
+	PrepareMachineWindow(&dlg, "Serial Port");
 	dlg.ShowModal();
 }
 

--- a/src/gui/main_frame_menus.cpp
+++ b/src/gui/main_frame_menus.cpp
@@ -188,7 +188,7 @@ void MainFrame::BuildMenus()
 	settings_menu->AppendSeparator();
 
 	mute_menu_item_ = settings_menu->AppendCheckItem(ID_MENU_MUTE, "Mute Sound");
-	fullscreen_menu_item_ = settings_menu->AppendCheckItem(ID_MENU_FULLSCREEN, "Full-screen Mode");
+	fullscreen_menu_item_ = settings_menu->AppendCheckItem(ID_MENU_FULLSCREEN, "Fullscreen");
 	integer_scaling_menu_item_ =
 	    settings_menu->AppendCheckItem(ID_MENU_INTEGER_SCALING, "Pixel Perfect");
 	fit_to_window_menu_item_ =

--- a/src/gui/main_frame_menus.cpp
+++ b/src/gui/main_frame_menus.cpp
@@ -391,6 +391,8 @@ void MainFrame::BuildToolBar()
 	                   "Single step");
 	tool_bar_->AddTool(ID_MENU_MACHINE_INSPECTOR, wxEmptyString, ToolbarIconInspector(icon_size),
 	                   "Open Machine Inspector");
+	tool_bar_->AddTool(ID_MENU_NETWORK_ANALYSER, wxEmptyString, ToolbarIconAnalyser(icon_size),
+	                   "Open Network Analyser");
 	tool_bar_->Realize();
 
 	tool_bar_->Bind(wxEVT_TOOL, &MainFrame::OnScreenshot, this, ID_MENU_SCREENSHOT);
@@ -404,6 +406,7 @@ void MainFrame::BuildToolBar()
 	tool_bar_->Bind(wxEVT_TOOL, &MainFrame::OnFullscreen, this, ID_MENU_FULLSCREEN);
 	tool_bar_->Bind(wxEVT_TOOL, &MainFrame::OnMachine, this, ID_MENU_MACHINE);
 	tool_bar_->Bind(wxEVT_TOOL, &MainFrame::OnMachineInspector, this, ID_MENU_MACHINE_INSPECTOR);
+	tool_bar_->Bind(wxEVT_TOOL, &MainFrame::OnNetworkAnalyser, this, ID_MENU_NETWORK_ANALYSER);
 }
 
 void MainFrame::BuildStatusBar()

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -797,6 +797,8 @@ void ManagerFrame::BuildToolBar()
 	    "Single step");
 	tool_bar_->AddTool(ID_MENU_MACHINE_INSPECTOR, wxEmptyString, ToolbarIconInspector(icon_size),
 	    "Open Machine Inspector");
+	tool_bar_->AddTool(ID_MENU_NETWORK_ANALYSER, wxEmptyString, ToolbarIconAnalyser(icon_size),
+	    "Open Network Analyser");
 	tool_bar_->Realize();
 
 	tool_bar_->Bind(wxEVT_TOOL, &ManagerFrame::OnStart, this, ID_START);
@@ -2401,6 +2403,7 @@ void ManagerFrame::UpdateMachineMenuState()
 			ID_MENU_MUTE, ID_MENU_FULLSCREEN,
 			ID_MENU_MACHINE, ID_MENU_DEBUG_RUN, ID_MENU_DEBUG_PAUSE,
 			ID_MENU_DEBUG_STEP, ID_MENU_MACHINE_INSPECTOR,
+			ID_MENU_NETWORK_ANALYSER,
 		};
 
 		for (int id : forwarded_tools) {

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -2658,7 +2658,9 @@ void ManagerFrame::CreateSupportBundle()
 
 	const wxString dir = MachineDirFor(machine);
 	const SupportBundleResult result = SupportBundleWrite(dlg.GetPath(), machine,
-	    dir, wxFileName(dir, "rpclog.txt").GetFullPath(), screenshot);
+	    dir, wxFileName(dir, "rpclog.txt").GetFullPath(), screenshot,
+	    wxFileName(wxString::FromUTF8(rpcemu_get_datadir()),
+	        "rpclog.txt").GetFullPath());
 
 	if (!screenshot.empty()) {
 		wxRemoveFile(screenshot);

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -783,7 +783,7 @@ void ManagerFrame::BuildToolBar()
 	tool_bar_->AddTool(ID_MENU_MUTE, wxEmptyString,
 	    ToolbarIconMute(false, icon_size), "Toggle sound mute");
 	tool_bar_->AddTool(ID_MENU_FULLSCREEN, wxEmptyString, ToolbarIconFullscreen(icon_size),
-	    "Toggle full-screen mode");
+	    "Toggle full-screen mode (Alt+Enter to leave)");
 	tool_bar_->AddTool(ID_MENU_MACHINE, wxEmptyString, ToolbarIconConfigure(icon_size),
 	    "Edit machine settings");
 

--- a/src/gui/network_analyser_window.cpp
+++ b/src/gui/network_analyser_window.cpp
@@ -253,6 +253,7 @@ NetworkAnalyserWindow::NetworkAnalyserWindow(wxWindow *parent)
 	 * a memcpy per frame for no reason.
 	 */
 	capture_->SetValue(true);
+	capture_->SetLabel("Capturing");
 	netcap_ring_enable(1);
 	timer_.Start(400);
 }
@@ -273,7 +274,10 @@ NetworkAnalyserWindow::ShowAndRaise()
 void
 NetworkAnalyserWindow::OnCapture(wxCommandEvent &)
 {
-	netcap_ring_enable(capture_->GetValue() ? 1 : 0);
+	const bool on = capture_->GetValue();
+
+	netcap_ring_enable(on ? 1 : 0);
+	capture_->SetLabel(on ? "Capturing" : "Capture");
 }
 
 void
@@ -362,6 +366,9 @@ NetworkAnalyserWindow::OnTimer(wxTimerEvent &)
 		    static_cast<unsigned long long>(st.frames_tx),
 		    static_cast<unsigned long long>(st.frames_rx));
 
+		if (!capture_->GetValue()) {
+			label += "   capture stopped";
+		}
 		if (st.file_active) {
 			label += "   writing to a file";
 		}

--- a/src/gui/support_bundle.cpp
+++ b/src/gui/support_bundle.cpp
@@ -26,7 +26,7 @@
  * state - both are large, and a state is a whole RAM image that could hold
  * anything the guest had open.
  *
- * The two text members are redacted on the way in. This is meant to be
+ * Every text member is redacted on the way in. This is meant to be
  * attached to a public issue, and the log carries the configuration verbatim:
  * settings.cpp logs every key it reads, so the VNC password is in there in
  * plain text along with the reporter's home directory.
@@ -202,7 +202,8 @@ SupportBundleSuggestedName(const wxString &machine_name)
 SupportBundleResult
 SupportBundleWrite(const wxString &dest_path, const wxString &machine_name,
                    const wxString &machine_dir, const wxString &log_path,
-                   const wxString &screenshot_path)
+                   const wxString &screenshot_path,
+                   const wxString &manager_log_path)
 {
 	SupportBundleResult result;
 	wxFFileOutputStream out(dest_path);
@@ -218,6 +219,13 @@ SupportBundleWrite(const wxString &dest_path, const wxString &machine_name,
 
 	/* Redacted: the log repeats the configuration as it parses it. */
 	ok = ok && AddRedactedFile(zip, "rpclog.txt", log_path, &result.members);
+
+	/* Named apart from the machine's own, which it sits beside. Absent for a
+	   machine started on its own, and no loss when it is. */
+	if (!manager_log_path.empty() && manager_log_path != log_path) {
+		ok = ok && AddRedactedFile(zip, "manager-rpclog.txt", manager_log_path,
+		    &result.members);
+	}
 
 	if (!machine_name.empty()) {
 		const wxFileName cfg(ConfigPathsConfigsDir(),

--- a/src/gui/support_bundle.h
+++ b/src/gui/support_bundle.h
@@ -64,12 +64,19 @@ struct SupportBundleResult {
  *                        machine happens to be showing, which is the one thing
  *                        here that cannot be redacted - and a machine that is
  *                        not running has no screen to show.
+ * @param manager_log_path The data directory's own rpclog.txt, written by a
+ *                        process that has not chosen a machine - which is the
+ *                        Manager, for its whole life. It records starting
+ *                        machines and attaching to them, so it is the log that
+ *                        says why a machine never got far enough to write one
+ *                        of its own. Left out when the file is not there.
  */
 SupportBundleResult SupportBundleWrite(const wxString &dest_path,
                                        const wxString &machine_name,
                                        const wxString &machine_dir,
                                        const wxString &log_path,
-                                       const wxString &screenshot_path = wxString());
+                                       const wxString &screenshot_path = wxString(),
+                                       const wxString &manager_log_path = wxString());
 
 /** Suggested leafname, e.g. "rpcemu-support-Test1-20260803.zip". */
 wxString SupportBundleSuggestedName(const wxString &machine_name);

--- a/src/gui/toolbar_icons.cpp
+++ b/src/gui/toolbar_icons.cpp
@@ -98,6 +98,11 @@ wxBitmap ToolbarIconInspector(const wxSize &size)
 	return SvgIcon(inspector_svg, size);
 }
 
+wxBitmap ToolbarIconAnalyser(const wxSize &size)
+{
+	return SvgIcon(analyser_svg, size);
+}
+
 wxBitmap ToolbarIconPower(const wxSize &size, bool on)
 {
 	return SvgIcon(on ? power_svg : stop_svg, size);

--- a/src/gui/toolbar_icons.h
+++ b/src/gui/toolbar_icons.h
@@ -36,6 +36,7 @@ wxBitmap ToolbarIconDebugRun(const wxSize &size = wxSize(24, 24));
 wxBitmap ToolbarIconDebugPause(const wxSize &size = wxSize(24, 24));
 wxBitmap ToolbarIconDebugStep(const wxSize &size = wxSize(24, 24));
 wxBitmap ToolbarIconInspector(const wxSize &size = wxSize(24, 24));
+wxBitmap ToolbarIconAnalyser(const wxSize &size = wxSize(24, 24));
 
 /* Starting and stopping a machine, which the Manager does and a running
    machine cannot. Deliberately not the debugger's run/pause icons: those now

--- a/src/gui/usb_dialog.cpp
+++ b/src/gui/usb_dialog.cpp
@@ -171,7 +171,7 @@ void UsbDialog::RebuildChoices()
 	int found;
 
 	choices_.clear();
-	choices_.push_back({UsbAttachment_None, "", false, true, false, "Nothing"});
+	choices_.push_back({UsbAttachment_None, "", false, true, "", false, "Nothing"});
 
 	found = usb_host_enumerate(devices, kMaxHostDevices);
 
@@ -181,12 +181,13 @@ void UsbDialog::RebuildChoices()
 		wxString label;
 		wxString note = ClassName(d.device_class);
 
+		const char *why = usb_host_open_error_text(&d);
+
 		snprintf(id, sizeof(id), "%04x:%04x", d.vendor, d.product);
 
-		if (!d.openable) {
-			note = note.empty() ? "no permission"
-			                    : note + ", no permission";
-		} else if (d.in_use) {
+		if (why != nullptr) {
+			note = note.empty() ? wxString(why) : note + ", " + why;
+		} else if (d.in_use == 1) {
 			note = note.empty() ? "in use by this computer"
 			                    : note + ", in use by this computer";
 		}
@@ -197,7 +198,8 @@ void UsbDialog::RebuildChoices()
 		}
 
 		choices_.push_back({UsbAttachment_Host, id, d.in_use == 1,
-		                    d.openable != 0, d.high_speed != 0, label});
+		                    d.openable != 0, why != nullptr ? why : "",
+		                    d.high_speed != 0, label});
 	}
 
 	for (int port = 0; port < USB_PORTS; port++) {
@@ -258,6 +260,7 @@ void UsbDialog::SelectFromConfig()
 			missing.in_use = false;
 			missing.openable = true;
 			missing.high_speed = false;
+			missing.open_error.clear();
 			missing.label = wxString::Format("%s  (not plugged in)",
 			    config.usb_host[port]);
 
@@ -297,8 +300,9 @@ void UsbDialog::UpdateStatus()
 
 		host++;
 		if (!choice->openable) {
-			text = "This account cannot open that device. It needs a udev "
-			       "rule granting access; see docs/usb.md.";
+			text = wxString::Format("That device cannot be opened (%s). "
+			    "See docs/usb.md for what your platform needs.",
+			    choice->open_error);
 		} else if (choice->in_use && text.empty()) {
 			text = "That device is in use by this computer. Attaching it "
 			       "takes it away from the host until you detach it.";

--- a/src/gui/usb_dialog.h
+++ b/src/gui/usb_dialog.h
@@ -49,7 +49,8 @@ private:
 		int kind;		/**< A UsbAttachment */
 		std::string host_id;	/**< "vvvv:pppp" for a host device */
 		bool in_use;		/**< The host has its own driver bound to it */
-		bool openable;		/**< Permissions allow it to be taken at all */
+		bool openable;		/**< It can be taken at all */
+		wxString open_error;	/**< Why not, when it cannot */
 		bool high_speed;	/**< Faster than the emulated controller can be */
 		wxString label;
 	};

--- a/src/usb_host.c
+++ b/src/usb_host.c
@@ -73,6 +73,14 @@ usb_host_unavailable_reason(void)
 	       "the host's USB devices.";
 }
 
+const char *
+usb_host_open_error_text(const UsbHostDeviceInfo *device)
+{
+	(void) device;
+
+	return NULL;
+}
+
 int
 usb_host_enumerate(UsbHostDeviceInfo *out, int max)
 {
@@ -435,6 +443,26 @@ usb_host_unavailable_reason(void)
 	return usb_host_reason;
 }
 
+const char *
+usb_host_open_error_text(const UsbHostDeviceInfo *device)
+{
+	if (device == NULL || device->openable) {
+		return NULL;
+	}
+
+	switch (device->open_error) {
+	case LIBUSB_ERROR_ACCESS:
+		return "no permission";
+	case LIBUSB_ERROR_NOT_SUPPORTED:
+		/* Windows, for a device on one of its own class drivers. */
+		return "needs a WinUSB driver";
+	case LIBUSB_ERROR_NO_DEVICE:
+		return "unplugged";
+	default:
+		return "cannot be opened";
+	}
+}
+
 /* --- Describing what the host has ---------------------------------------- */
 
 /**
@@ -562,9 +590,18 @@ usb_host_enumerate(UsbHostDeviceInfo *out, int max)
 		                    speed == LIBUSB_SPEED_SUPER ||
 		                    speed == LIBUSB_SPEED_SUPER_PLUS);
 
-		if (libusb_open(list[i], &handle) == 0) {
+		info->open_error = libusb_open(list[i], &handle);
+		if (info->open_error == 0) {
+			int active = libusb_kernel_driver_active(handle, 0);
+
 			info->openable = 1;
-			info->in_use = libusb_kernel_driver_active(handle, 0) == 1;
+			/* Negative is an error rather than an answer, and one of them is
+			   routine: libusb has no way to ask this on Windows, which returns
+			   LIBUSB_ERROR_NOT_SUPPORTED. Left at -1, "not known", so nothing
+			   downstream reports a driver that was never checked for. */
+			if (active >= 0) {
+				info->in_use = (active == 1);
+			}
 		}
 
 		usb_host_describe(handle, &dd, info->name, sizeof(info->name));

--- a/src/usb_host.h
+++ b/src/usb_host.h
@@ -56,8 +56,12 @@ typedef struct {
 	/** The host has a driver of its own bound to it: -1 if that is unknown. */
 	int in_use;
 
-	/** It can be opened at all. Zero usually means permissions. */
+	/** It can be opened at all. */
 	int openable;
+
+	/* The libusb_open() return code, when openable is zero: the reason differs
+	   per platform and so does the remedy. */
+	int open_error;
 
 	/** True for a device faster than the emulated controller can be. */
 	int high_speed;
@@ -75,6 +79,9 @@ int usb_host_available(void);
 
 /** Why it is not available, for an interface to show. Never NULL. */
 const char *usb_host_unavailable_reason(void);
+
+/** Why a listed device could not be opened, in words, or NULL if it could. */
+const char *usb_host_open_error_text(const UsbHostDeviceInfo *device);
 
 /**
  * List what is plugged into the host, for a user to choose from.


### PR DESCRIPTION
Seven small fixes to the Manager and the machine editor, each independent of the
others. Nothing here changes how the emulator runs; it is all interface.

## Windows a machine opens went behind the Manager

`993e0a7` gave a machine's windows the Manager's window as their owner, and
applied it to seven of them. Three were missed: **USB Devices**, **Serial Port**
and **VNC Server**. They open behind the Manager exactly as the others did.

VNC is the one worth mentioning: it sits inside `#ifdef RPCEMU_VNC`, which is
why it was passed over. USB and Serial were reported; VNC was found by checking
every `ShowModal` in the file rather than by trusting the list.

## USB devices said "no permission" when permission was not the problem

Every unopenable device was reported as "no permission", which is true on Linux
and wrong on Windows. Windows binds one of its own class drivers - `usbstor` for
a mass storage device, HID for input, `usbccgp` for a composite one - and libusb
cannot open through any of them. It needs WinUSB bound instead, which
`docs/usb.md` already explains. A user reading "no permission" goes looking for a
setting that will not help.

The reason was there and thrown away: `libusb_open()`'s return code is now kept,
and turned into words by `usb_host_open_error_text()` rather than in the
dialogue, which does not include libusb and should not learn to.

Also stops treating an error from `libusb_kernel_driver_active()` as an answer.
It is documented as unavailable on Windows and returns
`LIBUSB_ERROR_NOT_SUPPORTED` there, which `== 1` quietly made "no driver bound".

Confirmed on Windows: a mass storage device now reads "needs a WinUSB driver".

## The Network Analyser's Capture button said nothing

It works - the ring stops and starts - but the label never changed and neither
did anything else on screen, so a stopped analyser looked exactly like an idle
network. That is the confusion the Network Capture window's own comment warns
about, in the window that did not guard against it.

The toggle now reads "Capturing" or "Capture", and the status line says "capture
stopped" beside the frame counts.

## A toolbar button for the Network Analyser

Next to the Machine Inspector on both toolbars, the two being the same kind of
thing. It was reachable only from the Debug menu.

## The support bundle collected one log of two

`rpcemu_get_log_path()` answers the machine's directory once a machine has been
chosen, and the data directory before that - so the datadir's own `rpclog.txt` is
the Manager's, for its whole life, since the Manager never loads a configuration.

That is the log nobody was collecting, and it is the one that matters when a
machine fails to start: it records spawning the child and attaching to it, while
the machine's own log is empty or absent precisely because the machine never got
that far.

It goes in as `manager-rpclog.txt`, through the same redaction as the rest -
passwords and home directories out of both.

## The Card RAM list was cut off

A machine with an empty second processor slot gets a Card RAM list holding one
item, "-", and the dialogue is fitted around it. Fitting a card refills the list
with "64 KB (needs paging)" and the like, but the control keeps the width it was
measured at.

121 pixels to 199 on GTK, against a 158-pixel longest string.

## Fullscreen

The two windows disagreed - "Full-screen Mode" against "Fullscreen" - and the
Manager's full-screen toolbar button, unlike the machine window's, did not say
how to leave. Both now read "Fullscreen", with the documentation following. The
prose keeps "full-screen mode", where the hyphen is correct.

## Testing

Builds clean, 72/72 tests pass. Tested on Windows and Linux.
