### PR TITLE
macOS: the Manager could not be opened again while a machine ran

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -706,6 +706,7 @@ Useful even if you normally use the window.
 | Option | Does |
 | --- | --- |
 | `--machine <name>` | Start straight into that machine |
+| `--manager` | Show the manager window even when a default machine is set |
 | `--list-machines` | List them and exit |
 | `--datadir <dir>` | Use a different data directory for this run |
 | `--fetch-riscos` | Download RISC OS and make a machine ready to run, then exit |

--- a/src/gui/headless_main.cpp
+++ b/src/gui/headless_main.cpp
@@ -550,6 +550,8 @@ void HeadlessPrintUsage(const char *argv0)
 	    "and able to start any number of them at once.\n"
 	    "\n"
 	    "Options:\n"
+	    "  --manager             Show the Manager window even when a default machine\n"
+	    "                        is set, which would otherwise be opened instead.\n"
 	    "  --machine <name>      Machine to run (config name in the configs dir,\n"
 	    "                        with or without the .cfg suffix). On its own it\n"
 	    "                        starts the GUI directly on that machine, skipping\n"

--- a/src/gui/machine_ipc.cpp
+++ b/src/gui/machine_ipc.cpp
@@ -631,6 +631,13 @@ void MachineIpcServer::SendEvent(const IpcEvent &event)
 	}
 }
 
