### PR TITLE
Reconnect to the JSON server rather than giving up

### DIFF
--- a/src/gui/machine_edit_dialog.cpp
+++ b/src/gui/machine_edit_dialog.cpp
@@ -1035,12 +1035,14 @@ wxWindow *MachineEditDialog::BuildNetworkPage(wxWindow *parent)
 	json_form->Add(json_net_port_edit_, 0);
 
 	auto *json_note = MakeNote(json_parent,
-	    "Frames are carried to and from a tun/tap JSON server, so this machine "
-	    "shares one virtual network with every other emulator connected to it, "
-	    "RISC OS Pyromaniac included. The server can run on another computer, "
-	    "which is the point: it need not be this one. While this is on, the "
-	    "machine does not use the local wire between machines here - both carry "
-	    "every frame, and being on both would deliver everything twice. "
+	    "This machine shares one virtual network with every other emulator "
+	    "connected to the same server, RISC OS Pyromaniac included. The server "
+	    "can be on another computer, which is the point: machines on different "
+	    "computers can reach each other.\n\n"
+	    "While this is on, the server REPLACES the direct link to other "
+	    "machines started on this computer. Those machines can no longer "
+	    "be reached unless they are on this server too. NAT is unaffected: the "
+	    "machine still reaches the outside world exactly as before.\n\n"
 	    "Addresses are not handled for you: anything sharing this network needs "
 	    "an address on it that does not collide.");
 

--- a/src/net_json.c
+++ b/src/net_json.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "socket-compat.h"
 
@@ -44,7 +45,20 @@
    loop running instead of the emulator. */
 #define NET_JSON_POLL_MAX	64
 
+/* Longer when the server has never answered - usually one that is not running
+   yet - and shorter after a working one went away, which is more often a
+   restart than a decision. */
+#define NET_JSON_RETRY_COLD_SECONDS	10
+#define NET_JSON_RETRY_WARM_SECONDS	5
+
 static int json_fd = -1;
+
+/* Retrying, so a machine started before its server, or left running across a
+   server restart, joins the network by itself. */
+static int json_want_connection;	/* configured for a server at startup */
+static int json_ever_connected;		/* which of the two intervals applies */
+static time_t json_next_attempt;
+static int json_failure_logged;		/* so it is said once, not every attempt */
 
 /* Partial line left over from the last read: TCP gives no message boundaries,
    so a frame can arrive in pieces or several can arrive together. */
@@ -299,17 +313,31 @@ net_json_is_connected(void)
 }
 
 int
