### PR TITLE
Manager: offer the screen sizes, and mean the size on the screen

### DIFF
--- a/src/gui/machine_ipc.h
+++ b/src/gui/machine_ipc.h
@@ -257,6 +257,16 @@ enum class IpcRequestType : uint32_t {
 	 * See window_owner.h for what is and is not possible per platform.
 	 */
 	SetOwnerWindow,
+
+	/*
+	 * Set the RISC OS screen size. arg1 = width, arg2 = height.
+	 *
+	 * Its own verb rather than a MenuCommand: that works by sending an event to
+	 * the menu item owning the id, and these ids are outside the forwardable
+	 * range (main_frame.h). A size needs no id in any case - the machine's own
+	 * handler turns the id back into a width and height as its first act.
+	 */
+	SetScreenSize,		/* arg1 = width, arg2 = height */
 };
 
 /*
@@ -276,6 +286,15 @@ constexpr int kStateDebugPauseRequested = 100003;
 
 constexpr int kStateCdromSource = 100004;
 constexpr int kStateNetworkIsNat = 100005;
+
+/* The screen sizes this machine can offer, and which one it is set to. Sent
+   because the Manager cannot work the list out: which modes RISC OS has refused
+   is learned as it happens and lives in the machine's process. Sizes rather than
+   menu ids, an index meaning nothing to another process. The list is one value,
+   "1920x1080,1600x1200,...", the only non-integer in a report - which an older
+   Manager skips, as it does any id it does not know. */
+constexpr int kStateScreenModes = 100006;
+constexpr int kStateScreenSize = 100007;
 
 struct IpcRequest {
 	IpcRequestType type = IpcRequestType::RequestKeyFrame;

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -521,6 +521,14 @@ void MainFrame::HandleIpcRequest(const IpcRequest &request)
 			}
 		});
 		break;
+
+	case IpcRequestType::SetScreenSize: {
+		const unsigned width = (unsigned) request.arg1;
+		const unsigned height = (unsigned) request.arg2;
+
+		CallAfter([this, width, height] { ApplyScreenSize(width, height); });
+		break;
+	}
 	}
 }
 
@@ -723,6 +731,36 @@ void MainFrame::ReportMenuState()
 	report += wxString::Format(" %d=%d", kStateNetworkIsNat,
 	    config_copy_.network_type == NetworkType_NAT ? 1 : 0);
 
+	/* The screen sizes this machine can offer, so the Manager can show the same
+	   list. Built from the same call its own menu uses, so the two agree. */
+	{
+		std::vector<std::pair<unsigned, unsigned>> modes;
+		wxString list;
+
+		DisplayOptions::FixedModes(rpcemu_display_memory(), modes);
+		for (const auto &mode : modes) {
+			if (!list.empty()) {
+				list += ",";
+			}
+			list += wxString::Format("%ux%u", mode.first, mode.second);
+		}
+		if (!list.empty()) {
+			report += wxString::Format(" %d=%s", kStateScreenModes, list);
+		}
+		/*
+		 * What the desktop IS, not what it was configured to be. The two differ
+		 * whenever RISC OS has been given a mode from its own end - *WimpMode,
+		 * Configure, an application changing mode - and after a size it refused,
+		 * where the configured value is the one it would not take.
+		 */
+		const wxSize guest = CurrentGuestScreenSize();
+
+		if (guest.x > 0 && guest.y > 0) {
+			report += wxString::Format(" %d=%dx%d", kStateScreenSize,
+			    guest.x, guest.y);
+		}
+	}
+
 	if (emulator_ != nullptr && emulator_->IsRunning()) {
 		const MachineSnapshot snapshot = emulator_->TakeSnapshot();
 
@@ -736,9 +774,18 @@ void MainFrame::ReportMenuState()
 	event.type = IpcEventType::StateReport;
 	const wxScopedCharBuffer utf8 = report.utf8_str();
 
-	/* Truncation would only cost the Manager a tick-box it cannot see the
-	   state of, but the list is far shorter than the field, so it does not
-	   happen in practice. */
+	/*
+	 * Truncation used to cost at worst a tick-box the Manager could not see the
+	 * state of. The mode list changed that: cutting it mid-entry would offer a
+	 * size that is not a size. It still does not happen - the report is around
+	 * 280 bytes of 512 with every mode present - but it is now worth saying so
+	 * out loud rather than finding out from a menu full of nonsense.
+	 */
+	if (utf8.length() >= sizeof(event.path)) {
+		rpclog("Manager IPC: state report too long (%zu bytes), not sent\n",
+		    (size_t) utf8.length());
+		return;
+	}
 	strncpy(event.path, utf8.data(), sizeof(event.path) - 1);
 	event.path[sizeof(event.path) - 1] = '\0';
 	ipc_server_->SendEvent(event);
@@ -1561,10 +1608,30 @@ void MainFrame::OnScreenSize(wxCommandEvent &event)
 		return;		/* Stale id from a menu that has since been rebuilt */
 	}
 
