### PR TITLE
Settings: one menu, whether the Manager or the machine draws it

### DIFF
--- a/src/gui/main_frame_menus.cpp
+++ b/src/gui/main_frame_menus.cpp
@@ -31,6 +31,7 @@ extern "C" {
 }
 
 #include "display_options.h"
+#include "settings_labels.h"
 
 namespace {
 
@@ -189,7 +190,9 @@ void MainFrame::BuildMenus()
 	    ->SetHelp("Choose what is plugged into the emulated USB ports.");
 	settings_menu->AppendSeparator();
 
-	mute_menu_item_ = settings_menu->AppendCheckItem(ID_MENU_MUTE, "Mute Sound");
+	mute_menu_item_ = settings_menu->AppendCheckItem(ID_MENU_MUTE,
+	                                                 SettingsLabels::MuteSound());
+	mute_menu_item_->SetHelp(SettingsLabels::MuteSoundHelp());
 
 	/*
 	 * The display: a screen size, and how to draw it.
@@ -256,25 +259,24 @@ void MainFrame::BuildMenus()
 	 */
 	mouse_hack_menu_item_ =
 	    settings_menu->AppendCheckItem(ID_MENU_MOUSE_HACK,
-	                                   "Mouse Follows Host Pointer");
-	mouse_hack_menu_item_->SetHelp(
-	    "On, the RISC OS pointer goes wherever the host one is. Off, a click "
-	    "captures the mouse and RISC OS is sent movements instead, which is what "
-	    "games that drive the pointer themselves need. Alt+Enter gives it back.");
+	                                   SettingsLabels::MouseFollows());
+	mouse_hack_menu_item_->SetHelp(SettingsLabels::MouseFollowsHelp());
 	mouse_twobutton_menu_item_ =
-	    settings_menu->AppendCheckItem(ID_MENU_MOUSE_TWOBUTTON, "Two-button Mouse Mode");
+	    settings_menu->AppendCheckItem(ID_MENU_MOUSE_TWOBUTTON,
+	                                   SettingsLabels::TwoButtonMouse());
+	mouse_twobutton_menu_item_->SetHelp(SettingsLabels::TwoButtonMouseHelp());
 	shared_clipboard_menu_item_ =
-	    settings_menu->AppendCheckItem(ID_MENU_SHARED_CLIPBOARD, "Share Clipboard with RISC OS");
-	shared_clipboard_menu_item_->SetHelp(
-	    "Copy and paste text between the host and RISC OS. Needs the "
-	    "SharedClipboard module, which loads itself in the guest.");
-	cpu_idle_menu_item_ = settings_menu->AppendCheckItem(ID_MENU_CPU_IDLE, "Reduce CPU Usage");
+	    settings_menu->AppendCheckItem(ID_MENU_SHARED_CLIPBOARD,
+	                                   SettingsLabels::SharedClipboard());
+	shared_clipboard_menu_item_->SetHelp(SettingsLabels::SharedClipboardHelp());
+	cpu_idle_menu_item_ =
+	    settings_menu->AppendCheckItem(ID_MENU_CPU_IDLE,
+	                                   SettingsLabels::ReduceCpu());
+	cpu_idle_menu_item_->SetHelp(SettingsLabels::ReduceCpuHelp());
 	default_machine_menu_item_ =
 	    settings_menu->AppendCheckItem(ID_MENU_DEFAULT_MACHINE,
-	                                   "Open This Machine Automatically");
-	default_machine_menu_item_->SetHelp(
-	    "Start RPCEmu straight into this machine, without showing the machine "
-	    "list. Hold Shift while starting to get the list back.");
+	                                   SettingsLabels::DefaultMachine());
+	default_machine_menu_item_->SetHelp(SettingsLabels::DefaultMachineHelp());
 
 	/* Tools: things that act on the running machine rather than configure it,
 	   which is why this is not under Settings. */

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -22,6 +22,7 @@
 #include "manager_frame.h"
 
 #include "display_options.h"
