### PR TITLE
Give the keyboard back: the GL canvas was eating every key

### DIFF
--- a/src/gui/emulator_panel.cpp
+++ b/src/gui/emulator_panel.cpp
@@ -689,6 +689,40 @@ void EmulatorPanel::TryCreateGlCanvas()
 	gl_canvas_->Bind(wxEVT_MOUSEWHEEL, &EmulatorPanel::OnMouseWheel, this);
 	gl_canvas_->Bind(wxEVT_ENTER_WINDOW, &EmulatorPanel::OnEnterWindow, this);
 	gl_canvas_->Bind(wxEVT_LEAVE_WINDOW, &EmulatorPanel::OnLeaveWindow, this);
+
+	/*
+	 * ★ And the keyboard, which is not optional here.
+	 *
+	 * SetFocus() on this panel lands on the canvas instead: wxGTK gives focus to
+	 * the first focusable child, and a wxGLCanvas accepts it. So the panel never
+	 * holds focus once the canvas exists, and MainFrame's handlers - bound on the
+	 * panel - saw nothing at all. No typing reached RISC OS, and Alt+Enter could
+	 * not leave full screen, because that is decided in the same handler.
+	 *
+	 * Forwarded rather than handled: the frame owns what a key means, and one
+	 * place deciding that is what keeps the panel out of it.
+	 */
+	gl_canvas_->Bind(wxEVT_KEY_DOWN, &EmulatorPanel::ForwardKeyEvent, this);
+	gl_canvas_->Bind(wxEVT_KEY_UP, &EmulatorPanel::ForwardKeyEvent, this);
+
+	/* Whatever had focus, the canvas is what has it now; say so, so the first
+	   keystroke is not lost to a window that has gone. */
+	gl_canvas_->SetFocus();
+}
+
+/*
+ * Hand a key event to whoever is listening on this panel.
+ *
+ * Raised on this panel rather than left to Skip(): an unhandled event would
+ * climb to the parent anyway, but only if nothing on the canvas consumed it
+ * first, and wxGLCanvas is not required to leave it alone. Sending it here
+ * directly is what the frame's binding is waiting for.
+ */
+void EmulatorPanel::ForwardKeyEvent(wxKeyEvent &event)
+{
+	if (!GetEventHandler()->ProcessEvent(event)) {
+		event.Skip();
+	}
 }
 
 void EmulatorPanel::DestroyGlCanvas(const wxString &why)
@@ -702,6 +736,10 @@ void EmulatorPanel::DestroyGlCanvas(const wxString &why)
 
 	gl_canvas_->Destroy();
 	gl_canvas_ = nullptr;
+
+	/* The window holding the focus has just gone, so take it back: without this
+	   the keyboard dies the moment GL is given up on. */
+	SetFocus();
 
 	/* The CPU path has drawn nothing so far, so its cache is empty rather than
 	   stale: the next frame rebuilds it from scratch. */

--- a/src/gui/emulator_panel.h
+++ b/src/gui/emulator_panel.h
@@ -95,6 +95,9 @@ private:
 #if wxUSE_GLCANVAS
 	void TryCreateGlCanvas();
 	void DestroyGlCanvas(const wxString &why);
+	/* The canvas covers this panel and takes the focus with it, so its key
+	   events are raised here instead - see the definition. */
+	void ForwardKeyEvent(wxKeyEvent &event);
 	bool GlActive() const;
 	void StoreFrameForGl(const VideoUpdate &update);
 	void SupplyFrameToGl();


### PR DESCRIPTION
Fixes https://github.com/andrewtimmins/rpcemu-extended/issues/157

Nothing typed reached RISC OS, Alt+Enter would not leave full screen, and Ctrl+Shift+F12 never got to the guest to shut it down. All three are the same fault, and all three are decided in MainFrame::ProcessEmulatorKeyEvent, which was never called at all.

The panel creates a wxGLCanvas that covers it exactly and forwards thirteen mouse events from it. Key events were not among them, and that was survivable only while the panel held the focus - which it never does. SetFocus() on the panel lands on the canvas: wxGTK gives focus to the first focusable child and a wxGLCanvas accepts it. So MainFrame's handlers, bound on the panel, sat waiting for events that were being delivered to a window with nothing listening.

The two missing binds, forwarding to the panel rather than handling anything, because the frame owns what a key means. Confirmed against a standalone case of the same shape: focus does land on the canvas, and with the forwarding in place a Ctrl+Shift+F12 raised at it arrives at a handler bound on the panel.

DestroyGlCanvas() takes the focus back as well. It destroyed the focused window without doing so, which would have killed the keyboard a second time on any fall back to the CPU path - the same bug, waiting.