### PR TITLE
Manager: let the Inspector and the Analyser be typed past

### DIFF
--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -2356,7 +2356,8 @@ void MainFrame::OnNetworkAnalyser(wxCommandEvent &)
 {
 	if (network_analyser_window_ == nullptr) {
 		network_analyser_window_ = new NetworkAnalyserWindow(this);
-		PrepareMachineWindow(network_analyser_window_, "Network Analyser");
+		PrepareMachineWindow(network_analyser_window_, "Network Analyser",
+		    false);
 		network_analyser_window_->Bind(wxEVT_DESTROY,
 		    [this](wxWindowDestroyEvent &) {
 			network_analyser_window_ = nullptr;
@@ -2369,7 +2370,8 @@ void MainFrame::OnMachineInspector(wxCommandEvent &)
 {
 	if (machine_inspector_window_ == nullptr) {
 		machine_inspector_window_ = new MachineInspectorWindow(this, *emulator_);
-		PrepareMachineWindow(machine_inspector_window_, "Machine Inspector");
+		PrepareMachineWindow(machine_inspector_window_, "Machine Inspector",
+		    false);
 		machine_inspector_window_->Bind(wxEVT_DESTROY, [this](wxWindowDestroyEvent &) {
 			machine_inspector_window_ = nullptr;
 		});
@@ -3140,8 +3142,18 @@ void MainFrame::PostVideoUpdate(VideoUpdate update)
  *
  * Only for a managed machine: one running in its own window has that window as a
  * visible parent, and its title already says which machine it is.
+ *
+ * `own` is false for the windows that stay open while the machine is used. An
+ * owned window is a dialogue of its owner as far as the window manager is
+ * concerned, and it keeps the keyboard: with the Machine Inspector open, typing
+ * went into the Inspector's own fields even after the Manager was clicked, and
+ * the machine could not be typed at until it was closed. That is right for a
+ * modal dialogue, which is holding the keyboard on purpose, and wrong for a
+ * window meant to sit beside the machine while it runs. They still open in front
+ * - window_show_in_front() does that - they simply do not stay there.
  */
-void MainFrame::PrepareMachineWindow(wxWindow *window, const wxString &what)
+void MainFrame::PrepareMachineWindow(wxWindow *window, const wxString &what,
+                                     bool own)
 {
 	if (!managed_mode_ || window == nullptr) {
 		return;
@@ -3163,7 +3175,9 @@ void MainFrame::PrepareMachineWindow(wxWindow *window, const wxString &what)
 	/* Before it is shown: X11 keeps the hint across a map, and Windows wants the
 	   owner set while the window is still unmapped to place it correctly first
 	   time. */
-	window_set_owner(window, owner_window_id_);
+	if (own) {
+		window_set_owner(window, owner_window_id_);
+	}
 }
 
 void MainFrame::PostPointerShape(const PointerShape &shape)

--- a/src/gui/main_frame.h
+++ b/src/gui/main_frame.h
@@ -234,7 +234,8 @@ public:
 	 * identified by that window, and its dialogues are parented to something
 	 * visible.
 	 */
-	void PrepareMachineWindow(wxWindow *window, const wxString &what);
+	void PrepareMachineWindow(wxWindow *window, const wxString &what,
+	                          bool own = true);
 	void ShowError(const std::string &message) override;
 	void ShowFatal(const std::string &message) override;
 	void PostDebuggerStateChanged() override;

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -1317,13 +1317,14 @@ void ManagerFrame::DiscoverAlreadyRunningMachines()
 			continue;	/* running, but not as a --managed child - nothing for us to attach to */
 		}
 
-		AttachPanelFor(name, wxString::FromUTF8(MachineIpcNameFor(rpcemu_get_datadir(), name.utf8_str().data(), pid)),
+		AttachPanelFor(name, pid, wxString::FromUTF8(MachineIpcNameFor(rpcemu_get_datadir(), name.utf8_str().data(), pid)),
 		    wxString::FromUTF8(endpoint), false);
 	}
 	RefreshMachineList();
 }
 
-void ManagerFrame::AttachPanelFor(const wxString &name, const wxString &shared_fb_name,
+void ManagerFrame::AttachPanelFor(const wxString &name, long pid,
+                                  const wxString &shared_fb_name,
                                   const wxString &ipc_endpoint, bool newly_started)
 {
 	auto *panel = new RemoteEmulatorPanel(display_book_, shared_fb_name.utf8_str().data(),
@@ -1394,6 +1395,12 @@ void ManagerFrame::AttachPanelFor(const wxString &name, const wxString &shared_f
 	}
 	it->second.starting = false;
 	it->second.panel = panel;
+	/* Set for a machine found already running as well as one started here,
+	   where StartMachine() has recorded it: without it the machine cannot be
+	   granted the right to raise its own windows. */
+	if (pid != 0) {
+		it->second.pid = pid;
+	}
 
 	/*
 	 * Tell the machine which window its own dialogues should sit above. Without
@@ -1538,7 +1545,7 @@ void ManagerFrame::OnPollTimer(wxTimerEvent & /*event*/)
 		    machine_lock_owner_alive(pid) &&
 		    machine_lock_read_ipc_endpoint(dir.utf8_str().data(), endpoint, sizeof(endpoint)) &&
 		    endpoint[0] != '\0') {
-			AttachPanelFor(name, wxString::FromUTF8(MachineIpcNameFor(rpcemu_get_datadir(), name.utf8_str().data(), pid)),
+			AttachPanelFor(name, pid, wxString::FromUTF8(MachineIpcNameFor(rpcemu_get_datadir(), name.utf8_str().data(), pid)),
 			    wxString::FromUTF8(endpoint), true);
 
 			/* Still starting means the attempt failed, so fall through to
@@ -2380,6 +2387,26 @@ bool ManagerFrame::SendMenuCommand(int id, bool checked, const wxString &argumen
 	}
 	strncpy(request.path, utf8.data(), sizeof(request.path) - 1);
 	request.path[sizeof(request.path) - 1] = '\0';
+
+	/*
+	 * Let the machine put its own window in front, for the command that opens
+	 * one.
+	 *
+	 * Windows only, and it has to be done from here: a process may raise a
+	 * window only while it is the foreground one, and the machine never is - the
+	 * click that asks for the window went to this menu, so this process received
+	 * the last input event and the machine's SetForegroundWindow is refused.
+	 * That is why the Machine Inspector and the Network Analyser opened behind
+	 * this window the first time and correctly after it: the second open needs
+	 * no permission, the window already being above this one.
+	 *
+	 * AllowSetForegroundWindow hands the right over for one use, and this is the
+	 * moment the system means it to be used - the user has just clicked, and the
+	 * window they asked for is about to open. The grant lapses by itself at the
+	 * next input that is not directed at the machine, so it cannot accumulate
+	 * into a licence to interrupt.
+	 */
+	window_allow_foreground(it->second.pid);
 
 	it->second.panel->SendRequest(request);
 	return true;

--- a/src/gui/manager_frame.h
+++ b/src/gui/manager_frame.h
@@ -124,8 +124,11 @@ private:
 	wxString SnapshotPathFor(const wxString &name) const;
 	void ShowMachinePanel(const wxString &name);
 	void RemoveRunningEntry(const wxString &name);
-	void AttachPanelFor(const wxString &name, const wxString &shared_fb_name,
-	                     const wxString &ipc_endpoint, bool newly_started);
+	/* `pid` is the machine's process, kept so it can be granted the right to
+	   raise its own windows - see window_allow_foreground(). */
+	void AttachPanelFor(const wxString &name, long pid,
+	                    const wxString &shared_fb_name,
+	                    const wxString &ipc_endpoint, bool newly_started);
 
 	void OnMachineSelected(wxListEvent &event);
 	void OnMachineActivated(wxListEvent &event);

--- a/src/gui/window_owner.cpp
+++ b/src/gui/window_owner.cpp
@@ -142,3 +142,15 @@ window_show_in_front(wxWindow *window)
 		top->RequestUserAttention();
 	}
 }
+
+void
+window_allow_foreground(long pid)
+{
+#if defined(__WXMSW__)
+	if (pid > 0) {
+		AllowSetForegroundWindow((DWORD) pid);
+	}
+#else
+	(void) pid;
+#endif
+}

--- a/src/gui/window_owner.h
+++ b/src/gui/window_owner.h
@@ -79,4 +79,24 @@ void window_set_owner(wxWindow *window, uint64_t owner_id);
  */
 void window_show_in_front(wxWindow *window);
 
+/*
+ * Let another process raise a window of its own, once.
+ *
+ * ★ Windows restricts this and the restriction is the whole difficulty: a
+ * process may bring a window to the front only if it is already the foreground
+ * process or received the last input event. A machine started by the Manager is
+ * neither - the click that asks for its window went to the Manager's menu - so
+ * its Raise(), which is SetForegroundWindow() for a top-level window, is refused
+ * and Windows flashes the taskbar instead.
+ *
+ * Called by the process that DOES have the right, at the moment it is passing on
+ * a request to open a window. The grant is for one use and lapses at the next
+ * input not directed at that process, so it cannot become a standing licence to
+ * interrupt.
+ *
+ * Nothing to do anywhere else: X11 has no such restriction, and on Wayland and
+ * macOS a machine cannot raise its window across processes whatever we do.
+ */
+void window_allow_foreground(long pid);
+
 #endif /* WINDOW_OWNER_H */


### PR DESCRIPTION
With the Machine Inspector or the Network Analyser open, the machine could be
clicked but not typed at. Keys went into the Inspector's own fields, and stayed
there after the Manager was clicked - the only way back was to close it.

Reproducible on Linux and Windows. The mouse worked throughout, which is what
made it look like a keyboard fault rather than a focus one: mouse events are
delivered by pointer position, key events by focus.

## Why

Both are windows a machine opens, and a machine started from the Manager runs in
its own process. #993e0a7 gave those windows the Manager's window as their
**owner** - `XSetTransientForHint` on X11, `GWLP_HWNDPARENT` on Windows - so the
window manager would stop them opening behind it, which was a real and
frustrating problem.

That works, and it carries something that commit did not set out to ask for: an
owned window is a *dialogue of its owner* as far as the window manager is
concerned, and it keeps the keyboard.

For the nine modal dialogues that is exactly right - they hold the keyboard on
purpose and are gone in a moment. For these two it is not. They are meant to sit
beside a running machine and be read while it is used, and the panel that
forwards keys to the machine lives in the *Manager's* process - so a window in
the *machine's* process holding focus means nothing reaches the guest at all.

`PrepareMachineWindow()` now takes an `own` flag, false for exactly these two.
The modal dialogues are untouched.

## The Windows half

That alone fixed Linux and broke the first open on Windows: the two windows
opened behind the Manager once each, and correctly ever after.

The asymmetry is the explanation. A window that has never been shown has to be
*placed*, and placing it in front means `SetForegroundWindow` - which is what
`wxTopLevelWindowMSW::Raise()` calls:

```cpp
void wxTopLevelWindowMSW::Raise()
{
    ::SetForegroundWindow(GetHwnd());
}
```

Windows refuses that to a process which is not the foreground one and did not
receive the last input event. The machine is neither: the click that asked for
the window went to the Manager's menu. On the second open there is nothing to
place - the window is already above the Manager - so no permission is needed and
it worked.

`SetWindowPos(HWND_TOP)` is not a way round it, and the documentation is
explicit: *"To use SetWindowPos to bring a window to the top, the process that
owns the window must have SetForegroundWindow permission."*

The Manager does have that permission at the moment it matters, so it hands it
over: `AllowSetForegroundWindow(machine pid)` as the command is forwarded. The
grant is for one use and lapses at the next input not directed at the machine, so
it cannot become a standing licence to interrupt. X11 has no such restriction and
needs none of this.

## One thing found while wiring it up

`AttachPanelFor()` never received the pid, so `RunningMachine` kept a pid of zero
for any machine the Manager *attached to* rather than started - one already
running when the Manager opened. The grant would have quietly done nothing for
exactly those. It now takes the pid, and both call sites pass it.

## Testing

Builds clean, 72/72 tests pass. Tested on **Linux and Windows**:

- both windows open in front, on the first open and after
- the machine can be typed at while either is open
- the modal dialogues are as they were - in front, and holding the keyboard

Windows was built as a MinGW cross build and run natively.