+bool MachineIpcServer::HasClient() const
+{
+	std::lock_guard<std::mutex> lock(client_mutex_);
+
+	return client_fd_ >= 0;
+}
+
 void MachineIpcServer::Stop()
 {
 	if (!running_.exchange(false)) {

--- a/src/gui/machine_ipc.h
+++ b/src/gui/machine_ipc.h
@@ -352,6 +352,19 @@ enum class IpcEventType : uint32_t {
 	 * only when the shape changes, which is rarely.
 	 */
 	PointerShapeChanged,
+
+	/*
+	 * Ask the Manager showing this machine to bring itself to the front.
+	 *
+	 * macOS only in practice, and the reason is LaunchServices. A managed
+	 * machine runs the application's own bundle executable, so the system counts
+	 * it as an instance of RPCEmu Extended even though it never shows a window.
+	 * Opening the application again therefore activates that instance instead of
+	 * starting a new process, and nothing appears - see
+	 * RpcemuApp::MacReopenApp(), which sends this where a Manager is already
+	 * attached and starts one where none is.
+	 */
+	ManagerActivate,
 };
 
 struct IpcEvent {
@@ -412,13 +425,22 @@ public:
 	   itself is unaffected. */
 	void SendEvent(const IpcEvent &event);
 
+	/*
+	 * Whether a Manager is connected to this machine right now.
+	 *
+	 * Asked before deciding that "open the application again" means "start a
+	 * Manager": one that is already showing this machine should be raised
+	 * instead of joined by a second (see IpcEventType::ManagerActivate).
+	 */
+	bool HasClient() const;
+
 private:
 	void AcceptLoop();
 	void ClientLoop(int client_fd);
 
 	std::function<void(const IpcRequest &)> on_request_;
 	std::thread accept_thread_;
-	std::mutex client_mutex_;
+	mutable std::mutex client_mutex_;
 	int listen_fd_ = -1;
 	int client_fd_ = -1;
 	std::atomic<bool> running_{false};

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -22,6 +22,7 @@
 #include <wx/cmdline.h>
 #include <wx/display.h>
 #include <wx/evtloop.h>
+#include <wx/stdpaths.h>
 
 #include <cstdarg>
 #include <cstdio>
@@ -63,6 +64,26 @@ public:
 	bool OnInit() override;
 	void OnInitCmdLine(wxCmdLineParser &parser) override;
 
+#ifdef __WXOSX__
+	/*
+	 * "Open RPCEmu Extended", arriving at a process that is a machine.
+	 *
+	 * ★ On macOS a machine started by the Manager is, as far as the system is
+	 * concerned, the application itself: it runs the bundle's own executable, so
+	 * LaunchServices registers it as an instance of RPCEmu Extended even though
+	 * --managed means it never shows a window. Opening the application again -
+	 * from the Dock, from Finder, from `open` - therefore activates that
+	 * instance rather than starting a new process, and since it has no window,
+	 * nothing whatever appears. The Manager cannot be got back until every
+	 * machine has been stopped, which is not true on Windows or Linux, where a
+	 * second launch is simply a second process.
+	 *
+	 * The activation does at least arrive here, so this is where it is answered:
+	 * raise the Manager if one is attached, and start one if none is.
+	 */
+	void MacReopenApp() override;
+#endif
+
 	/*
 	 * wxAppConsoleBase::ExitMainLoop() only acts while the main loop is the
 	 * active one, and IsRunning() means exactly that - GetActive() == this. A
@@ -86,6 +107,12 @@ public:
 
 private:
 	void InstallSignalHandlers();
+
+#ifdef __WXOSX__
+	/* When the last reopen was answered. One click produces more than one of
+	   these, and each would otherwise start a Manager of its own. */
+	wxLongLong last_reopen_ = 0;
+#endif
 };
 
 #ifndef __WXMSW__
@@ -221,6 +248,15 @@ static const char *g_startup_state_file = nullptr;
  * framebuffer and control channel MainFrame::EnableManagedMode() sets up.
  */
 static bool g_startup_managed = false;
+
+/*
+ * --manager: show the Manager window whatever else is configured, which
+ * otherwise happens only when no machine is named and no default machine is
+ * set. Wanted by anyone who has set a default machine and still wants the list,
+ * and by MacReopenApp(), which starts a Manager on behalf of a machine the
+ * system handed "open the application" to.
+ */
+static bool g_startup_manager = false;
 
 /*
  * --fetch-riscos and its modifiers. Unlike the options above, this one is not
@@ -718,6 +754,55 @@ static bool FileIsReadable(const char *path)
  */
 wxIMPLEMENT_APP_NO_MAIN(RpcemuApp);
 
+#ifdef __WXOSX__
+void RpcemuApp::MacReopenApp()
+{
+	if (!g_startup_managed) {
+		/* An ordinary launch: this process has a window of its own and wx's
+		   own handling - show it, or restore it if it is minimised - is
+		   exactly right. */
+		wxApp::MacReopenApp();
+		return;
+	}
+
+	const wxLongLong now = wxGetLocalTimeMillis();
+
+	if (last_reopen_ != 0 && now - last_reopen_ < 2000) {
+		return;	/* the second and third of one click's worth - see last_reopen_ */
+	}
+	last_reopen_ = now;
+
+	auto *frame = dynamic_cast<MainFrame *>(GetTopWindow());
+
+	if (frame != nullptr && frame->AskManagerToActivate()) {
+		/* Logged because nothing else records that this process, rather than
+		   the Manager, was handed the request. */
+		rpclog("MacReopenApp: asked the Manager showing this machine to come "
+		       "to the front\n");
+		return;
+	}
+
+	/*
+	 * None attached, so the user closed it and is asking for it back. It has to
+	 * be a new process: this one is a machine, and the only window it has is the
+	 * machine's own, which --managed exists to keep hidden.
+	 *
+	 * Started directly rather than through LaunchServices ("open -n"), which
+	 * would ask the system to launch the application again and land back here
+	 * for the same reason this handler exists.
+	 */
+	wxString cmd;
+
+	cmd << '"' << wxStandardPaths::Get().GetExecutablePath() << "\" --manager"
+	    << " --datadir \"" << wxString::FromUTF8(rpcemu_get_datadir()) << '"';
+
+	rpclog("MacReopenApp: no Manager is attached, starting one\n");
+	if (wxExecute(cmd, wxEXEC_ASYNC) == 0) {
+		rpclog("MacReopenApp: could not start a Manager window\n");
+	}
+}
+#endif
+
 bool RpcemuApp::OnInit()
 {
 	SetAppName("RPCEmu Extended");
@@ -782,14 +867,15 @@ bool RpcemuApp::OnInit()
 		       nothing to open and the selector is the only sensible answer;
 		     - holding Shift while starting, which is the way back to the
 		       selector when the default machine itself is the problem;
-		     - --machine, handled above.
+		     - --machine, handled above;
+		     - --manager, which asks for this window by name.
 		   It can also be turned off from inside the machine, through
 		   Settings > Open This Machine Automatically. */
 		const wxString default_machine =
 		    wxString::FromUTF8(GetDefaultMachine());
 		bool used_default = false;
 
-		if (!default_machine.empty() && !wxGetKeyState(WXK_SHIFT)) {
+		if (!g_startup_manager && !default_machine.empty() && !wxGetKeyState(WXK_SHIFT)) {
 			const wxString candidate = default_machine + ".cfg";
 
 			if (wxFileExists(ConfigPathsAbsoluteConfigPath(candidate))) {
@@ -997,6 +1083,7 @@ int main(int argc, char **argv)
 	bool show_help = false;
 	bool resume = false;
 	bool managed = false;
+	bool manager = false;
 	const char *machine_name = nullptr;
 	const char *state_file = nullptr;
 
@@ -1176,6 +1263,8 @@ int main(int argc, char **argv)
 			   start and badly enough to be a nuisance - which nothing here can
 			   detect, so it has to be sayable. */
 			SetHardwareAccelerationOverride(0);
+		} else if (strcmp(arg, "--manager") == 0) {
+			manager = true;
 		} else if (strcmp(arg, "--managed") == 0) {
 			/* Internal: used by the Manager window to launch a machine it
 			   will display and control itself. Not documented as a
@@ -1296,6 +1385,20 @@ int main(int argc, char **argv)
 		return 2;
 	}
 
+	/* --manager asks for the window that lists the machines; --machine and
+	   --headless each say to run one instead, so neither can be meant at the
+	   same time. */
+	if (manager && machine_name != nullptr) {
+		ConsoleMessage(true, "error: --manager and --machine are mutually exclusive.\n");
+		ConsoleMessageFlush();
+		return 2;
+	}
+	if (manager && headless) {
+		ConsoleMessage(true, "error: --manager and --headless are mutually exclusive.\n");
+		ConsoleMessageFlush();
+		return 2;
+	}
+
 	/*
 	 * Every option below this point downloads something, and a build whose
 	 * wxWidgets has no wxWebRequest cannot. Refused here, once, rather than
@@ -1399,6 +1502,8 @@ int main(int argc, char **argv)
 		g_startup_state_file = state_file;
 		g_startup_managed = managed;
 	}
+
+	g_startup_manager = manager;
 
 	/* Normal graphical launch, with the options consumed above removed. */
 	return wxEntry(wx_argc, wx_argv);

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -388,6 +388,19 @@ void MainFrame::EnableManagedMode()
 	}
 }
 
+bool MainFrame::AskManagerToActivate()
+{
+	if (!ipc_server_ || !ipc_server_->HasClient()) {
+		return false;
+	}
+
+	IpcEvent event;
+
+	event.type = IpcEventType::ManagerActivate;
+	ipc_server_->SendEvent(event);
+	return true;
+}
+
 void MainFrame::MirrorToSharedFramebuffer(const VideoUpdate &update)
 {
 	if (!shared_fb_ || update.buffer == nullptr || update.xsize <= 0 || update.ysize <= 0) {

--- a/src/gui/main_frame.h
+++ b/src/gui/main_frame.h
@@ -207,6 +207,17 @@ public:
 	void EnableManagedMode();
 	bool IsManagedMode() const { return managed_mode_; }
 
+	/*
+	 * Ask the Manager showing this machine to come to the front, and say whether
+	 * there was one to ask.
+	 *
+	 * For the macOS case in RpcemuApp::MacReopenApp(): the system hands "open the
+	 * application" to whichever process it counts as the application, which may
+	 * well be a managed machine with no window. False means no Manager is
+	 * attached and one has to be started.
+	 */
+	bool AskManagerToActivate();
+
 	/* Shut down because the process was signalled. Saves what a machine would
 	   not want to lose and closes, without writing a snapshot - see
 	   closing_for_signal_. */

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -1428,6 +1428,37 @@ void ManagerFrame::DiscoverAlreadyRunningMachines()
 		    wxString::FromUTF8(endpoint), false);
 	}
 	RefreshMachineList();
+
+	/*
+	 * A machine found already running is shown, not merely listed.
+	 *
+	 * This window opens with nothing selected, and AttachPanelFor only puts a
+	 * machine on screen if it is the selected one - which is right for a
+	 * machine started from here while the user is pointing at another, and
+	 * wrong for the case this function exists to answer. Somebody who closed
+	 * the Manager, left a machine running and has opened the Manager again is
+	 * looking for that machine, and finding the list with an empty display area
+	 * beside it reads as though it had not been found.
+	 */
+	if (active_machine_.empty() && SelectedMachineName().empty()) {
+		for (size_t i = 0; i < machine_names_.size(); i++) {
+			const auto it = running_.find(machine_names_[i]);
+
+			if (it == running_.end() || it->second.panel == nullptr) {
+				continue;
+			}
+
+			/* Selecting the row is what the user would have done, so the
+			   toolbar and menus act on the machine being shown. It raises a
+			   selection event of its own, which shows the panel; doing it here
+			   as well costs nothing and does not depend on that. */
+			machine_list_->SetItemState((long) i,
+			    wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED,
+			    wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED);
+			ShowMachinePanel(machine_names_[i]);
+			break;
+		}
+	}
 }
 
 void ManagerFrame::AttachPanelFor(const wxString &name, long pid,
@@ -1484,6 +1515,13 @@ void ManagerFrame::AttachPanelFor(const wxString &name, long pid,
 			UpdateStatusText();
 		}
 	});
+
+	/* Asked for by a machine that the system handed "open the application" to,
+	   having no window of its own to answer with. Only this window comes
+	   forward: which machine it is showing was the user's choice, and the
+	   system picked which machine took the message, so changing it here would
+	   be this window rearranging itself for a reason nobody could see. */
+	panel->SetActivateRequestCallback([this]() { window_show_in_front(this); });
 
 	/* Alt+Enter leaves full screen. Answered false when there is none, so the
 	   key goes to the guest as any other would. */

--- a/src/gui/remote_emulator_panel.cpp
+++ b/src/gui/remote_emulator_panel.cpp
@@ -558,6 +558,17 @@ void RemoteEmulatorPanel::HandleIpcEvent(const IpcEvent &event)
 			});
 		}
 		break;
