### PR TITLE
Build: a bundle built in a worktree had no commit in its build id

### DIFF
--- a/build-macos.sh
+++ b/build-macos.sh
@@ -98,7 +98,12 @@ fi
 get_version() {
 	# See build.sh: number from VERSION, commit from git unless on a tag.
 	release="$([ -f VERSION ] && tr -d ' \t\r\n' < VERSION || echo 0.0.0)"
-	if command -v git >/dev/null 2>&1 && [ -d .git ] \
+	# `git rev-parse --git-dir` rather than `[ -d .git ]`: in a git worktree
+	# .git is a FILE pointing at the real one, so the directory test failed
+	# there and the build id came out as a bare version number with no
+	# commit in it - the one thing that says which source a bundle was built
+	# from.
+	if command -v git >/dev/null 2>&1 && git rev-parse --git-dir >/dev/null 2>&1 \
 	   && ! git describe --tags --exact-match --match 'v[0-9]*' >/dev/null 2>&1; then
 		commit="$(git rev-parse --short HEAD 2>/dev/null)"
 		if [ -n "$commit" ]; then

--- a/build-windows.sh
+++ b/build-windows.sh
@@ -90,7 +90,12 @@ fi
 get_version() {
 	# See build.sh: number from VERSION, commit from git unless on a tag.
 	release="$([ -f VERSION ] && tr -d ' \t\r\n' < VERSION || echo 0.0.0)"
-	if command -v git >/dev/null 2>&1 && [ -d .git ] \
+	# `git rev-parse --git-dir` rather than `[ -d .git ]`: in a git worktree
+	# .git is a FILE pointing at the real one, so the directory test failed
+	# there and the build id came out as a bare version number with no
+	# commit in it - the one thing that says which source a bundle was built
+	# from.
+	if command -v git >/dev/null 2>&1 && git rev-parse --git-dir >/dev/null 2>&1 \
 	   && ! git describe --tags --exact-match --match 'v[0-9]*' >/dev/null 2>&1; then
 		commit="$(git rev-parse --short HEAD 2>/dev/null)"
 		if [ -n "$commit" ]; then

--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,12 @@ get_version() {
 		echo "0.0.0"
 		return
 	fi
-	if command -v git >/dev/null 2>&1 && [ -d .git ] \
+	# `git rev-parse --git-dir` rather than `[ -d .git ]`: in a git worktree
+	# .git is a FILE pointing at the real one, so the directory test failed
+	# there and the build id came out as a bare version number with no
+	# commit in it - the one thing that says which source a bundle was built
+	# from.
+	if command -v git >/dev/null 2>&1 && git rev-parse --git-dir >/dev/null 2>&1 \
 	   && ! git describe --tags --exact-match --match 'v[0-9]*' >/dev/null 2>&1; then
 		local commit
 		commit="$(git rev-parse --short HEAD 2>/dev/null)"


### PR DESCRIPTION
Found while building the #187 fix in a git worktree, and separated out because it has nothing to do with that fix.

`get_version()` gated the commit lookup on `[ -d .git ]`. In a worktree `.git` is a **file** pointing at the real git directory, so the test failed and the version came out as a bare `2.0.0`:

```
RPCEmu Extended 2.0.0            <- built in a worktree
RPCEmu Extended 2.0.0-g56a7925   <- built in the main checkout
```

That string is the one thing in `BUILDINFO.txt` that says which source a bundle was built from, and it is how a release, or a copy installed for testing, is checked against the commit it claims. Losing it silently is worse than it looks: the bundle is then indistinguishable from any other.

`git rev-parse --git-dir` answers correctly in both layouts. All three build scripts carried the same test, so all three are changed: `build.sh`, `build-macos.sh`, `build-windows.sh`.

Verified by rebuilding the macOS bundle in the worktree afterwards: `RPCEmu Extended 2.0.0-g70d0683`, matching HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)