### PR TITLE
Honour RPCEMU_RESOURCE_DIR alongside a chosen data directory

### DIFF
--- a/docs/paths.md
+++ b/docs/paths.md
@@ -40,7 +40,7 @@ Linux, reached through `wxConfig`.
 | 5 | `configs/` in the current directory | No |
 | 6 | A macOS `.app` bundle: payload inside, data outside | No |
 | 7 | `configs/` in the install prefix or `/usr/share/rpcemu` | No |
-| 8 | `RPCEMU_RESOURCE_DIR` (settles the payload only) | No |
+| 8 | `RPCEMU_RESOURCE_DIR` is set, so data goes to the default location | No |
 | 9 | An existing default location that is already set up | **No** |
 | 10 | Nothing to go on, and a GUI to ask with: **ask** | Yes |
 | 11 | Nothing to go on and no GUI: the default, silently | No |
@@ -125,6 +125,20 @@ directory, not the data directory. So the resource directory follows the
 **payload**, wherever that is, independently of where the user keeps their
 machines: bundle, beside the binary, current directory, install prefix,
 `/usr/share/rpcemu`, and only then the data directory as a last resort.
+
+**`RPCEMU_RESOURCE_DIR` overrides all of that**, whatever the data directory
+turned out to be and whether or not that folder carries a payload of its own. It
+is the way to say where the payload is when it is not where RPCEmu would look,
+and it combines with `--datadir` or `RPCEMU_DATADIR` to place the two
+directories independently:
+
+```
+RPCEMU_DATADIR=~/my-machines RPCEMU_RESOURCE_DIR=/opt/rpcemu rpcemu
+```
+
+Note that row 8 of the table above is a different question — it is about where
+the *data* goes when the variable is the only thing set — and does not limit
+when the payload override applies.
 
 Pointing it at the data directory instead is what broke a real machine: none of
 that payload is in a folder the user picked for their machines, and `poduleroms`

--- a/src/gui/data_paths.cpp
+++ b/src/gui/data_paths.cpp
@@ -81,6 +81,12 @@ static bool HasPayloadDir(const wxString &base)
 /* Where the payload is, independently of where the user keeps their data. */
 static ResourceDirSource g_resource_source = RESOURCE_DIR_SAME_AS_DATA;
 
+/* RPCEMU_RESOURCE_DIR, read once by InitRpcemuPaths(). Empty when unset. It is
+   the answer rather than one of the places searched, so it is held here instead
+   of being an input to data_dir_resource_decide(). */
+static wxString g_env_resource_dir;
+static bool g_env_resource_used = false;
+
 static wxString FindResourceDir(const wxString &bundle_dir, const wxString &exe_dir,
                                 const wxString &cwd, const wxString &install_dir,
                                 const wxString &user_dir)