+	case IpcEventType::ManagerActivate:
+		/* The machine was handed "open the application" by the system and has
+		   no window to answer it with - see IpcEventType::ManagerActivate. */
+		if (on_activate_request_) {
+			CallAfter([this] {
+				if (on_activate_request_) {
+					on_activate_request_();
+				}
+			});
+		}
+		break;
 	case IpcEventType::TitleChanged:
 		/* Nothing shown for this yet in the Manager - see the class
 		   comment for what is deferred. */

--- a/src/gui/remote_emulator_panel.h
+++ b/src/gui/remote_emulator_panel.h
@@ -172,6 +172,16 @@ public:
 		on_capture_changed_ = std::move(callback);
 	}
 
+	/*
+	 * The machine has asked for the window showing it to be brought to the front
+	 * (IpcEventType::ManagerActivate). Runs on the GUI thread.
+	 */
+	using ActivateRequestCallback = std::function<void()>;
+	void SetActivateRequestCallback(ActivateRequestCallback callback)
+	{
+		on_activate_request_ = std::move(callback);
+	}
+
 private:
 	void OnPaint(wxPaintEvent &event);
 	void OnSize(wxSizeEvent &event);
@@ -278,6 +288,7 @@ private:
 	ErrorCallback on_error_;
 	LeaveFullScreenCallback on_leave_full_screen_;
 	CaptureChangedCallback on_capture_changed_;
