### PR TITLE
Keep machine settings that are edited while the machine is running

### DIFF
--- a/src/gui/machine_edit_dialog.cpp
+++ b/src/gui/machine_edit_dialog.cpp
@@ -2430,6 +2430,11 @@ void MachineEditDialog::SaveSettings()
 			}
 		}
 		settings.Write("openbus_ram_kb", ram_kb);
+
+		strncpy(config.openbus_card, name.utf8_str().data(),
+		    sizeof(config.openbus_card) - 1);
+		config.openbus_card[sizeof(config.openbus_card) - 1] = '\0';
+		config.openbus_ram_kb = (ram_kb > 0) ? (unsigned) ram_kb : 0u;
 	}
 
 	settings.Write("gfxcard_enabled",
@@ -2565,6 +2570,7 @@ void MachineEditDialog::ApplySavedSettingsToGlobalConfig(const wxString &rom_dir
 	config.vnc_password_readonly[
 	    sizeof(config.vnc_password_readonly) - 1] = '\0';
 	config.clipboard_enabled = clipboard_check_->GetValue() ? 1 : 0;
+	config.hostcmd_enabled = hostcmd_check_->GetValue() ? 1 : 0;
 	config.json_net_enabled = json_net_check_->GetValue() ? 1 : 0;
 	config.json_net_port = json_net_port_edit_->GetValue();
 	strncpy(config.json_net_host, json_net_host_edit_->GetValue().utf8_str().data(),

--- a/src/gui/machine_edit_dialog.cpp
+++ b/src/gui/machine_edit_dialog.cpp
@@ -2565,6 +2565,11 @@ void MachineEditDialog::ApplySavedSettingsToGlobalConfig(const wxString &rom_dir
 	config.vnc_password_readonly[
 	    sizeof(config.vnc_password_readonly) - 1] = '\0';
 	config.clipboard_enabled = clipboard_check_->GetValue() ? 1 : 0;
+	config.json_net_enabled = json_net_check_->GetValue() ? 1 : 0;
+	config.json_net_port = json_net_port_edit_->GetValue();
+	strncpy(config.json_net_host, json_net_host_edit_->GetValue().utf8_str().data(),
+	    sizeof(config.json_net_host) - 1);
+	config.json_net_host[sizeof(config.json_net_host) - 1] = '\0';
 }
 
 wxString MachineEditDialog::CurrentMachineNameForHd() const


### PR DESCRIPTION
Eenabling or disabling Pyromaniac networking in **Machine Settings →
Network** is not saved if the machine is running. The setting appears to take,
then reverts once the machine stops.

Three more settings turned out to have the same fault.

## The cause

`ApplySavedSettingsToGlobalConfig()` pushes each edited value into the live
`Config` as well as writing it to the machine's configuration file, and the
comment above it already says why:

> A running machine rewrites its whole configuration from memory when it exits.
> Anything set here that was only written to disc would be overwritten by the
> stale in-memory value at that point, so the change would appear to work and
> then quietly undo itself.

That write-back is `config_save(&config)` in `endrpcemu()` (`rpcemu.c:1990`).
The three `json_net_*` fields were written to the file but never into `Config`,
so the stale values went back over them.

The network *type* sitting immediately beside them on the same page is carried
by `config_apply_machine_edit()`, which does not reach these three — which is
why the failure looks arbitrary from the UI: one control on the page saves and
the one next to it does not.

## Auditing the rest

Rather than fix the reported field alone, every key was checked:

1. Every key `SaveSettings()` writes to disc — 33
2. Intersected with the keys `config_save()` writes back from memory — **29 can
   be clobbered**; the other 4 are never rewritten
3. Minus everything the dialog pushes into `Config` by either route
   (`ApplySavedSettingsToGlobalConfig` and `config_apply_machine_edit`) — 5 left
4. Each of those 5 checked against the whole file rather than those two
   functions

Step 4 mattered: `model` and `hostfs_path` are assigned inside `SaveSettings()`
itself and were false positives. Both carry comments describing this same
failure, as does `display_scaling` in `settings.cpp` — it has been fixed
piecemeal three times before.

The three that were genuinely missing:

| Key | Note |
| --- | --- |
| `hostcmd_enabled` | Its partner `hostcmd_socket` is safe only because it happens to go through `write_or_restore()` for command-line overrides |
| `openbus_card` | Written in a scoped block away from the other live-config assignments |
| `openbus_ram_kb` | Same block |

The openbus pair matters most: the dialog tells the user "Changing the second
processor takes effect when this machine next starts", so the value has to
survive the current run to mean anything at all. Setting a second processor on
a running machine was silently discarded on stop.

## Changes

Six lines in `machine_edit_dialog.cpp`, all mirroring what the surrounding code
already does for its own fields. No behaviour change for a machine that is not
running — that path never went through the live struct.

## Testing

Builds clean, 74/74 tests pass. For each of the four: start the machine, change
the setting, OK, stop the machine, reopen Settings — the value now persists
where it previously reverted. Also checked that editing a stopped machine still
behaves as before.