@@ -130,6 +136,9 @@ static wxString FindResourceDir(const wxString &bundle_dir, const wxString &exe_
  * and the machine came up with no HostFS, no card ROMs and no CMOS template.
  * Then it is looked for wherever it actually is, as for a remembered or default
  * data directory.
+ *
+ * RPCEMU_RESOURCE_DIR outranks even a self-contained tree, and is applied by
+ * InitRpcemuPaths() once the switch has run rather than here.
  */
 static wxString ResourceDirForGivenDataDir(const wxString &bundle_dir,
                                           const wxString &exe_dir,
@@ -213,14 +222,6 @@ static std::string DirPathForCore(const wxString &dir)
 	return std::string(NormalizeDirPath(dir).utf8_str().data());
 }
 
-static void SeedFileIfMissing(const wxString &src, const wxString &dst)
-{
-	if (!wxFileExists(src) || wxFileExists(dst)) {
-		return;
-	}
-	wxCopyFile(src, dst, false);
-}
-
 /* Copy every file under src into dst, but only those not already present, so
  * user-added files are never clobbered on subsequent launches. */
 static void SeedDirIfMissing(const wxString &src, const wxString &dst)
@@ -296,15 +297,8 @@ static bool SeedUserDataDir(const wxString &resource_dir, const wxString &user_d
 	 * index, so a packaged install can boot out of the box. */
 	SeedDirIfMissing(resource + "roms", user_roms);
 
-	const wxString user_netroms = user + "netroms";
-	const wxString resource_netroms = resource + "netroms";
-	if (wxDirExists(resource_netroms)) {
-		if (!wxDir::Make(user_netroms, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL)) {
-			return false;
-		}
-		SeedFileIfMissing(resource_netroms + wxFileName::GetPathSeparator() + "EtherRPCEm,ffa",
-		                  user_netroms + wxFileName::GetPathSeparator() + "EtherRPCEm,ffa");
-	}
+	/* netroms/, poduleroms/, gfxroms/ and usbroms/ are not seeded: they are
+	   loaded from the resource directory, which is not this one. */
 
 	return ConfigPathsEnsureDataLayout();
 }
@@ -380,10 +374,10 @@ void InitRpcemuPaths(const wxString &cli_datadir, DataDirPrompt prompt)
 
 	const DataDirDecision decision = data_dir_decide(&inputs);
 
-	/* RPCEMU_RESOURCE_DIR has no ResourceDirSource of its own - it is not one of
-	   the places that get searched, it is the answer - so the log line says so
-	   from here, as the headless resolver already did. */
-	bool env_resource_used = false;
+	/* Applied after the switch below. Reset as well as set, so a second call in
+	   one process does not inherit the first one's environment. */
+	g_env_resource_dir = env_resource;
+	g_env_resource_used = false;
 
 	switch (decision.source) {
 	/*
@@ -426,7 +420,7 @@ void InitRpcemuPaths(const wxString &cli_datadir, DataDirPrompt prompt)
 	case DATA_DIR_FROM_ENV_RESOURCE:
 		resource_dir = NormalizeDirPath(env_resource);
 		user_dir = UserDataRoot();
-		env_resource_used = true;
+		g_env_resource_used = true;
 		break;
 
 	case DATA_DIR_FROM_BUNDLE:
@@ -485,6 +479,23 @@ void InitRpcemuPaths(const wxString &cli_datadir, DataDirPrompt prompt)
 		break;
 	}
 
+	/*
+	 * RPCEMU_RESOURCE_DIR is the user saying outright where the payload is, so
+	 * it beats every answer above - including the branches that never search
+	 * because their layout already implied one.
+	 *
+	 * Applied here rather than inside the switch because data_dir_decide() only
+	 * reaches its own RPCEMU_RESOURCE_DIR case at rank 8, below --datadir and
+	 * RPCEMU_DATADIR at ranks 1 and 2. Setting the variable alongside either of
+	 * those therefore did nothing at all, and the two are exactly the
+	 * combination somebody needs when their data and their payload are in
+	 * different places.
+	 */
+	if (!g_env_resource_dir.empty()) {
+		resource_dir = NormalizeDirPath(g_env_resource_dir);
+		g_env_resource_used = true;
+	}
+
 	if (decision.should_remember && !user_dir.empty()) {
 		SetDataDir(user_dir.utf8_string());
 	}
@@ -512,8 +523,8 @@ void InitRpcemuPaths(const wxString &cli_datadir, DataDirPrompt prompt)
 	       data_dir_source_name(decision.source),
 	       user_dir.utf8_str().data());
 	rpclog("Paths: resource directory from %s: %s\n",
-	       env_resource_used ? "RPCEMU_RESOURCE_DIR"
-	                         : data_dir_resource_source_name(g_resource_source),
+	       g_env_resource_used ? "RPCEMU_RESOURCE_DIR"
+	                           : data_dir_resource_source_name(g_resource_source),
 	       resource_dir.utf8_str().data());
 
 	if (!SeedUserDataDir(resource_dir, user_dir)) {


### PR DESCRIPTION
Setting RPCEMU_RESOURCE_DIR together with --datadir or RPCEMU_DATADIR did nothing: data_dir_decide() reaches its RPCEMU_RESOURCE_DIR case at rank 8, below those two at ranks 1 and 2, and InitRpcemuPaths() read the variable only from that one branch. The payload was then searched for as if the variable were unset, which is how a run with both set ended up taking its poduleroms/ from the current directory.

That is the combination somebody needs when their machines and the payload are in different places, and it is the one the comment in InitRpcemuPaths() already promised worked. Apply the override once, after the data directory has been decided, so it beats every route to the payload including a data directory carrying its own.

The headless resolver in headless_main.cpp already did exactly this, so the two entry points now agree again.

Also drop the seeding of netroms/EtherRPCEm,ffa into the data directory. It was correct when RPCEMU_DATADIR set both directories at once; since they came apart the copy has been written but never read, and SeedFileIfMissing never overwrites, so a stale copy could shadow the real module if the resource directory ever fell back to the data directory.