+	ActivateRequestCallback on_activate_request_;
 
 	/*
 	 * The mouse mode, and whether the pointer has been captured in it.


### PR DESCRIPTION
## The fault

On macOS, start a machine from the Manager, close the Manager and leave the machine running, and there is no way back: opening RPCEmu Extended again does nothing at all. The only cure is to stop every machine first. Windows and Linux are unaffected, and the manual promises the opposite ("opening RPCEmu again reconnects to them").

## Why

A `--managed` machine runs the bundle's own executable, so LaunchServices counts it as an instance of RPCEmu Extended even though `--managed` means it never shows a window. Opening the application again therefore activates that instance instead of starting a new process, and a process with no window has nothing to show.

Confirmed rather than assumed: `lsappinfo` reports the running machine as `type="Foreground"` against `bundleID="com.github.andrewtimmins.rpcemu"`, and `open -a` returns 0 while starting nothing. Neither `NSApplicationActivationPolicyAccessory` nor `Prohibited` changes it, tested with a stub application from a copied bundle, so the activation has to be answered rather than avoided.

Nothing was wrong with reattachment itself: forcing a second instance with `open -n` produced a Manager that found the running machine and displayed it straight away.

## The fix

- The activation does reach the process, as a reopen event. `RpcemuApp::MacReopenApp()` now answers it: a machine with a Manager attached asks it to come forward over the existing control channel (new `IpcEventType::ManagerActivate`), and a machine with none starts a Manager itself. Debounced, because one click produces more than one event.
- A new `--manager` option, which is what the machine starts the Manager with so a default machine does not take the launch instead. Worth having by hand for the same reason, and documented in MANUAL.md and the usage text.
- A Manager that finds a machine already running now shows it as well as listing it. It had a panel for it and left the display area empty until something was selected, which is the wrong answer for the one case discovery exists for.

Everything outside `MacReopenApp()` is platform-neutral; the reopen handler is `#ifdef __WXOSX__`.

## Testing

macOS 26, arm64 bundle from `build-macos.sh`, against a scratch data directory:

- machine running, no Manager: opening the application brings up a Manager already showing the machine;
- machine and Manager running: the Manager comes to the front and no second one starts;
- Manager quit with the machine left running, then the application opened again: a Manager comes back showing the machine, which is the reported sequence.

The machine's own log names which of the two paths ran. Full test suite passes (77/77). The three warnings `tests/check-warnings.sh` reports were confirmed to pre-date this branch by rebuilding the unmodified files.

No `1.x` backport: that line has no Manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)