+#include "settings_labels.h"
 
 #include "window_owner.h"
 
@@ -694,28 +695,50 @@ void ManagerFrame::BuildMachineMenus(wxMenuBar *menu_bar)
 	machine_settings_menu_->Append(ID_MENU_PARALLEL, "Parallel Port...");
 	machine_settings_menu_->Append(ID_MENU_USB, "USB Devices...");
 	machine_settings_menu_->AppendSeparator();
-	machine_settings_menu_->AppendCheckItem(ID_MENU_MUTE, "Mute Sound");
-	machine_settings_menu_->AppendCheckItem(ID_MENU_FULLSCREEN, "Fullscreen");
+	machine_settings_menu_->AppendCheckItem(ID_MENU_MUTE,
+	    SettingsLabels::MuteSound())->SetHelp(SettingsLabels::MuteSoundHelp());
+	machine_settings_menu_->AppendCheckItem(ID_MENU_FULLSCREEN,
+	    DisplayOptions::FullScreen())->SetHelp(DisplayOptions::FullScreenHelp());
 	/*
-	 * How the machine draws its screen, as the radio pair it now is rather than
-	 * three checkboxes that contradicted each other.
+	 * How the machine draws its screen, in the submenu the machine's own window
+	 * puts it in. The group's name is the question the two answers answer, so
+	 * flattening it out here left the Manager with a bare pair of radio items
+	 * and nothing saying what they were about.
 	 *
-	 * The screen SIZE is deliberately not offered here. Which id means which
-	 * resolution depends on how much display memory that machine has, so it is
-	 * not something the Manager can decide on the machine's behalf - it is set in
-	 * the machine's own Settings menu, or in the machine editor.
+	 * The screen SIZE, the other half of that window's display settings, is not
+	 * offered here. The list is learned rather than computed - RISC OS accepts
+	 * only the modes its monitor definition declares, and which those are is
+	 * found out as they are refused - so the Manager would have to be told it by
+	 * the machine rather than work it out. Until then it is set in the machine's
+	 * own Settings menu, or in the machine editor.
 	 */
-	machine_settings_menu_->AppendRadioItem(ID_MENU_SCALING_ACTUAL,
-	    DisplayOptions::ScalingActualSize());
-	machine_settings_menu_->AppendRadioItem(ID_MENU_SCALING_MULTIPLES,
-	    DisplayOptions::ScalingWholeMultiples());
+	{
+		auto *scaling_menu = new wxMenu;
+
+		scaling_menu->AppendRadioItem(ID_MENU_SCALING_ACTUAL,
+		    DisplayOptions::ScalingActualSize())
+		    ->SetHelp(DisplayOptions::ScalingActualSizeHelp());
+		scaling_menu->AppendRadioItem(ID_MENU_SCALING_MULTIPLES,
+		    DisplayOptions::ScalingWholeMultiples())
+		    ->SetHelp(DisplayOptions::ScalingWholeMultiplesHelp());
+		machine_settings_menu_->AppendSubMenu(scaling_menu,
+		    DisplayOptions::ScalingGroup());
+	}
 	machine_settings_menu_->AppendSeparator();
 	machine_settings_menu_->AppendCheckItem(ID_MENU_MOUSE_HACK,
-	    "Mouse Follows Host Pointer");
-	machine_settings_menu_->AppendCheckItem(ID_MENU_MOUSE_TWOBUTTON, "Two-Button Mouse");
-	machine_settings_menu_->AppendCheckItem(ID_MENU_SHARED_CLIPBOARD, "Shared Clipboard");
-	machine_settings_menu_->AppendCheckItem(ID_MENU_CPU_IDLE, "Reduce CPU Usage");
-	machine_settings_menu_->AppendCheckItem(ID_MENU_DEFAULT_MACHINE, "Default Machine");
+	    SettingsLabels::MouseFollows())
+	    ->SetHelp(SettingsLabels::MouseFollowsHelp());
+	machine_settings_menu_->AppendCheckItem(ID_MENU_MOUSE_TWOBUTTON,
+	    SettingsLabels::TwoButtonMouse())
+	    ->SetHelp(SettingsLabels::TwoButtonMouseHelp());
+	machine_settings_menu_->AppendCheckItem(ID_MENU_SHARED_CLIPBOARD,
+	    SettingsLabels::SharedClipboard())
+	    ->SetHelp(SettingsLabels::SharedClipboardHelp());
+	machine_settings_menu_->AppendCheckItem(ID_MENU_CPU_IDLE,
+	    SettingsLabels::ReduceCpu())->SetHelp(SettingsLabels::ReduceCpuHelp());
+	machine_settings_menu_->AppendCheckItem(ID_MENU_DEFAULT_MACHINE,
+	    SettingsLabels::DefaultMachine())
+	    ->SetHelp(SettingsLabels::DefaultMachineHelp());
 
 	machine_tools_menu_ = new wxMenu();
 	machine_tools_menu_->Append(ID_MENU_PACKAGES, "Package Manager...");

