### PR TITLE
macOS: a shortcut opened a Terminal window, and carried no icon

### DIFF
--- a/src/gui/machine_shortcut.cpp
+++ b/src/gui/machine_shortcut.cpp
@@ -25,6 +25,12 @@
 #include <wx/textfile.h>
 #include <wx/utils.h>
 
+#include "gui_resources.h"
+
+extern "C" {
+#include "rpcemu.h"
+}
+
 #ifdef _WIN32
 #include <windows.h>
 #include <shlobj.h>	/* IShellLink, IPersistFile */
@@ -83,21 +89,88 @@ bool WriteShortcut(const wxString &path, const wxString &exe,
 }
 #elif defined(__WXOSX__)
 /*
- * A .command file, run in Terminal: macOS has no shortcut that carries
- * arguments. Through "open" rather than the binary inside the bundle, which
- * would bypass the icon and the dock; -n for a new instance, without which the
- * arguments are dropped; --args last, as it must be.
+ * A small application bundle, because macOS has no shortcut that carries
+ * arguments and the two things that come closest do not work here: a Finder
+ * alias and a symbolic link both point at a file and have nowhere to put
+ * "--machine KB5".
+ *
+ * ★ This used to be a .command file, and that is what put a second window on
+ * screen. A .command is an executable shell script that Terminal is registered
+ * to open, so double-clicking one starts Terminal, which opens a window, runs
+ * the line and leaves the window there. The window belongs to Terminal, not to
+ * RPCEmu, and nothing in this program could close it. An application bundle is
+ * opened by LaunchServices directly, with no interpreter in front of it and no
+ * window of its own, and it can carry an icon - which a .command cannot.
+ *
+ * The bundle is tiny: a plist, a one-line script and a copy of the icon.
+ *
+ *   <name>.app/Contents/Info.plist
+ *   <name>.app/Contents/MacOS/launch
+ *   <name>.app/Contents/Resources/rpcemu.icns
+ *
+ * It starts the emulator through "open" rather than the binary inside the
+ * bundle, which would bypass the icon and the dock; -n for a new instance,
+ * which is also what stops the click being swallowed by a machine already
+ * running (see RpcemuApp::MacReopenApp()); --args last, as it must be.
  */