-net_json_init(void)
+net_json_wants_connection(void)
+{
+	return json_want_connection;
+}
+
+/** Arrange for the next attempt, at whichever interval now applies. */
+static void
+net_json_schedule_retry(void)
+{
+	json_next_attempt = time(NULL) +
+	    (json_ever_connected ? NET_JSON_RETRY_WARM_SECONDS
+	                         : NET_JSON_RETRY_COLD_SECONDS);
+}
+
+/**
+ * One attempt at the server.
+ *
+ * @return 0 if the connection is up
+ */
+static int
+net_json_try_connect(void)
 {
 	struct addrinfo hints;
 	struct addrinfo *res = NULL, *rp;
 	char port[16];
-
-	net_json_close();
-
-	if (!config.json_net_enabled || config.json_net_host[0] == '\0') {
-		return -1;
-	}
 
 	snprintf(port, sizeof(port), "%d",
 	    config.json_net_port > 0 ? config.json_net_port : 33445);
@@ -319,8 +347,12 @@ net_json_init(void)
 	hints.ai_socktype = SOCK_STREAM;
 
 	if (getaddrinfo(config.json_net_host, port, &hints, &res) != 0) {
-		rpclog("net_json: cannot resolve %s:%s, this machine is not on that "
-		       "network\n", config.json_net_host, port);
+		if (!json_failure_logged) {
+			rpclog("net_json: cannot resolve %s:%s, retrying every %d "
+			       "seconds\n", config.json_net_host, port,
+			    NET_JSON_RETRY_COLD_SECONDS);
+			json_failure_logged = 1;
+		}
 		return -1;
 	}
 
@@ -338,17 +370,79 @@ net_json_init(void)
 	freeaddrinfo(res);
 
 	if (json_fd < 0) {
-		rpclog("net_json: cannot reach %s:%s, this machine is not on that "
-		       "network\n", config.json_net_host, port);
+		if (!json_failure_logged) {
+			rpclog("net_json: cannot reach %s:%s, retrying every %d "
+			       "seconds\n", config.json_net_host, port,
+			    json_ever_connected ? NET_JSON_RETRY_WARM_SECONDS
+			                        : NET_JSON_RETRY_COLD_SECONDS);
+			json_failure_logged = 1;
+		}
 		return -1;
 	}
 
 	socket_set_nonblocking(json_fd);
+	/* One frame per line, each written on its own: Nagle would hold each back
+	   waiting for company and add its delay to every frame on the wire. */
+	socket_set_nodelay(json_fd);
 	json_in_len = 0;
 
-	rpclog("net_json: on %s:%s; frames go there rather than to the loopback "
-	       "wire\n", config.json_net_host, port);
+	if (json_ever_connected) {
+		rpclog("net_json: reconnected to %s:%s\n", config.json_net_host, port);
+	} else {
+		rpclog("net_json: on %s:%s; frames go there rather than to the "
+		       "loopback wire\n", config.json_net_host, port);
+	}
+	json_ever_connected = 1;
+	json_failure_logged = 0;
 	return 0;
+}
+
+int
+net_json_init(void)
+{
+	net_json_close();
+
+	json_want_connection = 0;
+	json_ever_connected = 0;
+	json_failure_logged = 0;
+	json_next_attempt = 0;
+
+	if (!config.json_net_enabled || config.json_net_host[0] == '\0') {
+		return -1;
+	}
+
+	/*
+	 * From here this machine belongs to the JSON wire whether or not the server
+	 * answers, so the caller must not put it on the loopback wire instead: the
+	 * two are alternatives, and a machine on both receives every frame twice.
+	 * A first attempt that fails is therefore still success as far as the
+	 * caller is concerned - net_json_poll() keeps trying.
+	 */
+	json_want_connection = 1;
+
+	rpclog("net_json: this machine is on the %s:%d server's network; the "
+	       "direct link to machines started on this computer is off, and they "
+	       "are unreachable unless they are on that server too. NAT is "
+	       "unaffected.\n",
+	    config.json_net_host,
+	    config.json_net_port > 0 ? config.json_net_port : 33445);
+
+	if (net_json_try_connect() != 0) {
+		net_json_schedule_retry();
+	}
+	return 0;
+}
+
+/** Give up the connection, but keep wanting one. */
+static void
+net_json_drop(void)
+{
+	if (json_fd >= 0) {
+		closesocket(json_fd);
+		json_fd = -1;
+	}
+	json_in_len = 0;
+	net_json_schedule_retry();
 }
 
 void
@@ -359,6 +453,7 @@ net_json_close(void)
 		json_fd = -1;
 	}
 	json_in_len = 0;
+	json_want_connection = 0;
 }
 
 void
@@ -395,9 +490,9 @@ net_json_tx(const uint8_t *frame, int frame_len)
 		              sock_errno() == SOCK_EINTR)) {
 			continue;
 		}
-		rpclog("net_json: the server has gone; this machine is off that "
-		       "network\n");
-		net_json_close();
+		rpclog("net_json: the server has gone; retrying every %d seconds\n",
+		    NET_JSON_RETRY_WARM_SECONDS);
+		net_json_drop();
 		return;
 	}
 }
@@ -410,6 +505,13 @@ net_json_poll(void)
 	int lines = 0;
 
 	if (json_fd < 0) {
+		/* Waiting for a server to answer. Nothing is logged per attempt: the
+		   one failure message has already been written. */
+		if (json_want_connection && time(NULL) >= json_next_attempt) {
+			if (net_json_try_connect() != 0) {
+				net_json_schedule_retry();
+			}
+		}
 		return 0;
 	}
 
@@ -424,8 +526,10 @@ net_json_poll(void)
 			if (n > 0) {
 				json_in_len += (size_t) n;
 			} else if (n == 0) {
-				rpclog("net_json: the server closed the connection\n");
-				net_json_close();
+				rpclog("net_json: the server closed the connection; "
+				       "retrying every %d seconds\n",
+				    NET_JSON_RETRY_WARM_SECONDS);
+				net_json_drop();
 				return delivered;
 			}
 		}

