### PR TITLE
macOS: a menu that never opened was letting go of held keys

### DIFF
--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -2943,14 +2943,36 @@ void MainFrame::OnDisplayChanged(wxDisplayChangedEvent &event)
 	event.Skip();
 }
 
+/*
+ * A key held when a menu is pulled down has to be released, because the menu's
+ * own tracking loop swallows the key-up and the guest would be left holding the
+ * key for ever. Where that release belongs is not the same on every platform.
+ *
+ * wxOSX raises wxEVT_MENU_OPEN from NSMenu's menuNeedsUpdate:, which AppKit
+ * calls whenever it validates the menu bar and not only when a menu is opened.
+ * Those passes are frequent, and one of them lands between a modifier going
+ * down and the key it modifies arriving: the guest was told the modifier had
+ * come back up, so the first shifted keystroke of a session came out unshifted
+ * and stayed that way until the modifier was pressed again. That is issue #183,
+ * and it was the same reason the menu_open_ flag used to stick.
+ *
+ * menuDidClose:, which raises wxEVT_MENU_CLOSE, is sent only for a menu that
+ * really opened. By then the swallowed key-ups have already been missed, so
+ * macOS does the release there instead and the validation passes are ignored.
+ */
 void MainFrame::OnMenuOpen(wxMenuEvent &)
 {
+#ifndef __WXOSX__
 	ReleaseHeldKeys();
+#endif
 	menu_open_ = true;
 }
 
 void MainFrame::OnMenuClose(wxMenuEvent &)
 {
+#ifdef __WXOSX__
+	ReleaseHeldKeys();
+#endif
 	menu_open_ = false;
 	if (panel_ != nullptr) {
 		panel_->FocusPanel();


### PR DESCRIPTION
Fixes #183.

On macOS the first shifted keystroke of a session came out unshifted, and stayed that way until the modifier was released and pressed again. Any modifier, any partner key, and any other keypress appeared to cure it.

wxOSX raises `wxEVT_MENU_OPEN` from `NSMenu`'s `menuNeedsUpdate:`, which AppKit calls whenever it validates the menu bar, not only when a menu is opened. Those passes are frequent, and one lands between the modifier going down and the key it modifies arriving. `OnMenuOpen` released every held key, so the guest was handed a shift make and a shift break before the letter and answered with the lower case letter, correctly:

```
Keyboard: down raw=0x38 (Shift)
KbdCore: queue press   0x12          shift make, sent to the guest
MainFrame: OnMenuOpen                no menu was opened
KbdCore: queue release 0x12          shift break, unprompted
Keyboard: down raw=0x00 (A)          arrives with shift already released
```

The release is still needed, because a menu's tracking loop swallows the key-up of anything held while it is down. On macOS it moves to `wxEVT_MENU_CLOSE`, raised from `menuDidClose:`, which is sent only for a menu that really opened. The other platforms keep it where it was.

`GetMenu()` cannot be used to tell the two apart: it is non-null and the id is 0 for a menubar menu either way (`src/osx/menu_osx.cpp`, wxWidgets v3.3.3).

## Verified

Reproduced with the modifier as the genuine first key event of a session: the machine boots to the desktop, a text file is opened in Edit over the host command socket so no key has been pressed and the caret is already placed, then shift+A, b, shift+A are posted as real keyboard events.

| build | typed |
| --- | --- |
| `1.x` at db6dc1f, clean | `abA` |
| this change | `AbA` |
| the `1.x` backport | `AbA` |

Opening a real menu with the mouse while holding a key is the case the release exists for, and that has not been driven by script here, so it wants a manual check before release.

Backport for the 1.1.x line: #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)