### PR TITLE
1.x: keep the HostCmd setting when the machine is running

### DIFF
--- a/src/gui/machine_edit_dialog.cpp
+++ b/src/gui/machine_edit_dialog.cpp
@@ -2113,6 +2113,7 @@ void MachineEditDialog::ApplySavedSettingsToGlobalConfig(const wxString &rom_dir
 	config.vnc_password_readonly[
 	    sizeof(config.vnc_password_readonly) - 1] = '\0';
 	config.clipboard_enabled = clipboard_check_->GetValue() ? 1 : 0;
+	config.hostcmd_enabled = hostcmd_check_->GetValue() ? 1 : 0;
 }
 
 wxString MachineEditDialog::CurrentMachineNameForHd() const


### PR DESCRIPTION
Backport of the applicable part of #171 (v2 line) to `1.x`.

Ticking or clearing **Command socket (HostCmd)** in Machine Settings is not
saved if the machine is running. The setting appears to take, then reverts once
the machine stops.

## The cause

`ApplySavedSettingsToGlobalConfig()` pushes each edited value into the live
`Config` as well as writing it to the machine's configuration file, and the
comment above it says why:

> A running machine rewrites its whole configuration from memory when it exits.
> Anything set here that was only written to disc would be overwritten by the
> stale in-memory value at that point, so the change would appear to work and
> then quietly undo itself.

That write-back is `config_save(&config)` in `endrpcemu()`. `hostcmd_enabled`
was written to the file but never into `Config`, so the stale value went back
over it.

The field immediately beside it, `hostcmd_socket`, is safe — but only because
it happens to go through `write_or_restore()` for command-line overrides, not
because anything handles this case.

## Changes

One line, matching what the surrounding code already does for its own fields.
No behaviour change for a machine that is not running — that path never went
through the live struct.

## Testing

Builds clean, 52/52 tests pass. Start the machine, toggle the HostCmd checkbox,
OK, stop the machine, reopen Settings — the value now persists where it
previously reverted. Editing a stopped machine still behaves as before.
