### PR TITLE
Manager: draw the toolbar and status bar when Windows will not

### DIFF
--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -1333,6 +1333,12 @@ void ManagerFrame::RefreshUiState()
 	UpdateStatusText();
 	UpdateButtons();
 	UpdateMachineMenuState();
+
+	/* Both of those grey and ungrey tools, which on Windows are not redrawn on
+	   their own - the same withheld WM_PAINT as RepaintBandsNow(), reached by a
+	   different route. Once at the end rather than in each: they enable
+	   overlapping sets of tools. */
+	RepaintBandsNow();
 }
 
 void ManagerFrame::UpdateButtons()

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -207,6 +207,12 @@ wxBEGIN_EVENT_TABLE(ManagerFrame, wxFrame)
 	EVT_MENU(wxID_EXIT, ManagerFrame::OnExit)
 	EVT_CLOSE(ManagerFrame::OnClose)
 	EVT_TIMER(ID_POLL_TIMER, ManagerFrame::OnPollTimer)
+	/* Both, and neither implies the other: ICONIZE covers minimise and restore,
+	   MAXIMIZE only the maximise. See RepaintBandsNow(). */
+	EVT_ICONIZE(ManagerFrame::OnIconize)
+	EVT_MAXIMIZE(ManagerFrame::OnMaximize)
+	/* Un-maximising raises no event of its own; see OnFrameSize(). */
+	EVT_SIZE(ManagerFrame::OnFrameSize)
 wxEND_EVENT_TABLE()
 
 ManagerFrame::ManagerFrame()
@@ -537,6 +543,98 @@ void ManagerFrame::RelayoutAroundToolBar()
 	Refresh();
 	Update();
 	PositionCollapseButton();
+}
+
+/*
+ * Draw the toolbar and the status bar now, rather than waiting for Windows to
+ * get round to it.
+ *
+ * ★ Restoring or maximising this window leaves both bands blank until something
+ * unrelated repaints them - a menu being opened is the usual accident. Measured
+ * on Windows with GetUpdateRect: after a restore both bands report an update
+ * region covering their whole width and keep it, undelivered, for as long as the
+ * user waits. They were never drawn; the pixels are whatever was there before.
+ *
+ * The reason is the machine's own picture. Direct2D draws it at the guest's
+ * frame rate, and WM_PAINT is synthesised by Windows only when the message queue
+ * has nothing else in it, so the two bands - which paint natively and are asked
+ * for by nobody - lose the race indefinitely. Turning hardware acceleration off
+ * makes the symptom disappear entirely, which is what identified it.
+ *
+ * Refresh() alone cannot fix that: it adds to the update region and waits for
+ * the same WM_PAINT. Update() is ::UpdateWindow(), which paints synchronously
+ * and does not queue, so the band is drawn whatever else is pending.
+ *
+ * Windows only. Nothing else showed this, and a synchronous repaint of two bands
+ * is not worth spending elsewhere.
+ */
+void ManagerFrame::RepaintBandsNow()
+{
+#ifdef __WXMSW__
+	if (tool_bar_ != nullptr && tool_bar_->IsShown()) {
+		tool_bar_->Refresh();
+		tool_bar_->Update();
+	}
+	if (wxStatusBar *status = GetStatusBar()) {
+		if (status->IsShown()) {
+			status->Refresh();
+			status->Update();
+		}
+	}
+#endif
+}
+
+/*
+ * Restored, or maximised, or un-maximised.
+ *
+ * Both events are needed and neither implies the other: wxEVT_ICONIZE covers
+ * minimise and restore, wxEVT_MAXIMIZE only the maximise. Queued rather than
+ * done here, because the size that follows the event is the one the bands have
+ * to be drawn at - painting now would draw them at the old size and leave the
+ * same stale picture, one size out of date.
+ */
+void ManagerFrame::OnWindowStateChanged()
+{
+	CallAfter([this] { RepaintBandsNow(); });
+}
+
+void ManagerFrame::OnIconize(wxIconizeEvent &event)
+{
+	/* Only on the way back: nothing needs drawing while the window is gone, and
+	   a paint asked for then is one Windows discards. */
+	if (!event.IsIconized()) {
+		OnWindowStateChanged();
+	}
+	event.Skip();
+}
+
+void ManagerFrame::OnMaximize(wxMaximizeEvent &event)
+{
+	OnWindowStateChanged();
+	event.Skip();
+}
+
+/*
+ * Un-maximising raises no event of its own - wxEVT_MAXIMIZE is only the way in -
+ * and it leaves the same two blank bands, at the smaller size. The probe caught
+ * it as a plain size event still reporting a full-width update region, so the
+ * size path has to ask for the repaint too.
+ *
+ * Only when the maximised state actually changed, not on every size event: a
+ * drag of the window's edge raises one per mouse movement, and a synchronous
+ * repaint of two bands on each would be paid for in the drag feeling heavy. The
+ * bands redraw by themselves during a drag - it is the transitions that lose
+ * them.
+ */
+void ManagerFrame::OnFrameSize(wxSizeEvent &event)
+{
+	const bool maximized = IsMaximized();
+
+	if (maximized != was_maximized_) {
+		was_maximized_ = maximized;
+		OnWindowStateChanged();
+	}
+	event.Skip();
 }
 
 /* Hide the furniture and leave the machine. */

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -1185,7 +1185,12 @@ void ManagerFrame::SetMuteToolState(bool muted)
 	mute_tool_muted_ = muted;
 	tool_bar_->SetToolNormalBitmap(ID_MENU_MUTE, ToolbarIconMute(muted));
 
