### PR TITLE
1.x: ask again for a screen size RISC OS has left

### DIFF
--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -1084,7 +1084,18 @@ void MainFrame::OnScreenSize(wxCommandEvent &event)
 	const unsigned want_x = fixed_mode_items_[index].first;
 	const unsigned want_y = fixed_mode_items_[index].second;
 
-	if (want_x == config_copy_.screen_size_x &&
+	/*
+	 * Nothing to do only when the desktop is ALREADY this size, which is not the
+	 * same as the configuration naming it. RISC OS changes mode from its own end,
+	 * and a refused size leaves the configuration naming one it would not take,
+	 * so testing the configuration alone made picking the configured size do
+	 * nothing at all - with no way to ask for it again.
+	 */
+	const wxSize guest = panel_ != nullptr ? panel_->GuestScreenSize()
+	                                       : wxSize(0, 0);
+
+	if (guest.x == (int) want_x && guest.y == (int) want_y &&
+	    want_x == config_copy_.screen_size_x &&
 	    want_y == config_copy_.screen_size_y)
 	{
 		return;
@@ -1202,13 +1213,29 @@ void MainFrame::RebuildScreenSizeMenu()
 		fixed_mode_items_.push_back(modes[i]);
 	}
 
-	/* Tick whichever entry the configuration names. A machine whose size is no
-	   longer on offer - VRAM reduced, or the graphics card taken out - leaves
-	   nothing ticked, which is the honest display of it: the size it is
-	   configured for is not one this machine can currently show. */
+	/*
+	 * Tick the size the desktop actually is, falling back to the configured one
+	 * until a frame has said otherwise.
+	 *
+	 * The desktop rather than the configuration, because the two part company
+	 * readily: RISC OS can be given a mode from its own end, and a size it
+	 * refuses leaves the configuration naming one it would not take. A tick
+	 * against either would be pointing at a mode that is not on the screen.
+	 *
+	 * Nothing ticked is a real answer and is left to happen: the desktop is in a
+	 * mode this list does not offer, which is what a guest that has gone its own
+	 * way looks like, and claiming the nearest entry would be a lie.
+	 */
+	const wxSize shown = panel_ != nullptr ? panel_->GuestScreenSize()
+	                                       : wxSize(0, 0);
+	const unsigned tick_x = shown.x > 0 ? (unsigned) shown.x
+	                                    : config_copy_.screen_size_x;
+	const unsigned tick_y = shown.y > 0 ? (unsigned) shown.y
+	                                    : config_copy_.screen_size_y;
+
 	for (size_t i = 0; i < fixed_mode_items_.size(); i++) {
-		if (fixed_mode_items_[i].first == config_copy_.screen_size_x &&
-		    fixed_mode_items_[i].second == config_copy_.screen_size_y)
+		if (fixed_mode_items_[i].first == tick_x &&
+		    fixed_mode_items_[i].second == tick_y)
 		{
 			screen_size_menu_->Check(
 			    (int) (ID_MENU_SCREEN_FIXED_FIRST + (int) i), true);
@@ -1303,7 +1330,9 @@ void MainFrame::RequestGuestMode(unsigned width, unsigned height,
 		return;
 	}
 
-	rpcemu_request_guest_size(fitted_w, fitted_h);
+	/* A named size is forced through: see rpcemu_request_guest_size_ex(). A
+	   window drag is not, so its quantising still holds. */
+	rpcemu_request_guest_size_ex(fitted_w, fitted_h, explicit_choice ? 1 : 0);
 
 	/*
 	 * Only a size the user named is checked.
@@ -1430,6 +1459,10 @@ void MainFrame::NoteGuestFrame()
 	}
 	guest_size_seen_ = guest;
 	guest_resize_timer_.StartOnce(kGuestSettleMs);
+
+	/* The tick follows the desktop, so it has to move when RISC OS changes mode
+	   from its own end and not only when the change was asked for here. */
+	RebuildScreenSizeMenu();
 }
 
 void MainFrame::OnGuestResizeTimer(wxTimerEvent &event)

--- a/src/rpcemu.c
+++ b/src/rpcemu.c
@@ -189,6 +189,12 @@ rpcemu_guest_size_for(unsigned width, unsigned height,
 void
 rpcemu_request_guest_size(unsigned width, unsigned height)
 {
+	rpcemu_request_guest_size_ex(width, height, 0);
+}
+
+void
+rpcemu_request_guest_size_ex(unsigned width, unsigned height, int force)
+{
 	unsigned fitted_w = 0, fitted_h = 0;
 
 	if (width == 0 || height == 0) {
@@ -205,7 +211,16 @@ rpcemu_request_guest_size(unsigned width, unsigned height)
 		return;
 	}
 
-	if (fitted_w == guest_size_width && fitted_h == guest_size_height) {
+	/*
+	 * The same size as last time is normally nothing to do. Not when the size
+	 * was named: this records what was ASKED for, and RISC OS may have moved
+	 * since - it changes mode from its own end, and a refused size leaves this
+	 * naming one it would not take. Asking again for the size already recorded
+	 * then did nothing at all, no generation bump, so the guest was never told
+	 * and the request read as a refusal two seconds later.
+	 */
+	if (!force && fitted_w == guest_size_width &&
+	    fitted_h == guest_size_height) {
 		return;
 	}
 

--- a/src/rpcemu.h
+++ b/src/rpcemu.h
@@ -496,6 +496,16 @@ extern int rpcemu_default_screen_size(unsigned *width, unsigned *height);
 extern void rpcemu_request_guest_size(unsigned width, unsigned height);
 
 /*
+ * The same, but "force" asks again even for the size already recorded.
+ *
+ * For a size the user named, where the record is of what was asked for rather
+ * than of what RISC OS is showing: it may have changed mode from its own end, or
+ * refused the recorded size, and in both cases asking again must reach it.
+ */
+extern void rpcemu_request_guest_size_ex(unsigned width, unsigned height,
+                                         int force);
+
+/*
  * What rpcemu_request_guest_size() would settle on for this size, without
  * asking for anything.
  *


### PR DESCRIPTION
**Against `1.x`, not `main`.**

Change the screen mode from inside RISC OS - `*WimpMode`, Configure, an
application - and the size the machine was configured for can no longer be chosen
from *Settings → RISC OS Screen Size*. Picking it does nothing, and two seconds
later it is struck off the list as refused, leaving no way to ask for it at all
until the machine is restarted.

## Reproducing

1. Start a machine configured for, say, 1920 x 1080
2. In RISC OS, change to a different mode
3. *Settings → RISC OS Screen Size → 1920 x 1080*

Nothing happens, and the entry disappears from the menu. It comes back on
restarting the machine - `mode_unavailable[]` is in-memory only - but not before.

## What was wrong

Three things had to agree that a size was worth asking for, and all three were
comparing against a record of what had been **requested** rather than what the
desktop actually is.

**`OnScreenSize()` returned early when the configuration already named the
size.** The configuration is what was asked for, so after RISC OS had moved on
its own, the one entry the user most wanted was the one click that did nothing.
It now tests the desktop as well, and declines only when the screen is already
that size.

This is the one that makes the rest reachable: without it the request never got
as far as the core.

**`rpcemu_request_guest_size()` ignores a request for the size it last
recorded.** That is right for a window drag, which walks through every
intermediate width and would otherwise have the guest reflowing its desktop over
and over. It is wrong for a size the user named: the record still held the old
size, so no generation was bumped, the guest was never told, and the silence read
as a refusal to the verify timer two seconds later. A named size now forces the
request through; a drag does not, so the quantising is untouched.

**The menu ticked the configured size**, which after either of the above is a
mode that is not on the screen. It follows the desktop now, rebuilt when the
guest changes mode rather than only when the change was asked for here. Nothing
ticked is left to mean what it says: the desktop is in a mode this list does not
offer.

## Relationship to the v2 line

Found while adding this menu to the Manager on v2 (#165), but the fault is older
than that and none of it is Manager-specific - the code here is byte-for-byte
what v2 had. This branch has no `managed_mode_`, so it needs none of the
frame-tracking that v2 also required: `panel_->GuestScreenSize()` is always
correct here.

Raised separately rather than folded into #165 because on this branch it is a
pre-existing bug rather than a follow-on.

## Testing

Builds clean, 50/50 tests pass. Tested on Linux: changing mode inside RISC OS and
picking the original size back from the menu, and the tick following a mode
change made from the guest.

**Not covered:** a genuine refusal, which needs a monitor definition that
declines a mode. That path is unchanged by this PR - it still reports in the
machine's own window - but it is the least exercised part of the area.
