### PR TITLE
Give every machine its own MAC address

### DIFF
--- a/src/gui/config_paths.cpp
+++ b/src/gui/config_paths.cpp
@@ -265,6 +265,13 @@ void ConfigPathsPrepareClonedConfig(const wxString &config_path,
 	ConfigFileUseGeneralGroup(settings);
 	settings.Write("name", new_name);
 
+	/* Cleared so config_load() gives the clone one of its own: two machines
+	   sharing a MAC address is fatal to both the moment they meet, and a clone
+	   is the likeliest pair to end up on one network. */
+	if (settings.HasEntry("macaddress")) {
+		settings.Write("macaddress", wxEmptyString);
+	}
+
 	for (const char *key : own_channel) {
 		if (settings.HasEntry(key)) {
 			settings.Write(key, wxEmptyString);

--- a/src/gui/mac_address_input.h
+++ b/src/gui/mac_address_input.h
@@ -1,0 +1,150 @@
+/*
+  RPCEmu - An Acorn system emulator
+
+  Copyright (C) 2026 Andy Timmins
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifndef MAC_ADDRESS_INPUT_H
+#define MAC_ADDRESS_INPUT_H
+
+#include <cctype>
+#include <cstddef>
+#include <cstdio>
+#include <random>
+#include <string>
+
+/*
+ * The MAC address field's typing rules, apart from wxWidgets so they can be
+ * tested without a window.
+ */
+namespace MacAddressInput {
+
+/** Is this a hex digit, in either case? */
+inline bool IsHexDigit(char c)
+{
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}
+
+/**
+ * Reduce whatever is in the field to the address it describes.
+ *
+ * Everything that is not a hex digit is dropped - including the separators,
+ * which Format() puts back where they belong - so a pasted "06-02-03-04-05-06"
+ * or "060203040506" is accepted as readily as a typed one. Case is preserved
+ * for Format() to settle.
+ */
+inline std::string Digits(const std::string &text)
+{
+	std::string digits;
+
+	for (const char c : text) {
+		if (IsHexDigit(c) && digits.size() < 12) {
+			digits.push_back(c);
+		}
+	}
+	return digits;
+}
+
+/**
+ * Lay hex digits out as an address, colons and all.
+ *
+ * A partial address formats as far as it goes, so the field reads correctly
+ * while it is still being typed.
+ *
+ * `trailing_separator` adds the colon after a complete pair. It is what the
+ * typist gets for pressing ':' themselves: without it that keypress appeared to
+ * do nothing at all - the colon was stripped and only came back when the next
+ * digit arrived - and a field that ignores a key you were right to press reads
+ * as broken rather than as helpful.
+ */
+inline std::string Format(const std::string &digits, bool trailing_separator = false)
+{
+	std::string out;
+
+	for (size_t i = 0; i < digits.size(); i++) {
+		if (i != 0 && (i % 2) == 0) {
+			out.push_back(':');
+		}
+		out.push_back((char) tolower((unsigned char) digits[i]));
+	}
+
+	/* Not after the sixth pair: the address is complete and a seventh could
+	   never follow. */
+	if (trailing_separator && !digits.empty() && (digits.size() % 2) == 0 &&
+	    digits.size() < 12) {
+		out.push_back(':');
+	}
+	return out;
+}
+
+/** Does this text end in a separator the typist put there? */
+inline bool EndsWithSeparator(const std::string &text)
+{
+	if (text.empty()) {
+		return false;
+	}
+
+	const char last = text[text.size() - 1];
+
+	return last == ':' || last == '-' || last == '.' || last == ' ';
+}
+
+/** What the field should read, given what was typed into it. */
+inline std::string Normalise(const std::string &text)
+{
+	return Format(Digits(text), EndsWithSeparator(text));
+}
+
+/** Is this a complete address, ready to be saved? */
+inline bool IsComplete(const std::string &text)
+{
+	return Digits(text).size() == 12;
+}
+
+/**
+ * Make up an address for a machine that has never had one.
+ *
+ * Locally administered and not multicast - bit 1 of the first byte set, bit 0
+ * clear - so it cannot collide with real hardware.
+ *
+ * std::random_device rather than rand(): rand() is the same sequence in every
+ * process unless it is seeded, so every machine on every computer would be
+ * handed one identical address, which is the collision this exists to avoid.
+ * The caller writes the result back to the machine's configuration, since one
+ * generated afresh on every start would change identity on every boot.
+ */
+inline std::string Generate()
+{
+	std::random_device rd;
+	std::uniform_int_distribution<unsigned> byte(0, 255);
+	unsigned char hwaddr[6];
+	char out[18];
+
+	for (unsigned char &b : hwaddr) {
+		b = (unsigned char) byte(rd);
+	}
+	hwaddr[0] = (unsigned char) ((hwaddr[0] | 0x02u) & ~0x01u);
+
+	std::snprintf(out, sizeof(out), "%02x:%02x:%02x:%02x:%02x:%02x",
+	              hwaddr[0], hwaddr[1], hwaddr[2],
+	              hwaddr[3], hwaddr[4], hwaddr[5]);
+	return std::string(out);
+}
+
+} /* namespace MacAddressInput */
+
+#endif /* MAC_ADDRESS_INPUT_H */

--- a/src/gui/machine_edit_dialog.cpp
+++ b/src/gui/machine_edit_dialog.cpp
@@ -55,6 +55,7 @@ extern "C" {
 }
 
 #include "display_options.h"
+#include "mac_address_input.h"
 
 namespace {
 
@@ -999,10 +1000,25 @@ wxWindow *MachineEditDialog::BuildNetworkPage(wxWindow *parent)
 	network_combo_->Append("Off");
 	network_combo_->Append("NAT");
 
+	mac_address_edit_ = new wxTextCtrl(page, wxID_ANY, wxEmptyString);
+	/* The shape of the answer, shown while the field is empty: without it a
+	   plain box gives no clue that the colons arrive on their own. */
+	mac_address_edit_->SetHint("xx:xx:xx:xx:xx:xx");
+	mac_address_edit_->SetToolTip(
+	    "Must be unique to this machine. The colons are added as you type. "
+	    "Leave empty for a new address to be generated.");
+
 	auto *form = new wxFlexGridSizer(2, 8, 8);
 	form->AddGrowableCol(1, 1);
 	form->Add(new wxStaticText(page, wxID_ANY, "Network:"), 0, wxALIGN_CENTER_VERTICAL);
 	form->Add(network_combo_, 1, wxEXPAND);
+	form->Add(new wxStaticText(page, wxID_ANY, "MAC address:"), 0, wxALIGN_CENTER_VERTICAL);
+	form->Add(mac_address_edit_, 1, wxEXPAND);
+
+	/* Corrected as it is typed: colons inserted, a typed separator honoured,
+	   anything that is not a hex digit refused. */
+	mac_address_edit_->Bind(wxEVT_TEXT,
+	    [this](wxCommandEvent &event) { OnMacAddressText(event); });
 
 	auto *note = MakeNote(page,
 	    "NAT needs no configuration of this computer and suits every use: the "
@@ -1057,6 +1073,85 @@ wxWindow *MachineEditDialog::BuildNetworkPage(wxWindow *parent)
 	sizer->Add(json_box, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 10);
 	page->SetSizer(sizer);
 	return page;
+}
+
+/**
+ * Keep the MAC address field in the shape of a MAC address as it is typed.
+ *
+ * The caret is put back where the same number of digits precede it, rather than
+ * at the same offset: inserting a colon in front of it would otherwise leave it
+ * one character behind, and typing the third digit of an address would put the
+ * caret in the middle of the pair the typist had just completed.
+ */
+void MachineEditDialog::OnMacAddressText(wxCommandEvent &event)
+{
+	if (mac_address_edit_ == nullptr || in_mac_address_update_) {
+		return;
+	}
+
+	const wxString before = mac_address_edit_->GetValue();
+	const std::string normalised =
+	    MacAddressInput::Normalise(std::string(before.utf8_str().data()));
+	const wxString after = wxString::FromUTF8(normalised.c_str());
+
+	if (after == before) {
+		event.Skip();
+		return;
+	}
+
+	/* How many digits are to the left of the caret; the caret belongs after
+	   that many digits once the colons have been settled. */
+	const long caret = mac_address_edit_->GetInsertionPoint();
+	size_t digits_before_caret = 0;
+	for (long i = 0; i < caret && i < (long) before.length(); i++) {
+		if (MacAddressInput::IsHexDigit((char) before[i])) {
+			digits_before_caret++;
+		}
+	}
+
+	long new_caret = 0;
+	size_t seen = 0;
+	while (new_caret < (long) after.length() && seen < digits_before_caret) {
+		if (MacAddressInput::IsHexDigit((char) after[new_caret])) {
+			seen++;
+		}
+		new_caret++;
+	}
+
+	/* Past the separator this keystroke just produced, rather than in front of
+	   it: the typist pressed it to finish the pair and the next digit belongs
+	   after it. */
+	while (new_caret < (long) after.length() &&
+	       !MacAddressInput::IsHexDigit((char) after[new_caret]) &&
+	       caret >= (long) before.length()) {
+		new_caret++;
+	}
+
+	in_mac_address_update_ = true;
+	mac_address_edit_->ChangeValue(after);
+	mac_address_edit_->SetInsertionPoint(new_caret);
+	in_mac_address_update_ = false;
+}
+
+/**
+ * The address to save, which is empty unless a whole one was typed.
+ *
+ * A half-finished address is discarded rather than written: it would not parse,
+ * and the machine would fall back to a generated one anyway without saying so.
+ * Empty is a real answer - it asks for a new address to be generated.
+ */
+wxString MachineEditDialog::SelectedMacAddress() const
+{
+	if (mac_address_edit_ == nullptr) {
+		return wxEmptyString;
+	}
+
+	const std::string text(mac_address_edit_->GetValue().utf8_str().data());
+
+	if (!MacAddressInput::IsComplete(text)) {
+		return wxEmptyString;
+	}
+	return wxString::FromUTF8(MacAddressInput::Normalise(text).c_str());
 }
 
 /** Grey the server fields when the machine is not joining one. */
@@ -2265,6 +2360,16 @@ void MachineEditDialog::LoadSettings()
 	}
 
 	{
+		wxString mac;
+
+		/* Absent and empty are the same thing here: both mean this machine has
+		   not been given an address yet. */
+		settings.Read("macaddress", &mac, wxEmptyString);
+		mac_address_edit_->ChangeValue(wxString::FromUTF8(
+		    MacAddressInput::Normalise(std::string(mac.utf8_str().data())).c_str()));
+	}
+
+	{
 		long json_on = 0, json_port = 33445;
 		wxString json_host;
 
@@ -2492,6 +2597,7 @@ void MachineEditDialog::SaveSettings()
 
 	settings.Write("refresh_rate", refresh_slider_->GetValue());
 	settings.Write("network_type", network_type);
+	settings.Write("macaddress", SelectedMacAddress());
 	settings.Write("json_net_enabled",
 	    static_cast<long>(json_net_check_->GetValue() ? 1 : 0));
 	settings.Write("json_net_host", json_net_host_edit_->GetValue());
@@ -2571,6 +2677,14 @@ void MachineEditDialog::ApplySavedSettingsToGlobalConfig(const wxString &rom_dir
 	    sizeof(config.vnc_password_readonly) - 1] = '\0';
 	config.clipboard_enabled = clipboard_check_->GetValue() ? 1 : 0;
 	config.hostcmd_enabled = hostcmd_check_->GetValue() ? 1 : 0;
+	{
+		const wxString mac = SelectedMacAddress();
+
+		if (!mac.empty()) {
+			free(config.macaddress);
+			config.macaddress = strdup(mac.utf8_str().data());
+		}
+	}
 	config.json_net_enabled = json_net_check_->GetValue() ? 1 : 0;
 	config.json_net_port = json_net_port_edit_->GetValue();
 	strncpy(config.json_net_host, json_net_host_edit_->GetValue().utf8_str().data(),

--- a/src/gui/machine_edit_dialog.h
+++ b/src/gui/machine_edit_dialog.h
@@ -79,6 +79,8 @@ private:
 	wxWindow *BuildOptionsPage(wxWindow *parent);
 	wxWindow *BuildNetworkPage(wxWindow *parent);
 	void UpdateJsonNetEnabled();
+	void OnMacAddressText(wxCommandEvent &event);
+	wxString SelectedMacAddress() const;
 	wxWindow *BuildDrivesPage(wxWindow *parent);
 	wxWindow *BuildPodulesPage(wxWindow *parent);
 	wxWindow *BuildCoProcessorPage(wxWindow *parent);
@@ -222,6 +224,10 @@ private:
 	wxSlider *refresh_slider_ = nullptr;
 	wxStaticText *refresh_label_ = nullptr;
 	wxComboBox *network_combo_ = nullptr;
+	wxTextCtrl *mac_address_edit_ = nullptr;
+	/* Set while the field is being rewritten, so the change that causes does
+	   not come back round as another edit to correct. */
+	bool in_mac_address_update_ = false;
 	/* Pyromaniac Networking: the JSON tun/tap server this machine joins. */
 	wxCheckBox *json_net_check_ = nullptr;
 	wxStaticText *json_net_host_label_ = nullptr;

--- a/src/gui/settings.cpp
+++ b/src/gui/settings.cpp
@@ -36,6 +36,7 @@ extern "C" {
 #include <wx/arrstr.h>
 
 #include "display_options.h"
+#include "mac_address_input.h"
 
 static char current_config_path[512] = "";
 
@@ -498,6 +499,7 @@ extern "C" void config_load_from_path(Config *cfg, const char *path)
 	}
 
 	wxString sText;
+	bool macaddress_generated = false;
 	settings.Read("name", &sText, wxEmptyString);
 	if (snprintf(cfg->name, sizeof(cfg->name), "%s", sText.utf8_str().data()) >= (int) sizeof(cfg->name)) {
 		rpclog("config_load: name too long - truncated\n");
@@ -656,7 +658,15 @@ extern "C" void config_load_from_path(Config *cfg, const char *path)
 		cfg->network_type = NetworkType_Off;
 	}
 
+	/* A machine that has never had a MAC address is given one now, and it is
+	   written straight back so it stays that machine's address. */
 	settings.Read("macaddress", &sText, wxEmptyString);
+	if (sText.empty()) {
+		sText = wxString::FromUTF8(MacAddressInput::Generate().c_str());
+		macaddress_generated = true;
+		rpclog("Networking: this machine had no MAC address, so it has been "
+		       "given %s\n", sText.utf8_str().data());
+	}
 	config_replace_strdup(&cfg->macaddress, sText);
 
 	settings.Read("cpu_idle", &value, 0L);
@@ -847,6 +857,19 @@ extern "C" void config_load_from_path(Config *cfg, const char *path)
 	   can say. Nothing migrates a machine's keys into the app settings file any
 	   more - config_save() writes them back where they came from. */
 	app_settings_apply_overrides(cfg);
+
+	/* The one key, not config_save(): the overrides above are in cfg now, and
+	   saving the whole structure would record them as the user's own. The group
+	   is set again first - podule_config_load() above leaves the path in its
+	   own group, and the key would be written there instead. */
+	if (macaddress_generated && cfg->macaddress != NULL) {
+		ConfigFileUseGeneralGroup(settings);
+		settings.Write("macaddress", wxString(cfg->macaddress, wxConvUTF8));
+		if (!settings.Flush()) {
+			rpclog("Networking: could not record the new MAC address; this "
+			       "machine will be given a different one next time\n");
+		}
+	}
 
 	machine_config_loaded = true;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -900,6 +900,15 @@ target_link_libraries(test_clone_config PRIVATE rpcemu_core m)
 rpcemu_setup_wxwidgets(test_clone_config)
 rpcemu_add_test(test_clone_config)
 
+# The MAC address field's typing rules and the generator behind them. No wx:
+# mac_address_input.h is deliberately free of it so it can be tested like this.
+add_executable(test_mac_address test_mac_address.cpp test_stubs.c)
+target_include_directories(test_mac_address PRIVATE
+                           ${CMAKE_CURRENT_SOURCE_DIR}/../src
+                           ${CMAKE_CURRENT_SOURCE_DIR}/../src/gui)
+target_link_libraries(test_mac_address PRIVATE rpcemu_core m)
+rpcemu_add_test(test_mac_address)
+
 add_executable(test_net_slot test_net_slot.c)
 target_include_directories(test_net_slot PRIVATE
                            ${CMAKE_CURRENT_SOURCE_DIR}/../src)
@@ -992,7 +1001,7 @@ rpcemu_add_test(test_unzip)
 #
 # Raise RPCEMU_EXPECTED_TESTS when adding a test. If that feels like a chore, it
 # is the only line in the file that cannot go stale without being noticed.
-set(RPCEMU_EXPECTED_TESTS 63)	# tests that build on every platform
+set(RPCEMU_EXPECTED_TESTS 64)	# tests that build on every platform
 if(RPCEMU_JIT_TESTS)
     math(EXPR RPCEMU_EXPECTED_TESTS "${RPCEMU_EXPECTED_TESTS} + 10")	# JIT differential
 endif()

--- a/tests/test_clone_config.cpp
+++ b/tests/test_clone_config.cpp
@@ -85,6 +85,7 @@ main(int argc, char **argv)
 		settings.Write("hostfs_path", src_dir + "/hostfs");
 		settings.Write("hd4_path", src_dir + "/hd4.hdf");
 		settings.Write("cdrom_iso", "/srv/media/riscos.iso");
+		settings.Write("macaddress", "06:02:03:04:05:06");
 		settings.Write("mem_size", 512L);
 		settings.Flush();
 	}
@@ -104,6 +105,10 @@ main(int argc, char **argv)
 	    read_key(cfg, "netcap_socket").empty());
 
 	/* Write targets: two machines appending to one file is never intended. */
+	/* Two machines with one address stop each other working the moment they
+	   meet, and a clone is the likeliest pair to end up on one network. */
+	check("the MAC address is not inherited",
+	    read_key(cfg, "macaddress") == "");
 	check("the capture file is not inherited",
 	    read_key(cfg, "network_capture").empty());
 	check("the serial log is not inherited",

--- a/tests/test_mac_address.cpp
+++ b/tests/test_mac_address.cpp
@@ -1,0 +1,170 @@
+/*
+  RPCEmu - An Acorn system emulator
+
+  Copyright (C) 2026 Andy Timmins
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+/*
+ * The MAC address field's typing rules, and the generator that fills it in for
+ * a machine that has never had an address.
+ */
+
+#include <cstdio>
+#include <cstring>
+#include <set>
+#include <string>
+
+#include "mac_address_input.h"
+
+extern "C" {
+#include "network.h"
+}
+
+static int failures = 0;
+
+static void
+check(const char *what, bool ok)
+{
+	std::printf("%s: %s\n", ok ? "ok" : "FAIL", what);
+	if (!ok) {
+		failures++;
+	}
+}
+
+int
+main(void)
+{
+	using namespace MacAddressInput;
+
+	std::printf("typing an address\n");
+	check("a complete address is left as it is",
+	    Normalise("06:02:03:04:05:06") == "06:02:03:04:05:06");
+	check("colons are inserted as the digits arrive",
+	    Normalise("060203") == "06:02:03");
+	check("a lone digit stands on its own",
+	    Normalise("0") == "0");
+	check("no trailing colon after a complete pair",
+	    Normalise("0602") == "06:02");
+
+	/*
+	 * ★ Pressing ':' must visibly do something.
+	 *
+	 * It used to be stripped and only reappear when the next digit arrived, so
+	 * the keypress looked ignored and the field looked broken - the one thing a
+	 * typist is most likely to try.
+	 */
+	std::printf("typing a separator\n");
+	check("a colon after a pair is kept",
+	    Normalise("06:") == "06:");
+	check("so is a hyphen",
+	    Normalise("06-") == "06:");
+	check("and it is not doubled when the next digit arrives",
+	    Normalise("06:0") == "06:0");
+	check("a colon mid-pair waits for the pair to finish",
+	    Normalise("0:") == "0");
+	check("no seventh separator after a complete address",
+	    Normalise("06:02:03:04:05:06:") == "06:02:03:04:05:06");
+	check("a trailing separator still counts as complete",
+	    IsComplete("06:02:03:04:05:06:"));
+
+	std::printf("what the field refuses\n");
+	check("letters beyond f are dropped",
+	    Normalise("zz06gg02") == "06:02");
+	check("spaces and punctuation are dropped",
+	    Normalise("06 02-03") == "06:02:03");
+	check("more than six pairs cannot be typed",
+	    Normalise("060203040506070809") == "06:02:03:04:05:06");
+
+	std::printf("case\n");
+	check("upper case is folded to lower, matching the generator",
+	    Normalise("AA:BB:CC:DD:EE:FF") == "aa:bb:cc:dd:ee:ff");
+	check("mixed case likewise",
+	    Normalise("aA:Bb:cC:Dd:eE:Ff") == "aa:bb:cc:dd:ee:ff");
+
+	std::printf("other separators, as pasted\n");
+	check("hyphens are accepted",
+	    Normalise("06-02-03-04-05-06") == "06:02:03:04:05:06");
+	check("no separator at all is accepted",
+	    Normalise("060203040506") == "06:02:03:04:05:06");
+
+	std::printf("completeness\n");
+	check("a whole address is complete", IsComplete("06:02:03:04:05:06"));
+	check("a partial address is not", !IsComplete("06:02:03"));
+	check("an empty field is not", !IsComplete(""));
+	check("eleven digits are not enough", !IsComplete("06:02:03:04:05:0"));
+
+	std::printf("a generated address\n");
+	{
+		const std::string generated = Generate();
+		uint8_t parsed[6];
+
+		check("is 17 characters", generated.size() == 17);
+		check("parses as a MAC address",
+		    network_macaddress_parse(generated.c_str(), parsed) == 1);
+		/*
+		 * Bit 1 of the first byte set and bit 0 clear: the range set aside for
+		 * addresses nobody registered, which cannot collide with real hardware.
+		 * A multicast address (bit 0) would be accepted by the parser and then
+		 * behave very strangely as a source address.
+		 */
+		check("is locally administered", (parsed[0] & 0x02) != 0);
+		check("is not multicast", (parsed[0] & 0x01) == 0);
+		check("reads back as it was written",
+		    Normalise(generated) == generated);
+	}
+
+	{
+		/*
+		 * ★ The addresses must differ, and this is the check that would have
+		 * caught the first version: it used an unseeded rand(), so every machine
+		 * on every computer was handed one identical address - exactly the
+		 * collision the whole feature exists to prevent.
+		 */
+		std::set<std::string> seen;
+		bool all_local = true;
+		bool all_unicast = true;
+		bool all_parse = true;
+
+		for (int i = 0; i < 1000; i++) {
+			const std::string mac = Generate();
+			uint8_t bytes[6];
+
+			seen.insert(mac);
+			if (network_macaddress_parse(mac.c_str(), bytes) != 1) {
+				all_parse = false;
+				continue;
+			}
+			if ((bytes[0] & 0x02) == 0) {
+				all_local = false;
+			}
+			if ((bytes[0] & 0x01) != 0) {
+				all_unicast = false;
+			}
+		}
+		check("1000 generated addresses are all different", seen.size() == 1000);
+		check("every one parses", all_parse);
+		check("every one is locally administered", all_local);
+		check("every one is unicast", all_unicast);
+	}
+
+	if (failures != 0) {
+		std::printf("\n%d check(s) failed\n", failures);
+		return 1;
+	}
+	std::printf("\nall checks passed\n");
+	return 0;
+}


### PR DESCRIPTION
Two machines that can see each other need different Ethernet addresses; two
sharing one stops both working.

## The bug this started from

RPCEmu derives a machine's MAC address from a slot claimed by **binding a TCP
port on `INADDR_LOOPBACK`** (`net_slot.c`), then uses `0x06 + slot` as the last
byte (`network-nat.c:217`). That is unique among machines on one computer, and
**identical on two different computers** — 127.0.0.1 is not shared between
hosts, so each machine binds its own and every one of them takes slot 0.

Connecting two hosts is exactly what Pyromaniac networking is for. Two machines
on one JSON tun/tap server, one on Linux and one on Windows, both came up as
`06:02:03:04:05:06`, and neither worked. Nothing in the log said why: the
`net_slot:` line is only printed for slot > 0, so both were silently slot 0.

The generator's own comment already knew the risk — *"two machines with one MAC
address on one network is fatal to both"* — it just had no way to detect an
instance on another host.

## What this adds

**A generated address.** A machine whose configuration has no `macaddress` —
the key absent, or present but empty — is given a random locally administered
one when it starts, and it is written straight back so it stays that machine's
address. This happens in `config_load()`, so every way of starting a machine
gets it: the Manager, the selector, `--machine`, and headless alike.

Written at load rather than at exit, so a machine that crashes on its first boot
keeps the address it booted with rather than getting a different one next time.
It writes the single key with `Flush()` rather than calling `config_save()`,
which would record any command-line override as though the user had chosen it.

**A field to set it by hand**, on the Network tab, for the case where an address
has to match something in particular. It formats as it is typed — colons
inserted, case folded to match the generator, anything that is not a hex digit
refused — and accepts a pasted address with hyphens or no separators at all.
Clearing it asks for a new address to be generated. A half-typed address is
discarded rather than saved, since it would not parse and the machine would
silently generate one instead.

Both entry points share `MachineEditDialog`, so Machine and Managed get the
field together.

**Changing it earns the restart prompt** with no new code: `MachineNeedsRestart()`
already compares `macaddress` by value.

**A clone gets its own.** The address is cleared alongside the other
per-machine identity keys in `ConfigPathsPrepareClonedConfig()` — a clone being
the likeliest pair to end up on one network.

## Two bugs found while building it

Both were caught by running the thing, not by reading it.

**An unseeded `rand()`** gave *every* machine on *every* computer one identical
address — precisely the collision the feature exists to prevent. Now
`std::random_device`. `test_mac_address.cpp` checks that 1000 generated
addresses are distinct, locally administered and unicast, which is the check
that would have caught it.

**The write-back landed in the wrong config group.** `podule_config_load()`
leaves the path in its own group, so the key was written under `[PoduleConfig]`.
Fixed by setting the group again before writing.

## On the field being confusing

The first version stripped a typed `:` and only produced one when the *third*
digit arrived — so pressing colon appeared to do nothing, and the field read as
broken. A typed separator is now honoured, and the field carries an
`xx:xx:xx:xx:xx:xx` hint so its shape is visible before anything is typed.

## Testing

Builds clean with no new warnings; 75/75 tests pass.

`tests/test_mac_address.cpp` is new — 26 checks over the typing rules and the
generator, with no wxWidgets, so it runs on every platform.
`mac_address_input.h` is deliberately free of wx for that reason.
`test_clone_config.cpp` gains a check that the address is not inherited.

Exercised by hand: a config with no `macaddress` key and one with an empty
`macaddress=` both acquire an address on first start and keep it on the second;
`--machine` behaves the same as the Manager.

## Deliberately not done

**Existing machines keep the address they have.** A machine with a
slot-derived `macaddress` already in its configuration is left alone; only an
absent or empty one is filled in. Migrating them would change the MAC of every
machine anyone already has, which is not this change's call to make.