+
+/* Anything that would end the string early or be read as markup. The machine
+   name reaches the plist from a name the user chose. */
+static wxString PlistEscape(const wxString &text)
+{
+	wxString out;
+
+	for (const wxUniChar c : text) {
+		switch ((int) c) {
+		case '&': out << "&amp;"; break;
+		case '<': out << "&lt;"; break;
+		case '>': out << "&gt;"; break;
+		default: out << c; break;
+		}
+	}
+	return out;
+}
+
+/*
+ * A bundle identifier for the shortcut, which must be its own and must NOT be
+ * the emulator's: LaunchServices treats every process running a bundle's
+ * executable as an instance of that application, and two applications claiming
+ * one identifier is exactly the confusion that made the Manager unreachable
+ * once already.
+ */
+static wxString ShortcutBundleId(const wxString &name)
+{
+	wxString id;
+
+	for (const wxUniChar c : name) {
+		if (wxIsalnum(c) || c == '-') {
+			id << c;
+		} else {
+			id << '-';
+		}
+	}
+	if (id.empty()) {
+		id = "machine";
+	}
+	return "com.github.andrewtimmins.rpcemu.shortcut." + id;
+}
+
+static bool WriteExecutableFile(const wxString &path, const wxString &text)
+{
+	wxFFile file(path, "wb");
+
+	if (!file.IsOpened() || !file.Write(text) || !file.Close()) {
+		return false;
+	}
+	return wxFileName(path).SetPermissions(wxPOSIX_USER_READ | wxPOSIX_USER_WRITE |
+	    wxPOSIX_USER_EXECUTE | wxPOSIX_GROUP_READ | wxPOSIX_GROUP_EXECUTE |
+	    wxPOSIX_OTHERS_READ | wxPOSIX_OTHERS_EXECUTE);
+}
+
 bool WriteShortcut(const wxString &path, const wxString &exe,
                           const wxString &args, const wxString &working_dir,
                           const wxString &description)
 {
-	wxFFile file(path, "wb");
-
-	if (!file.IsOpened()) {
-		return false;
-	}
-
 	/* Contents/MacOS/<binary> back up to the .app itself. */
 	wxFileName bundle(exe);
 
@@ -105,19 +178,104 @@ bool WriteShortcut(const wxString &path, const wxString &exe,
 	bundle.RemoveLastDir();
 
 	const wxString app = bundle.GetPath();
-	wxString text;
+	const wxString contents = path + "/Contents";
+	const wxString macos = contents + "/MacOS";
+	const wxString resources = contents + "/Resources";
 
-	text << "#!/bin/sh\n"
-	     << "# " << description << "\n"
-	     << "open -n -a \"" << app << "\" --args " << args << "\n";
+	/*
+	 * Replacing rather than merging. The user has already agreed to overwrite,
+	 * and a bundle written over an older one of the same name would otherwise
+	 * keep whatever the old one had and this one does not.
+	 */
+	if (wxFileName::DirExists(path)) {
+		if (!wxFileName::Rmdir(path, wxPATH_RMDIR_RECURSIVE)) {
+			return false;
+		}
+	} else if (wxFileExists(path)) {
+		if (!wxRemoveFile(path)) {
+			return false;
+		}
+	}
 
-	if (!file.Write(text) || !file.Close()) {
+	if (!wxFileName::Mkdir(macos, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL) ||
+	    !wxFileName::Mkdir(resources, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL)) {
 		return false;
 	}
 
-	wxFileName(path).SetPermissions(wxPOSIX_USER_READ | wxPOSIX_USER_WRITE |
-	    wxPOSIX_USER_EXECUTE | wxPOSIX_GROUP_READ | wxPOSIX_GROUP_EXECUTE |
-	    wxPOSIX_OTHERS_READ | wxPOSIX_OTHERS_EXECUTE);
+	/*
+	 * The icon, taken from the bundle this process is running out of.
+	 *
+	 * ★ Not from rpcemu_get_resourcedir(). That is where the guest payload
+	 * lives, and --datadir moves it: a Manager started with an explicit data
+	 * directory looks for the icon in that folder, does not find it, and writes
+	 * a shortcut with no icon at all. The icon is part of the application, not
+	 * part of anybody's data, and the bundle is already worked out just above
+	 * because the shortcut has to name it anyway.
+	 *
+	 * The resource directory is still worth a look as a fallback, for a build
+	 * run from its own directory rather than from a bundle. A source build that
+	 * never ran build-macos.sh has no .icns anywhere, and a shortcut with the
+	 * system's blank application icon still works, so finding neither is not a
+	 * failure.
+	 */
+	wxString icns = app + "/Contents/Resources/rpcemu.icns";
+
+	if (!wxFileExists(icns)) {
+		icns = wxString::FromUTF8(rpcemu_get_resourcedir()) + "rpcemu.icns";
+	}
+
+	const bool have_icon = wxFileExists(icns) &&
+	    wxCopyFile(icns, resources + "/rpcemu.icns");
+
+	wxString plist;
+
+	plist << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+	      << "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" "
+	         "\"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
+	      << "<plist version=\"1.0\">\n<dict>\n"
+	      << "\t<key>CFBundleName</key><string>" << PlistEscape(description) << "</string>\n"
+	      << "\t<key>CFBundleDisplayName</key><string>" << PlistEscape(description) << "</string>\n"
+	      << "\t<key>CFBundleExecutable</key><string>launch</string>\n"
+	      << "\t<key>CFBundleIdentifier</key><string>" << ShortcutBundleId(description) << "</string>\n"
+	      << "\t<key>CFBundlePackageType</key><string>APPL</string>\n"
+	      << "\t<key>CFBundleInfoDictionaryVersion</key><string>6.0</string>\n"
+	      << "\t<key>CFBundleShortVersionString</key><string>1.0</string>\n"
+	      << "\t<key>CFBundleVersion</key><string>1.0</string>\n";
+	if (have_icon) {
+		plist << "\t<key>CFBundleIconFile</key><string>rpcemu</string>\n";
+	}
+	/* No dock icon and no menu bar for the launcher itself: it starts the
+	   emulator and exits, and a second icon appearing beside the one it started
+	   would be the same complaint in a different place. */
+	plist << "\t<key>LSUIElement</key><true/>\n"
+	      << "\t<key>NSHighResolutionCapable</key><true/>\n"
+	      << "</dict>\n</plist>\n";
+
+	wxFFile plist_file(contents + "/Info.plist", "wb");
+
+	if (!plist_file.IsOpened() || !plist_file.Write(plist) || !plist_file.Close()) {
+		return false;
+	}
+
+	wxString launch;
+
+	launch << "#!/bin/sh\n"
+	       << "# " << description << "\n"
+	       << "exec open -n -a \"" << app << "\" --args " << args << "\n";
+
+	if (!WriteExecutableFile(macos + "/launch", launch)) {
+		return false;
+	}
+
+	/* Not required by anything modern, and four bytes to say what this is to
+	   anything that still looks. */
+	wxFFile pkginfo(contents + "/PkgInfo", "wb");
+
+	if (pkginfo.IsOpened()) {
+		pkginfo.Write("APPL????");
+		pkginfo.Close();
+	}
+	(void) working_dir;	/* "open" starts the machine in its own; see above */
 	return true;
 }
 #else
@@ -135,6 +293,15 @@ bool WriteShortcut(const wxString &path, const wxString &exe,
 		return false;
 	}
 
+	/*
+	 * The icon by absolute path where this build has one, and by name where it
+	 * does not. A bare "rpcemu" is a theme lookup, which finds something only
+	 * for a packaged install that put an icon in the theme; for a build run
+	 * from its own directory - which is most of the ways this program is used -
+	 * it silently finds nothing and the launcher shows the generic icon.
+	 */
+	const wxString logo = AppLogoPath();
+	const wxString icon = wxFileExists(logo) ? logo : wxString("rpcemu");
 	wxString text;
 
 	text << "[Desktop Entry]\n"
@@ -143,7 +310,7 @@ bool WriteShortcut(const wxString &path, const wxString &exe,
 	     << "Comment=Risc PC and A7000 emulator\n"
 	     << "Exec=\"" << exe << "\" " << args << "\n"
 	     << "Path=" << working_dir << "\n"
-	     << "Icon=rpcemu\n"
+	     << "Icon=" << icon << "\n"
 	     << "Terminal=false\n"
 	     << "Categories=Game;Emulator;\n"
 	     << "Keywords=RISC OS;Acorn;RiscPC;\n";

--- a/src/gui/machine_shortcut.h
+++ b/src/gui/machine_shortcut.h
@@ -25,9 +25,12 @@
 
 /*
  * A shortcut that opens one machine, in whatever form the desktop understands:
- * a .lnk on Windows, a .desktop on Linux, a .command on macOS. wxWidgets has
- * nothing for this, so there is a writer per platform and they share nothing
- * but this declaration.
+ * a .lnk on Windows, a .desktop on Linux, a small application bundle on macOS.
+ * wxWidgets has nothing for this, so there is a writer per platform and they
+ * share nothing but this declaration.
+ *
+ * Each carries the emulator's icon, so the shortcut looks like the thing it
+ * starts rather than like a script.
  *
  * Answers false if it could not be written, which the caller reports.
  */

--- a/src/gui/manager_frame.cpp
+++ b/src/gui/manager_frame.cpp
@@ -2468,8 +2468,10 @@ void ManagerFrame::OnCreateShortcut(wxCommandEvent & /*event*/)
 	const wxString extension = ".lnk";
 	const wxString wildcard = "Shortcuts (*.lnk)|*.lnk";
 #elif defined(__WXOSX__)
-	const wxString extension = ".command";
-	const wxString wildcard = "Shell commands (*.command)|*.command";
+	/* An application bundle, not a .command file: see machine_shortcut.cpp for
+	   why, and note that the "file" this dialogue returns is a directory. */
+	const wxString extension = ".app";
+	const wxString wildcard = "Applications (*.app)|*.app";
 #else
 	const wxString extension = ".desktop";
 	const wxString wildcard = "Desktop entries (*.desktop)|*.desktop";
@@ -2490,7 +2492,16 @@ void ManagerFrame::OnCreateShortcut(wxCommandEvent & /*event*/)
 		return;
 	}
 
-	if (!WriteShortcut(dialog.GetPath(), exe, args,
+	/* A name typed without the extension still has to be a shortcut: every
+	   platform decides what a file is from it, and macOS will not treat a
+	   directory as an application without it. */
+	wxString path = dialog.GetPath();
+
+	if (!path.EndsWith(extension)) {
+		path << extension;
+	}
+
+	if (!WriteShortcut(path, exe, args,
 	        wxFileName(exe).GetPath(), name)) {
 		wxMessageBox("The shortcut could not be written.",
 		    "RPCEmu Extended Manager", wxOK | wxICON_ERROR, this);
@@ -2498,7 +2509,7 @@ void ManagerFrame::OnCreateShortcut(wxCommandEvent & /*event*/)
 	}
 
 	rpclog("Manager: shortcut for '%s' written to %s\n",
-	    name.utf8_str().data(), dialog.GetPath().utf8_str().data());
+	    name.utf8_str().data(), path.utf8_str().data());
 }
 
 /*


### PR DESCRIPTION
## The fault

Double-clicking a shortcut on macOS puts **two** windows on screen. The second is Terminal's, not ours.

A shortcut was written as a `.command` file: an executable shell script that Terminal is registered to open. Opening one starts Terminal, which opens a window, runs the single line inside and leaves the window there for the user to close. Nothing in this program owns that window or can close it. A `.command` also cannot carry an icon, so it showed with the generic script icon.

Reproduced before changing anything: opening the generated `.command` gave a Terminal window titled `Andy — KB5.command — 120×30` alongside the machine.

**Only macOS was affected**, despite the reasonable suspicion that it would be all three. A `.lnk` is opened by the shell with no console, and the `.desktop` file already says `Terminal=false`.

## The fix

A small application bundle, which LaunchServices opens directly with no interpreter in front of it and no window of its own, and which can carry an icon:

```
<name>.app/Contents/Info.plist
<name>.app/Contents/MacOS/launch          (#!/bin/sh + exec open -n -a ... --args ...)
<name>.app/Contents/Resources/rpcemu.icns
```

The two obvious alternatives do not work: a Finder alias and a symbolic link both point at a file and have nowhere to put `--machine KB5`. `LSUIElement` keeps the launcher itself out of the Dock, since it starts the emulator and exits. Its bundle identifier is its own, deliberately not the emulator's - two applications claiming one identifier is what made the Manager unreachable in #187.

Two more things came out of testing it:

- **The icon comes from the bundle this process is running out of**, not from `rpcemu_get_resourcedir()`. That is where the guest payload lives and `--datadir` moves it, so a Manager started with an explicit data directory wrote a bundle with an empty `Resources` and no `CFBundleIconFile`. Caught in exactly that configuration.
- **The `.desktop` icon was a theme lookup.** A bare `Icon=rpcemu` resolves only for a packaged install that put an icon in the icon theme; a build run from its own directory silently got the generic icon. It now names the shipped `rpcemu.png` by absolute path where there is one, and keeps the theme name as the fallback.

Plus: a name typed into the dialogue without an extension now gets one, on all three platforms.

## Testing

No test in this project links wxWidgets, so `WriteShortcut()` was exercised through a small harness built against wxBase in a scratch directory rather than by clicking a save dialogue:

- the bundle it writes passes `plutil -lint`, and opening it starts the machine with **no Terminal window**;
- writing over an existing shortcut of the same name replaces it rather than merging;
- with the resource directory pointed at a data directory - the case that produced the iconless shortcut - the icon is still found and `CFBundleIconFile` is written.

Finder shows the result as Kind "Application" with the RPCEmu icon, against "Terminal shell script" for the old form. The full suite passes (77/77), and `tests/check-warnings.sh` reports nothing new for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)