-	const unsigned want_x = fixed_mode_items_[index].first;
-	const unsigned want_y = fixed_mode_items_[index].second;
+	ApplyScreenSize(fixed_mode_items_[index].first,
+	    fixed_mode_items_[index].second);
+}
 
-	if (want_x == config_copy_.screen_size_x &&
+/* The size, however it was chosen: this window's own menu, or the Manager's copy
+   of it over IPC. Shared so the two cannot come to mean different things. */
+void MainFrame::ApplyScreenSize(unsigned want_x, unsigned want_y)
+{
+	if (want_x == 0 || want_y == 0) {
+		return;
+	}
+
+	/*
+	 * Nothing to do only when the desktop is ALREADY this size, which is not the
+	 * same as the configuration naming it. RISC OS can be in a different mode
+	 * from the configured one - it changes mode from its own end, and a refused
+	 * size leaves the configuration naming one it would not take - and testing
+	 * the configuration there made picking the size shown in the menu do
+	 * nothing at all, with no way to ask for it again.
+	 */
+	const wxSize guest = CurrentGuestScreenSize();
+
+	if (guest.x == (int) want_x && guest.y == (int) want_y &&
+	    want_x == config_copy_.screen_size_x &&
 	    want_y == config_copy_.screen_size_y)
 	{
 		return;
@@ -1579,6 +1646,9 @@ void MainFrame::OnScreenSize(wxCommandEvent &event)
 	/* Named explicitly, so a refusal is reported rather than quietly turned
 	   into some other size. */
 	RequestGuestMode(want_x, want_y, true);
+
+	RebuildScreenSizeMenu();
+	ReportMenuState();
 }
 
 /*
@@ -1682,13 +1752,29 @@ void MainFrame::RebuildScreenSizeMenu()
 		fixed_mode_items_.push_back(modes[i]);
 	}
 
-	/* Tick whichever entry the configuration names. A machine whose size is no
-	   longer on offer - VRAM reduced, or the graphics card taken out - leaves
-	   nothing ticked, which is the honest display of it: the size it is
-	   configured for is not one this machine can currently show. */
+	/*
+	 * Tick the size the desktop actually is, falling back to the configured one
+	 * until a frame has said otherwise.
+	 *
+	 * The desktop rather than the configuration, because the two part company
+	 * readily: RISC OS can be given a mode from its own end (*WimpMode,
+	 * Configure, an application), and a size it refuses leaves the configuration
+	 * naming one it would not take. A tick against either would be pointing at a
+	 * mode that is not on the screen.
+	 *
+	 * Nothing ticked is a real answer and is left to happen: the desktop is in a
+	 * mode this list does not offer, which is exactly what a guest that has gone
+	 * its own way looks like, and claiming the nearest entry would be a lie.
+	 */
+	const wxSize guest = CurrentGuestScreenSize();
+	const unsigned want_x = guest.x > 0 ? (unsigned) guest.x
+	                                    : config_copy_.screen_size_x;
+	const unsigned want_y = guest.y > 0 ? (unsigned) guest.y
+	                                    : config_copy_.screen_size_y;
+
 	for (size_t i = 0; i < fixed_mode_items_.size(); i++) {
-		if (fixed_mode_items_[i].first == config_copy_.screen_size_x &&
-		    fixed_mode_items_[i].second == config_copy_.screen_size_y)
+		if (fixed_mode_items_[i].first == want_x &&
+		    fixed_mode_items_[i].second == want_y)
 		{
 			screen_size_menu_->Check(
 			    (int) (ID_MENU_SCREEN_FIXED_FIRST + (int) i), true);
@@ -1783,7 +1869,9 @@ void MainFrame::RequestGuestMode(unsigned width, unsigned height,
 		return;
 	}
 
-	rpcemu_request_guest_size(fitted_w, fitted_h);
+	/* A named size is forced through: see rpcemu_request_guest_size_ex(). A
+	   window drag is not, so its quantising still holds. */
+	rpcemu_request_guest_size_ex(fitted_w, fitted_h, explicit_choice ? 1 : 0);
 
 	/*
 	 * Only a size the user named is checked.
@@ -1817,6 +1905,24 @@ void MainFrame::RequestGuestMode(unsigned width, unsigned height,
  * in force was a definition file rather than the synthesised EDID. Nothing on the
  * host can know which modes a given definition declares, so they are learned.
  */
+/*
+ * How big the guest's desktop actually is.
+ *
+ * Two sources, because a managed machine's panel is never given a frame: its
+ * window is not shown, so PostVideoUpdate() sends the frame to the Manager and
+ * returns, and the panel is left saying 640x480 for ever. Asking it whether a
+ * mode change was taken therefore answered "refused" every time, whatever the
+ * guest had done.
+ */
+wxSize MainFrame::CurrentGuestScreenSize() const
+{
+	if (managed_mode_) {
+		return wxSize(managed_guest_x_.load(std::memory_order_relaxed),
+		    managed_guest_y_.load(std::memory_order_relaxed));
+	}
+	return panel_ != nullptr ? panel_->GuestScreenSize() : wxSize(0, 0);
+}
+
 void MainFrame::OnModeVerifyTimer(wxTimerEvent &event)
 {
 	(void)event;
@@ -1824,17 +1930,23 @@ void MainFrame::OnModeVerifyTimer(wxTimerEvent &event)
 	/* Only ever reached for a size the user named: RequestGuestMode() starts this
 	   timer for nothing else, so there is no "was this explicit" to test. */
 
-	if (panel_ == nullptr || mode_requested_ == wxSize(0, 0)) {
+	if (mode_requested_ == wxSize(0, 0)) {
 		return;
 	}
 
 	const wxSize requested = mode_requested_;
-	const wxSize guest = panel_->GuestScreenSize();
+	const wxSize guest = CurrentGuestScreenSize();
 
 	mode_requested_ = wxSize(0, 0);
 
 	if (guest == requested) {
 		return;		/* Taken */
+	}
+
+	/* Nothing has said what size the guest is yet, so there is no evidence
+	   either way and a refusal must not be inferred from the absence of it. */
+	if (guest.x <= 0 || guest.y <= 0) {
+		return;
 	}
 
 	rpclog("Display: the guest refused %dx%d\n", requested.x, requested.y);
@@ -1856,6 +1968,7 @@ void MainFrame::OnModeVerifyTimer(wxTimerEvent &event)
 	 */
 	display_mode_mark_unavailable((unsigned) requested.x, (unsigned) requested.y);
 	RebuildScreenSizeMenu();
+	ReportMenuState();
 
 	/*
 	 * Said once, plainly, with the cause and the cure.
@@ -1870,20 +1983,29 @@ void MainFrame::OnModeVerifyTimer(wxTimerEvent &event)
 	 * comes from CMOS and the monitor definition only vets it - so suggesting a
 	 * restart would be sending somebody round a loop that does not arrive.
 	 */
-	wxMessageBox(
-	    wxString::Format(
-	        "RISC OS would not switch to %d x %d, and is still using %d x %d.\n\n"
-	        "It only accepts screen modes the monitor definition it has loaded "
-	        "declares, and that one does not include this size, so it has been "
-	        "taken out of the list.\n\n"
-	        "To get the full set of sizes, stop RISC OS loading its own monitor "
-	        "definition file: in Configure, set the monitor type to Auto or EDID "
-	        "rather than a definition file, then restart the machine. The "
-	        "emulator's own monitor definition offers every size in the list.",
-	        requested.x, requested.y,
-	        guest.x > 0 ? guest.x : requested.x,
-	        guest.y > 0 ? guest.y : requested.y),
-	    "Screen Size Not Available", wxOK | wxICON_INFORMATION, this);
+	const wxString explanation = wxString::Format(
+	    "RISC OS would not switch to %d x %d, and is still using %d x %d.\n\n"
+	    "It only accepts screen modes the monitor definition it has loaded "
+	    "declares, and that one does not include this size, so it has been "
+	    "taken out of the list.\n\n"
+	    "To get the full set of sizes, stop RISC OS loading its own monitor "
+	    "definition file: in Configure, set the monitor type to Auto or EDID "
+	    "rather than a definition file, then restart the machine. The "
+	    "emulator's own monitor definition offers every size in the list.",
+	    requested.x, requested.y,
+	    guest.x > 0 ? guest.x : requested.x,
+	    guest.y > 0 ? guest.y : requested.y);
+
+	/* Through the Manager when there is one, for the reason ShowError() gives:
+	   a managed machine's window is never shown, so a box modal to it is modal
+	   to something the user cannot find. */
+	if (managed_mode_) {
+		ShowError(std::string(explanation.utf8_str()));
+		return;
+	}
+
+	wxMessageBox(explanation, "Screen Size Not Available",
+	    wxOK | wxICON_INFORMATION, this);
 }
 
 void MainFrame::NoteGuestFrame()
@@ -1910,6 +2032,10 @@ void MainFrame::NoteGuestFrame()
 	}
 	guest_size_seen_ = guest;
 	guest_resize_timer_.StartOnce(kGuestSettleMs);
+
+	/* The tick follows the desktop, so it has to move when RISC OS changes mode
+	   from its own end and not only when the change was asked for here. */
+	RebuildScreenSizeMenu();
 }
 
 void MainFrame::OnGuestResizeTimer(wxTimerEvent &event)
@@ -2846,6 +2972,23 @@ void MainFrame::PostVideoUpdate(VideoUpdate update)
 		/* No window is shown, so there is nothing for panel_ to paint: send
 		   the frame to the Manager instead of building a wxBitmap nobody
 		   will ever see. Safe from any thread - see MirrorToSharedFramebuffer. */
+		/* host_xsize/ysize rather than xsize/ysize: those are the buffer's
+		   dimensions, these are the screen's, doubling included, which is what
+		   GuestScreenSize() means and what OnModeVerifyTimer() waits for. */
+		if (update.host_xsize > 0 && update.host_ysize > 0) {
+			const int was_x = managed_guest_x_.exchange(update.host_xsize,
+			    std::memory_order_relaxed);
+			const int was_y = managed_guest_y_.exchange(update.host_ysize,
+			    std::memory_order_relaxed);
+
+			/* The desktop changed size, so the Manager's copy of the screen-size
+			   menu is out of date - including when RISC OS did it from its own
+			   end, which nothing else here would notice. Told once per change,
+			   not once per frame. */
+			if (was_x != update.host_xsize || was_y != update.host_ysize) {
+				CallAfter([this] { ReportMenuState(); });
+			}
+		}
 		MirrorToSharedFramebuffer(update);
 		return;
 	}

--- a/src/gui/main_frame.h
+++ b/src/gui/main_frame.h
@@ -358,6 +358,8 @@ private:
 	 * the graphics card is fitted or the VRAM altered, not just at startup.
 	 */
 	void RebuildScreenSizeMenu();
+	void ApplyScreenSize(unsigned want_x, unsigned want_y);
+	wxSize CurrentGuestScreenSize() const;
 
 	/** True when the window's size is not derived from the guest's desktop. */
 	bool WindowSizeIsFree() const;
@@ -589,6 +591,12 @@ private:
 	   Guards the save-on-exit so it never blocks trying to snapshot a machine
 	   that has already failed. */
 	std::atomic<bool> fatal_occurred_{false};
+
+	/* The guest's screen size, as the frames say it is. Only kept for a managed
+	   machine, whose panel is never given a frame to learn it from, and written
+	   on the VIDC thread - hence atomic. */
+	std::atomic<int> managed_guest_x_{0};
+	std::atomic<int> managed_guest_y_{0};
 	bool menu_open_ = false;
 	bool window_active_ = false;
 	bool full_screen_ = false;

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -96,6 +96,13 @@ enum {
 	ID_POLL_TIMER,
 };
 
+/* Not the machine's ids for the same menu, and never sent anywhere: the chosen
+   size travels as a width and height. */
+enum {
+	ID_SCREEN_SIZE_FIRST = wxID_HIGHEST + 600,
+	ID_SCREEN_SIZE_LAST = ID_SCREEN_SIZE_FIRST + 63,
+};
+
 enum {
 	kStatusIconRunning = 0,
 	kStatusIconStarting,
@@ -109,6 +116,39 @@ enum {
    the far side of it and a machine reads as "Running" throughout them. */
 constexpr int kStartupTimeoutMs = 10000;
 constexpr int kPollIntervalMs = 200;
+
+/* "1920x1080". False rather than a partial answer: a size that did not parse is
+   one the menu must not offer. */
+bool ParseScreenSize(const wxString &text, unsigned &width, unsigned &height)
+{
+	const int x = text.Find('x');
+	long w = 0, h = 0;
+
+	if (x == wxNOT_FOUND ||
+	    !text.Left(x).ToLong(&w) || !text.Mid(x + 1).ToLong(&h) ||
+	    w <= 0 || h <= 0) {
+		return false;
+	}
+	width = (unsigned) w;
+	height = (unsigned) h;
+	return true;
+}
+
+/* "1920x1080,1600x1200,..." */
+void ParseScreenModes(const wxString &text,
+    std::vector<std::pair<unsigned, unsigned>> &out)
+{
+	wxStringTokenizer modes(text, ",");
+
+	out.clear();
+	while (modes.HasMoreTokens()) {
+		unsigned w = 0, h = 0;
+
+		if (ParseScreenSize(modes.GetNextToken(), w, h)) {
+			out.emplace_back(w, h);
+		}
+	}
+}
 } /* namespace */
 
 /*
@@ -705,14 +745,19 @@ void ManagerFrame::BuildMachineMenus(wxMenuBar *menu_bar)
 	 * flattening it out here left the Manager with a bare pair of radio items
 	 * and nothing saying what they were about.
 	 *
-	 * The screen SIZE, the other half of that window's display settings, is not
-	 * offered here. The list is learned rather than computed - RISC OS accepts
-	 * only the modes its monitor definition declares, and which those are is
-	 * found out as they are refused - so the Manager would have to be told it by
-	 * the machine rather than work it out. Until then it is set in the machine's
-	 * own Settings menu, or in the machine editor.
+	 * The screen SIZE is the other half, and the list is learned rather than
+	 * computed - RISC OS accepts only the modes its monitor definition declares,
+	 * and which those are is found out as they are refused - so it is filled in
+	 * from what the machine reports rather than worked out here. Empty, and
+	 * greyed, until it does.
 	 */
 	{
+		auto *screen_menu = new wxMenu;
+
+		screen_size_menu_ = screen_menu;
+		screen_size_parent_ = machine_settings_menu_->AppendSubMenu(screen_menu,
+		    DisplayOptions::ScreenSizeGroup());
+
 		auto *scaling_menu = new wxMenu;
 
 		scaling_menu->AppendRadioItem(ID_MENU_SCALING_ACTUAL,
@@ -779,6 +824,11 @@ void ManagerFrame::BuildMachineMenus(wxMenuBar *menu_bar)
 	Bind(wxEVT_MENU, &ManagerFrame::OnMachineMenuCommand, this,
 	    ID_MENU_SCREENSHOT, ID_MENU_CHECK_UPDATE);
 	Bind(wxEVT_MENU, &ManagerFrame::OnMachineMenuCommand, this, wxID_ABOUT);
+
+	/* Its own handler rather than the range above: these ids are the Manager's
+	   own and mean nothing to the machine, so what travels is the size. */
+	Bind(wxEVT_MENU, &ManagerFrame::OnScreenSize, this,
+	    ID_SCREEN_SIZE_FIRST, ID_SCREEN_SIZE_LAST);
 }
 
 void ManagerFrame::BuildToolBar()
@@ -1087,6 +1137,93 @@ void ManagerFrame::SetNatMenuState(bool is_nat)
 	if (netcap_item_ != nullptr) {
 		netcap_item_->Enable(is_nat);
 	}
+}
+
+/*
+ * The screen sizes the machine on show has offered, as a menu.
+ *
+ * Rebuilt rather than patched, like the machine's own: the list is short, and it
+ * changes wholesale when a different machine is shown.
+ *
+ * The submenu is greyed while the list is empty rather than left to open onto
+ * nothing. Empty is not only the no-machine case: a machine reports when asked,
+ * so there is a moment after it attaches when it is running and has not said
+ * yet. The greying loop in UpdateMachineMenuState() cannot do this one - it
+ * disables a submenu by disabling the items inside it, and there are none.
+ */
+void ManagerFrame::RebuildScreenSizeMenu()
+{
+	if (screen_size_menu_ == nullptr) {
+		return;
+	}
+
+	for (size_t i = 0; i < screen_size_items_.size(); i++) {
+		screen_size_menu_->Delete((int) (ID_SCREEN_SIZE_FIRST + (int) i));
+	}
+	screen_size_items_.clear();
+
+	auto it = running_.find(active_machine_);
+
+	if (it == running_.end()) {
+		if (screen_size_parent_ != nullptr) {
+			screen_size_parent_->Enable(false);
+		}
+		return;
+	}
+
+	const RunningMachine &machine = it->second;
+	const size_t limit =
+	    (size_t) (ID_SCREEN_SIZE_LAST - ID_SCREEN_SIZE_FIRST) + 1;
+
+	for (size_t i = 0; i < machine.screen_modes.size() && i < limit; i++) {
+		const unsigned w = machine.screen_modes[i].first;
+		const unsigned h = machine.screen_modes[i].second;
+		wxMenuItem *item = screen_size_menu_->AppendRadioItem(
+		    (int) (ID_SCREEN_SIZE_FIRST + (int) i),
+		    DisplayOptions::ModeLabel(w, h));
+
+		item->SetHelp(DisplayOptions::ScreenSizeHelp());
+		screen_size_items_.emplace_back(w, h);
+
+		/* The size the machine reports its desktop to be, which is not always
+		   the one asked for: RISC OS can change mode from its own end, and a
+		   refused size leaves it on the old one. Nothing ticked means the
+		   desktop is in a mode this list does not offer. */
+		if (w == machine.screen_size_x && h == machine.screen_size_y) {
+			item->Check(true);
+		}
+	}
+
+	if (screen_size_parent_ != nullptr) {
+		screen_size_parent_->Enable(!screen_size_items_.empty());
+	}
+}
+
+void ManagerFrame::OnScreenSize(wxCommandEvent &event)
+{
+	const size_t index = (size_t) (event.GetId() - ID_SCREEN_SIZE_FIRST);
+
+	if (index >= screen_size_items_.size()) {
+		return;		/* Stale id from a menu that has since been rebuilt */
+	}
+
+	auto it = running_.find(active_machine_);
+
+	if (it == running_.end() || it->second.panel == nullptr) {
+		return;
+	}
+
+	IpcRequest request;
+
+	request.type = IpcRequestType::SetScreenSize;
+	request.arg1 = (int32_t) screen_size_items_[index].first;
+	request.arg2 = (int32_t) screen_size_items_[index].second;
+	it->second.panel->SendRequest(request);
+
+	/* The tick is not set here. The machine reports back what it actually
+	   settled on, which is not necessarily this - RISC OS refuses sizes its
+	   monitor definition does not declare - and showing the asked-for one would
+	   claim a change that did not happen. */
 }
 
 void ManagerFrame::RefreshUiState()
@@ -2459,6 +2596,10 @@ void ManagerFrame::UpdateMachineMenuState()
 		return;
 	}
 
+	/* The list belongs to the machine on show, so it follows the switch rather
+	   than waiting for that machine's next report. */
+	RebuildScreenSizeMenu();
+
 	/*
 	 * Help stays usable with no machine running.
 	 *
@@ -2579,8 +2720,32 @@ void ManagerFrame::ApplyStateReport(const wxString &machine, const wxString &rep
 		long id = 0;
 		long value = 0;
 
-		if (!pair.Left(equals).ToLong(&id) ||
-		    !pair.Mid(equals + 1).ToLong(&value)) {
+		if (!pair.Left(equals).ToLong(&id)) {
+			continue;
+		}
+
+		/* The two whose values are sizes rather than integers, taken before the
+		   ToLong below that every other pair needs. */
+		if (id == kStateScreenModes || id == kStateScreenSize) {
+			auto it = running_.find(machine);
+
+			if (it != running_.end()) {
+				const wxString text = pair.Mid(equals + 1);
+
+				if (id == kStateScreenModes) {
+					ParseScreenModes(text, it->second.screen_modes);
+				} else {
+					ParseScreenSize(text, it->second.screen_size_x,
+					    it->second.screen_size_y);
+				}
+				if (machine == active_machine_) {
+					RebuildScreenSizeMenu();
+				}
+			}
+			continue;
+		}
+
+		if (!pair.Mid(equals + 1).ToLong(&value)) {
 			continue;
 		}
 

--- a/src/gui/manager_frame.h
+++ b/src/gui/manager_frame.h
@@ -22,6 +22,7 @@
 #define MANAGER_FRAME_H
 
 #include <map>
+#include <utility>
 #include <vector>
 
 #include <wx/wx.h>
@@ -78,6 +79,10 @@ private:
 		bool debug_pause_requested = false;
 		int cdrom_source = 0;		/* 0 disabled, 1 empty, 2 an image */
 		bool network_is_nat = false;
+		/* Empty until the machine has reported, which greys the submenu. */
+		std::vector<std::pair<unsigned, unsigned>> screen_modes;
+		unsigned screen_size_x = 0;
+		unsigned screen_size_y = 0;
 	};
 
 	void BuildUi();
@@ -202,6 +207,11 @@ private:
 
 	wxMenu *machine_disc_menu_ = nullptr;
 	wxMenu *machine_settings_menu_ = nullptr;
+	wxMenu *screen_size_menu_ = nullptr;
+	wxMenuItem *screen_size_parent_ = nullptr;
+	std::vector<std::pair<unsigned, unsigned>> screen_size_items_;
+	void RebuildScreenSizeMenu();
+	void OnScreenSize(wxCommandEvent &event);
 	wxMenu *machine_tools_menu_ = nullptr;
 	wxMenu *machine_debug_menu_ = nullptr;
 	wxMenu *machine_help_menu_ = nullptr;

--- a/src/rpcemu.c
+++ b/src/rpcemu.c
@@ -192,6 +192,12 @@ rpcemu_guest_size_for(unsigned width, unsigned height,
 void
 rpcemu_request_guest_size(unsigned width, unsigned height)
 {
+	rpcemu_request_guest_size_ex(width, height, 0);
+}
+
+void
+rpcemu_request_guest_size_ex(unsigned width, unsigned height, int force)
+{
 	unsigned fitted_w = 0, fitted_h = 0;
 
 	if (width == 0 || height == 0) {
@@ -208,7 +214,16 @@ rpcemu_request_guest_size(unsigned width, unsigned height)
 		return;
 	}
 
-	if (fitted_w == guest_size_width && fitted_h == guest_size_height) {
+	/*
+	 * The same size as last time is normally nothing to do. Not when the size
+	 * was named: this records what was ASKED for, and RISC OS may have moved
+	 * since - it changes mode from its own end, and a refused size leaves this
+	 * naming one it would not take. Asking again for the size already recorded
+	 * then did nothing at all, no generation bump, so the guest was never told
+	 * and the request read as a refusal two seconds later.
+	 */
+	if (!force && fitted_w == guest_size_width &&
+	    fitted_h == guest_size_height) {
 		return;
 	}
 

--- a/src/rpcemu.h
+++ b/src/rpcemu.h
@@ -543,6 +543,16 @@ extern int rpcemu_default_screen_size(unsigned *width, unsigned *height);
 extern void rpcemu_request_guest_size(unsigned width, unsigned height);
 
 /*
+ * The same, but "force" asks again even for the size already recorded.
+ *
+ * For a size the user named, where the record is of what was asked for rather
+ * than of what RISC OS is showing: it may have changed mode from its own end, or
+ * refused the recorded size, and in both cases asking again must reach it.
+ */
+extern void rpcemu_request_guest_size_ex(unsigned width, unsigned height,
+                                         int force);
+
+/*
  * What rpcemu_request_guest_size() would settle on for this size, without
  * asking for anything.
  *


### PR DESCRIPTION
Follows #164, which aligned the two Settings menus and left this as the one entry
the Manager did not have.

## Why it was missing, and why that reason was wrong

The comment said the list "is not something one process can tell another". It is
- `MachineEditDialog::PendingDisplayMemory()` already builds the same list from
configuration, with no machine running at all.

The real obstacle is that the list is **learned**. RISC OS accepts only the modes
its monitor definition declares, and which those are is discovered as they are
refused (`display_mode_mark_unavailable()`), so it lives in the machine's process
and has to be reported rather than computed.

It rides the state report, which was built to be extended: the list as
`1920x1080,1600x1200,...` and the size the desktop currently is. That list is the
only value in a report which is not an integer, and it costs nothing - a Manager
built before this runs `ToLong()` over it, fails, and skips the pair, exactly as
it does with any id it does not recognise.

Worst case with every mode present is **289 bytes of the 512 available**. The
truncation comment is now a check: it used to cost at most a tick-box nobody
could see, and would now cut a mode list mid-entry and offer a size that is not
a size.

**Nothing new crosses the forwardable id range.** Those ids are deliberately
outside it - sixty-four would push it into the timer ids, which a `static_assert`
guards - and none is needed. The machine's own handler turns the id into a width
and height as its first act, so `SetScreenSize` carries the size instead.

## The tick follows the desktop, not the configuration

Three faults found while testing, all the same shape: something was asked whether
a mode change had happened, and answered from a record of what had been
*requested*.

**A managed machine's panel is never given a frame.** Its window is not shown, so
`PostVideoUpdate()` mirrors to the Manager and returns - leaving
`GuestScreenSize()` reading 640x480 for ever. Every mode change from the Manager
was therefore judged a refusal: the dialogue appeared every time and, worse, each
one struck a working mode off the list. Now recorded from the frames, taking
`host_xsize`/`host_ysize`, which is the screen's size including VIDC doubling and
so exactly what the panel would have reported.

**The menu ticked the configured size.** RISC OS changes mode from its own end,
and a refused size leaves the configuration naming one it would not take, so the
tick could point at a mode that was not on the screen. It is the reported desktop
size now, in both windows. Nothing ticked is left to mean what it says: the
desktop is in a mode this list does not offer.

**A named size is forced through.** `rpcemu_request_guest_size()` ignores a
request for the size already recorded - right for a window drag walking through
intermediate widths, wrong for a size the user named. After a mode change made
inside RISC OS the record still held the old size, so asking for it again bumped
no generation, told the guest nothing, and read as a refusal two seconds later. A
drag still does not force, so the quantising is untouched.

A genuine refusal is now reported through the Manager when there is one, for the
reason `ShowError()` gives: a managed machine's window is never shown, so a box
modal to it is modal to something the user cannot find.

## Testing

Builds clean, 72/72 tests pass. Tested on Linux, from the Manager: switching
sizes, changing mode inside RISC OS and watching both menus follow, and asking
again for a size RISC OS had left.

**Not covered:** a genuine refusal. It needs a monitor definition that declines a
mode, which I have no machine configured for - so the path that reports one
through the Manager is the least exercised part of this change.