-	/* The new bitmap is not always drawn on its own. */
+	/*
+	 * The new bitmap is not always drawn on its own, and Update() is what makes
+	 * this work where a bare Refresh() would not: it paints synchronously
+	 * instead of queueing a WM_PAINT the toolbar may wait a long time for. See
+	 * RepaintBandsNow() for why that wait happens at all.
+	 */
 	tool_bar_->Refresh();
 	tool_bar_->Update();
 }
@@ -1210,7 +1215,6 @@ void ManagerFrame::SetDebugToolState(bool paused, bool pausing)
 		tool_bar_->EnableTool(ID_MENU_DEBUG_RUN, paused);
 		tool_bar_->EnableTool(ID_MENU_DEBUG_PAUSE, !paused || pausing);
 		tool_bar_->EnableTool(ID_MENU_DEBUG_STEP, paused);
-		tool_bar_->Refresh();
 	}
 }
 
@@ -1361,7 +1365,6 @@ void ManagerFrame::UpdateButtons()
 		tool_bar_->EnableTool(ID_RESUME, can_resume);
 		tool_bar_->EnableTool(ID_STOP, is_running);
 		tool_bar_->EnableTool(ID_RESET, is_live);
-		tool_bar_->Refresh();	/* see UpdateMachineMenuState */
 	}
 	if (start_item_ != nullptr) start_item_->Enable(have_selection && !is_running);
 	if (resume_item_ != nullptr) {
@@ -2794,9 +2797,6 @@ void ManagerFrame::UpdateMachineMenuState()
 		for (int id : forwarded_tools) {
 			tool_bar_->EnableTool(id, have_machine);
 		}
-
-		/* Greying a tool does not always redraw it. */
-		tool_bar_->Refresh();
 	}
 
 	/*

--- a/src/gui/manager_frame.h
+++ b/src/gui/manager_frame.h
@@ -176,6 +176,16 @@ private:
 	/* Showing or hiding the toolbar needs both a size event and a repaint;
 	   neither implies the other. */
 	void RelayoutAroundToolBar();
+
+	/* The toolbar and status bar, drawn synchronously. See the definition for
+	   why they do not draw themselves after a restore or a maximise. */
+	void RepaintBandsNow();
+	void OnWindowStateChanged();
+	void OnIconize(wxIconizeEvent &event);
+	void OnMaximize(wxMaximizeEvent &event);
+	void OnFrameSize(wxSizeEvent &event);
+	/* What OnFrameSize compares against, so a drag does not repaint per step. */
+	bool was_maximized_ = false;
 	void OnExit(wxCommandEvent &event);
 	void OnClose(wxCloseEvent &event);
 	void OnMachineListSize(wxSizeEvent &event);


### PR DESCRIPTION
On Windows, with a machine running, the Manager's toolbar and status bar stopped
being drawn:

- **minimise then restore** — toolbar icons and status bar text both gone
- **maximise or un-maximise** — status bar blank, and the right-hand debug tools
  drawn at their old positions
- **running machine → stopped machine → back** — the toolbar kept the stopped
  machine's greying

All three corrected themselves the moment any menu was opened. The second is the
"debug icons drift out of alignment" oddity that was looked at in August and
shelved as a wx defect; it is the same bug as the other two.

## The cause

**Direct2D starves the frame's bands of `WM_PAINT`.**

The Manager draws the machine's picture with
`wxGraphicsRenderer::GetDirect2DRenderer()` at the guest's frame rate. Windows
synthesises `WM_PAINT` only when the message queue holds nothing else, so the
toolbar and status bar — which paint natively and are asked for by nobody — lose
that race indefinitely.

Measured with `GetUpdateRect` on both bands: after a restore each reports an
update region covering its whole width and **holds it, undelivered**, through the
restore, through several seconds of waiting, and until a menu is opened. The
pixels are simply whatever was there before, which is why a maximise loses less
than a minimise — less was invalidated.

Confirmed by bisection: turning hardware acceleration off makes every symptom
disappear with nothing else changed. On Windows that setting selects Direct2D,
not OpenGL — `TryCreateGlCanvas` returns unconditionally under `__WXMSW__`, so
the Manager never creates a GL canvas there at all.

## The fix

`RepaintBandsNow()` — `Refresh()` **and `Update()`** on both bands. `Update()` is
`::UpdateWindow()`, which paints synchronously and does not queue.

**A bare `Refresh()` cannot work here**: it adds to the update region and waits
for the very `WM_PAINT` being withheld. Three such calls were already scattered
through this file from earlier attempts at these symptoms, and none of them ever
did anything — the middle commit removes them.

Called from three window transitions (ICONIZE for the restore, MAXIMIZE, and the
size path for un-maximising, which raises no event of its own) and from
`RefreshUiState()` for the machine-switch case.

The size path acts only when the maximised state actually changed: a drag of the
window edge raises a size event per mouse movement, and two synchronous band
repaints on each would be paid for in the drag feeling heavy.

## Not touched

- **The machine window needs none of this.** It contains no Direct2D at all, so
  the cause is absent — and it was the control that disproved two earlier
  theories about this bug. Adding the fix there would remove that.
- **`AddStretchableSpace()` stays.** An earlier theory held that stale
  stretchable-space geometry was consumed by `wxToolBar::HandlePaint`'s
  `ValidateRgn`, and the recommendation was to drop it and left-align the debug
  tools. Measurement killed that: with the bug on screen, `client=1920`,
  `sum=1920`, `slack=0`, and the spacer stable at 1392px throughout. It would
  have cost the right-aligned debug group for nothing.

## Testing

Builds clean, 73/73 tests pass. Tested on Windows: minimise/restore, maximise,
un-maximise, machine switching, a drag-resize for the guard, and that the mute
button still redraws.

Linux and macOS are unaffected by construction — `RepaintBandsNow()` is empty
outside `__WXMSW__`, and neither platform showed any of these symptoms.