--- a/src/net_json.h
+++ b/src/net_json.h
@@ -40,7 +40,14 @@
  * Both are hubs. An instance on both would send each frame to its loopback
  * peers AND to the server, which replicates it to the same peers if they are
  * also connected, and every frame would arrive twice. So a machine configured
- * with a server uses that and nothing else; network-nat.c enforces it.
+ * with a server uses that as its ONLY machine-to-machine wire, and machines
+ * started on this computer are unreachable unless they are on the same server;
+ * network-nat.c enforces it, from net_json_wants_connection() rather than from
+ * whether the server is currently answering.
+ *
+ * This is the local wire only. NAT is untouched - slirp_input() is called for
+ * every frame whatever wire it went to - so the machine reaches the outside
+ * world exactly as it would otherwise.
  *
  * WIRE FORMAT. One JSON object per line, and the Ethernet header is taken
  * apart rather than sent whole:
@@ -75,15 +82,16 @@ extern "C" {
  *
  * Does nothing and reports failure when the machine has no server configured,
  * which is how network-nat.c decides whether to use the loopback wire instead.
- * A server that is configured but cannot be reached is reported and the machine
- * carries on without it.
+ * A server that is configured but cannot be reached is reported, and
+ * net_json_poll() keeps trying for it.
  *
- * @return 0 if connected, -1 otherwise
+ * @return 0 if this machine is on the JSON wire, connected or waiting to be;
+ *         -1 if no server is configured
  */
 extern int net_json_init(void);
 
 /**
- * Disconnect and release the socket.
+ * Disconnect, release the socket, and stop wanting a connection.
  */
 extern void net_json_close(void);
 
@@ -93,6 +101,17 @@ extern void net_json_close(void);
  * @return 1 if connected, 0 if not
  */
 extern int net_json_is_connected(void);
+
+/**
+ * Whether this machine belongs to a JSON server, connected or not.
+ *
+ * The two wires are alternatives, so a machine waiting for its server must not
+ * be put on the loopback wire in the meantime: it would be on both when the
+ * server came back and receive every frame twice.
+ *
+ * @return 1 if a server is configured for this machine
+ */
+extern int net_json_wants_connection(void);
 
 /**
  * Send a frame the guest has transmitted.

--- a/src/network-nat.c
+++ b/src/network-nat.c
@@ -299,7 +299,9 @@ network_nat_init(void)
 	 * hubs that flood every frame. A machine on both would send each frame to
 	 * its local peers and to the server, which replicates it to those same
 	 * peers if they are connected too, and everything would arrive twice. So a
-	 * machine that names a server uses it, and the loopback wire stays off.
+	 * machine that names a server uses it, and the loopback wire stays off -
+	 * including while that server is unreachable and being retried, which is
+	 * why this asks whether one is configured rather than whether it answered.
 	 */
 	if (net_json_init() != 0) {
 		net_switch_init();
@@ -334,7 +336,8 @@ network_nat_reset(void)
 static void
 poll_local_wire(void)
 {
-	if (net_json_is_connected()) {
+	/* Polled while disconnected too: that is what retries the server. */
+	if (net_json_wants_connection()) {
 		net_json_poll();
 	} else {
 		net_switch_poll();
@@ -513,8 +516,13 @@ network_nat_tx(uint32_t errbuf, uint32_t mbufs, uint32_t dest, uint32_t src, uin
 	 * arp_input() in slirp/slirp.c), so it does not answer for another guest
 	 * and cannot hijack a conversation between two of them.
 	 */
-	if (net_json_is_connected()) {
-		net_json_tx(nat.tx_buffer, packet_length);
+	/* Dropped rather than sent to the loopback wire while the server is away:
+	   this machine is not on that wire, and the frame would reach machines
+	   that are not its peers. */
+	if (net_json_wants_connection()) {
+		if (net_json_is_connected()) {
+			net_json_tx(nat.tx_buffer, packet_length);
+		}
 	} else {
 		net_switch_tx(nat.tx_buffer, packet_length);
 	}

--- a/tests/test_net_json.c
+++ b/tests/test_net_json.c
@@ -21,6 +21,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "socket-compat.h"
+
 #include "net_json.h"
 
 #include "rpcemu.h"
@@ -211,13 +213,117 @@ test_whitespace(void)
 	        "\"src\": [1,2,3,4,5,6], \"frame_type\": 2048}", out, sizeof(out)) == 19);
 }
 
+/*
+ * Reconnecting.
+ *
+ * A machine used to give up for good the moment the server was unavailable, so
+ * one started before its server, or left running across a server restart, was
+ * off the network until somebody restarted it.
+ *
+ * A real listening socket rather than a mock: what is under test is the
+ * connect/close/reconnect sequence against a real TCP stack, and the retry
+ * interval is deliberately not waited out - the point is that the attempt is
+ * made at all, and that the machine stays on the JSON wire while it waits.
+ */
+static int
+open_listener(unsigned short *port_out)
+{
+	struct sockaddr_in addr;
+	socklen_t len = sizeof(addr);
+	int fd = (int) socket(AF_INET, SOCK_STREAM, 0);
+
+	if (fd < 0) {
+		return -1;
+	}
+	memset(&addr, 0, sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	addr.sin_port = 0;	/* any free port */
+
+	if (bind(fd, (struct sockaddr *) &addr, sizeof(addr)) != 0 ||
+	    listen(fd, 4) != 0 ||
+	    getsockname(fd, (struct sockaddr *) &addr, &len) != 0) {
+		closesocket(fd);
+		return -1;
+	}
+	*port_out = ntohs(addr.sin_port);
+	return fd;
+}
+
+static void
+test_reconnect(void)
+{
+	unsigned short port = 0;
+	int listener;
+
+	printf("reconnecting\n");
+
+	listener = open_listener(&port);
+	if (listener < 0) {
+		check("a listening socket could be opened", 0);
+		return;
+	}
+
+	/* A server that is not there: the port is one nothing is listening on,
+	   which is the machine-started-before-its-server case. */
+	closesocket(listener);
+
+	config.json_net_enabled = 1;
+	snprintf(config.json_net_host, sizeof(config.json_net_host), "127.0.0.1");
+	config.json_net_port = (int) port;
+
+	check("init succeeds even though the server is not there",
+	    net_json_init() == 0);
+	check("and the machine is not connected", !net_json_is_connected());
+	/* ★ The point of the whole change: not connected, but still on this wire,
+	   so network-nat.c must not put it on the loopback wire instead. */
+	check("but it does still want the connection", net_json_wants_connection());
+
+	/* The server appears. Reopening the same port is what a server restart
+	   looks like from here. */
+	listener = open_listener(&port);
+	if (listener < 0) {
+		check("the listener could be reopened", 0);
+		return;
+	}
+	config.json_net_port = (int) port;
+
+	/* The retry is due immediately after a failed init only once the interval
+	   has passed, so this drives the attempt directly rather than sleeping. */
+	check("a fresh init connects once the server is up",
+	    net_json_init() == 0 && net_json_is_connected());
+
+	/* The server goes away underneath a working connection. */
+	closesocket(listener);
+	net_json_close();
+	check("closing gives up the connection", !net_json_is_connected());
+	check("and stops wanting one", !net_json_wants_connection());
+
+	config.json_net_enabled = 0;
+	config.json_net_host[0] = '\0';
+	check("no server configured is not wanting one",
+	    net_json_init() == -1 && !net_json_wants_connection());
+}
+
 int
 main(void)
 {
+#ifdef _WIN32
+	/* Sockets do nothing at all before this on Windows, and net_json.c is
+	   normally reached long after rpcemu.c has done it. */
+	WSADATA wsadata;
+
+	if (WSAStartup(MAKEWORD(2, 2), &wsadata) != 0) {
+		printf("FAIL: WSAStartup\n");
+		return 1;
+	}
+#endif
+
 	test_encoding();
 	test_round_trip();
 	test_bad_input();
 	test_whitespace();
+	test_reconnect();
 
 	printf("\n%s\n", failures ? "FAILED" : "All tests passed");
 	return failures != 0;

--- a/tests/test_net_tx.c
+++ b/tests/test_net_tx.c
@@ -131,9 +131,10 @@ int broadcast_relay_tx(const uint8_t *pkt, int pkt_len) { (void) pkt; (void) pkt
 /* The hub that carries frames to other emulators on this host. Stubbed rather
    than linked so the test opens no sockets: what is under test is the bounds
    on the mbuf walk, and a frame that reaches the hub has already passed them.
-   net_json_is_connected() answers no, so the switch is the branch taken - the
-   same one an ordinary machine uses. */
+   net_json_wants_connection() answers no, so the switch is the branch taken -
+   the same one an ordinary machine uses. */
 int  net_json_is_connected(void) { return 0; }
+int  net_json_wants_connection(void) { return 0; }
 void net_json_tx(const uint8_t *frame, int frame_len) { (void) frame; (void) frame_len; }
 int  net_json_init(void) { return -1; }
 void net_json_close(void) { }


### PR DESCRIPTION
A machine that could not reach its JSON tun/tap server never tried again. It had
to be restarted — awkward when the server is on another computer, and awkward
when the machine was simply started first. A server that went away mid-session
was worse: the connection was closed, nothing retried it, and the machine was
off that network for good with one line in the log to say so.

## Retrying

`net_json_poll()` now retries:

| | Interval |
| --- | --- |
| The server has never answered | **10 seconds** |
| A working connection was lost | **5 seconds** |

Ten for the cold case because that is usually a server not running yet or a host
name that is wrong, and there is no point asking every few seconds. Five for the
warm one because a server that was working and went away is more often a restart
than a decision.

Connecting, losing the connection and reconnecting are each logged once. The
attempts in between are not — a machine left overnight against a server that
never comes back should not fill its log.

Verified by driving `poll()` against a server that appears and disappears:

```
t=0   no server   → "cannot reach 127.0.0.1:33499, retrying every 10 seconds"
t=10  server up   → "on 127.0.0.1:33499; frames go there..."
t=13  server gone → "the server closed the connection; retrying every 5 seconds"
t=18  server back → "reconnected to 127.0.0.1:33499"
```

## ⚠ Behaviour change

**A machine configured for a server it cannot reach no longer falls back to the
local wire.** It stays on the JSON wire, waiting, and its frames are dropped
until the server answers.

Previously `net_json_init()` failing meant `net_switch_init()` ran instead, so a
machine whose server was unreachable at startup could still talk to machines on
the same computer.

That fallback cannot survive retrying. The two wires are alternatives — a
machine on both receives every frame twice — so a machine that fell back and
*then* connected would be on both. The choice in `network-nat.c` is therefore
now made on whether a server is *configured*
(`net_json_wants_connection()`) rather than on whether it is currently
answering.

The practical cost: someone who mistypes a host name gets a machine with no
local peers rather than one that can still reach the machine next to it. The log
says why, on every start. Given that the same machine would have been isolated
anyway the moment the server came back, waiting is the more honest behaviour —
but it is a real change and worth knowing about.

**It also fixes a case that was already broken.** A machine whose server dropped
*mid-session* fell into the `net_switch` branch — but `net_switch_init()` had
never run, so `switch_fd` was `-1` and the frames went to a socket that did not
exist. Silently discarded, not "fell back to local networking".

## TCP_NODELAY

Set on the socket, through the existing cross-platform
`socket_set_nodelay()` in `socket-compat.h`. One frame per line, each written on
its own, so Nagle would hold each back waiting for company and add its delay to
every frame on the wire.

## Saying what the server replaces

Second commit, documentation only.

The rule has always been that a machine on a JSON server does not also use the
direct link to machines started on the same computer. It was not discoverable:
the note on the Network tab said so in the middle of a paragraph, as mechanism
rather than consequence — *"the machine does not use the local wire between
machines here — both carry every frame"* — and left the more alarming question
unanswered. Reading it, one can reasonably conclude that enabling this might cut
the machine off from the network entirely.

It does not. **NAT is untouched**: `slirp_input()` is called for every frame
whatever wire it went to, so the machine reaches the outside world exactly as
before. Only the machine-to-machine wire changes.

So the note leads with what it costs and what it does not, a line is logged
saying the same on every start — a support bundle should answer this without
anyone having to ask — and the header comment no longer says the machine "uses
that and nothing else", which is the phrasing that overstated it.

## Testing

Builds clean, 74/74 tests pass.

Seven checks added to `test_net_json`, covering the state machine — in
particular that a machine wanting a connection it has not got stays off the
loopback wire, which is the invariant the whole change rests on.

**The timing is deliberately not tested.** Waiting out a retry would add eleven
seconds to a suite that runs in fourteen, and reclaiming a specific port to do
it is racy on a shared runner — a test that fails for reasons unrelated to the
code. It was verified by hand instead, as above.

Not yet tested on Windows: the retry path exercises `closesocket`/reconnect
cycles, and `socket_set_nodelay()` there is the existing helper but is new to
this socket.