--- a/src/gui/settings_labels.h
+++ b/src/gui/settings_labels.h
@@ -1,0 +1,93 @@
+/*
+  RPCEmu - An Acorn system emulator
+
+  Copyright (C) 2026 Andy Timmins
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+/*
+ * settings_labels.h - the Settings menu entries that are not display options.
+ *
+ * A machine's Settings menu is built twice: by the machine's own window
+ * (main_frame_menus.cpp) and by the Manager, for the machine it is showing
+ * (manager_frame.cpp). Both offer the same settings and each used to spell them
+ * out for itself, so they drifted - "Two-button Mouse Mode" against "Two-Button
+ * Mouse", "Share Clipboard with RISC OS" against "Shared Clipboard", "Open This
+ * Machine Automatically" against "Default Machine". Three settings reading as
+ * six, and the Manager set no help text at all, so the same menu explained
+ * itself in one window and said nothing in the other.
+ *
+ * Naming each one once makes the two menus mirror each other by construction
+ * rather than by somebody remembering to change both. The help text is here for
+ * the same reason: both windows show it in the status bar.
+ *
+ * The display choices are named in display_options.h, which the machine editor
+ * reads as well - they are kept separate because that file also holds the mode
+ * arithmetic, which has nothing to do with menus.
+ */
+
+#ifndef SETTINGS_LABELS_H
+#define SETTINGS_LABELS_H
+
+namespace SettingsLabels {
+
+inline const char *MuteSound() { return "Mute Sound"; }
+inline const char *MuteSoundHelp()
+{
+	return "Silence this machine. RISC OS carries on as though it were making "
+	       "the sound.";
+}
+
+inline const char *MouseFollows() { return "Mouse Follows Host Pointer"; }
+inline const char *MouseFollowsHelp()
+{
+	return "On, the RISC OS pointer goes wherever the host one is. Off, a click "
+	       "captures the mouse and RISC OS is sent movements instead, which is "
+	       "what games that drive the pointer themselves need. Alt+Enter gives "
+	       "it back.";
+}
+
+inline const char *TwoButtonMouse() { return "Two-button Mouse Mode"; }
+inline const char *TwoButtonMouseHelp()
+{
+	return "Treat the middle button as the RISC OS menu button, for a mouse that "
+	       "has only two.";
+}
+
+inline const char *SharedClipboard() { return "Share Clipboard with RISC OS"; }
+inline const char *SharedClipboardHelp()
+{
+	return "Copy and paste text between the host and RISC OS. Needs the "
+	       "SharedClipboard module, which loads itself in the guest.";
+}
+
+inline const char *ReduceCpu() { return "Reduce CPU Usage"; }
+inline const char *ReduceCpuHelp()
+{
+	return "Let the host processor idle when RISC OS is idle, instead of running "
+	       "flat out.";
+}
+
+inline const char *DefaultMachine() { return "Open This Machine Automatically"; }
+inline const char *DefaultMachineHelp()
+{
+	return "Start RPCEmu straight into this machine, without showing the machine "
+	       "list. Hold Shift while starting to get the list back.";
+}
+
+} /* namespace SettingsLabels */
+
+#endif /* SETTINGS_LABELS_H */


### PR DESCRIPTION
A machine's Settings menu is built twice - by the machine's own window
(`main_frame_menus.cpp`) and by the Manager, for the machine it is showing
(`manager_frame.cpp`). The two had drifted apart, in wording and in shape.

## Three settings that read as six

| | Machine window | Manager |
|---|---|---|
| | Two-button Mouse **Mode** | Two-**B**utton Mouse |
| | **Share** Clipboard **with RISC OS** | **Shared** Clipboard |
| | **Open This Machine Automatically** | **Default Machine** |

The Manager also set no help text anywhere, so the same menu explained itself in
one window and said nothing in the other.

The names now come from `settings_labels.h`, one place, the way the display
choices already come from `display_options.h`. A new file rather than more of
that one: `display_options.h` also holds the mode arithmetic - `FixedModes()`,
`ClampDisplayScaling()` - which `settings.cpp` includes the whole header to
reach one function of, and menu labels have nothing to do with it.

The names kept are the machine window's, which were the fuller ones. Mute Sound
and Reduce CPU Usage had no help text in either window and now have some.

The machine editor's checkboxes are deliberately left alone. It uses sentence
case throughout - "Sound", "CD-ROM drive", "VNC server" - which is a dialogue
convention rather than drift, and forcing menu Title Case on it would break its
own consistency to fix a problem it does not have.

## Show In Window, in a submenu again

It is a submenu in the machine's window and was appended flat in the Manager, so
the Manager showed a bare pair of radio items with nothing naming the question
they answer - which is the confusion that submenu was introduced to remove,
surviving in the other window.

```
Settings                          Settings
  Mute Sound                        Mute Sound
  Fullscreen                        Fullscreen
  Actual Size                       Show In Window > Actual Size
  Whole Multiples Only              ---------------  Whole Multiples Only
  ---------------------             Mouse Follows Host Pointer
  Mouse Follows Host Pointer        ...
```

Moving items into a submenu is safe for both things that reach them by id, and
both were checked rather than assumed: `wxMenuBar::FindItem()` recurses, which is
how `ApplyStateReport` ticks them, and the click handler is bound on the frame
over an id range rather than on the menu, so nesting does not enter into it. The
machine window already relied on both, for these same two ids.

## RISC OS Screen Size is still not offered here

The comment saying why was wrong, and is corrected. It claimed the list is not
something one process can tell another. It is - the machine editor computes the
same list from configuration alone, with no running machine
(`MachineEditDialog::PendingDisplayMemory()`).

The real reason is that the list is **learned** rather than computed: RISC OS
accepts only the modes its monitor definition declares, and which those are is
found out as they are refused (`display_mode_mark_unavailable()`), so the
machine would have to report it rather than the Manager work it out.

That is a data-plumbing change of its own and is left for one. It looks
tractable - `StateReport` is extensible `key=value` pairs with around 388 bytes
spare in its 512-byte field, against roughly 150 for the current fifteen modes -
but it needs two new `RunningMachine` fields, a bound check the existing
truncation comment does not cover, and a check that `ID_MENU_SCREEN_FIXED_FIRST`
falls inside the forwardable id range, which it appears not to.

## Testing

Builds clean with no new warnings, 72/72 tests pass. Tested on Linux.

No test accompanies this: it is menu construction, which the suite has no way to
reach without a display. The labels being shared is what stops the drift
recurring.
