### PR TITLE
A machine started from a shortcut had no logo in its About window

### DIFF
--- a/src/gui/gui_resources.cpp
+++ b/src/gui/gui_resources.cpp
@@ -23,6 +23,7 @@
 #include <wx/bitmap.h>
 #include <wx/filefn.h>
 #include <wx/filename.h>
+#include <wx/stdpaths.h>
 #include <wx/frame.h>
 #include <wx/icon.h>
 #include <wx/image.h>
@@ -34,8 +35,42 @@ extern "C" {
 wxString
 AppLogoPath()
 {
-	return wxString::FromUTF8(rpcemu_get_resourcedir()) + "resources" +
-	    wxFileName::GetPathSeparator() + "rpcemu.png";
+	const wxChar sep = wxFileName::GetPathSeparator();
+	const wxString from_data =
+	    wxString::FromUTF8(rpcemu_get_resourcedir()) + "resources" + sep + "rpcemu.png";
+
+	if (wxFileExists(from_data)) {
+		return from_data;
+	}
+
+	/*
+	 * ★ The logo is part of the application, not part of anybody's data, so
+	 * where the resource directory has none this looks in the application's own.
+	 *
+	 * The two are usually the same folder and this changes nothing. They are not
+	 * the same when a data directory is named on the command line and holds a
+	 * payload of its own: the resource directory becomes that folder (see
+	 * ResourceDirForGivenDataDir), which has poduleroms/ and roms/ but no
+	 * resources/rpcemu.png, because nothing ever puts one there. A machine
+	 * started from a shortcut is exactly that case - the shortcut passes
+	 * --datadir - so its About window showed the drawn placeholder while the
+	 * Manager beside it, started with no --datadir, showed the logo.
+	 *
+	 * GetResourcesDir() is Contents/Resources inside a bundle and the
+	 * executable's own directory anywhere else, which is where the payload sits
+	 * in an ordinary install on all three platforms.
+	 */
+	const wxString app_resources =
+	    wxFileName::DirName(wxStandardPaths::Get().GetResourcesDir()).GetFullPath();
+	const wxString from_app = app_resources + "resources" + sep + "rpcemu.png";
+
+	if (wxFileExists(from_app)) {
+		return from_app;
+	}
+
+	/* Neither: answer the same thing as before, so a caller reporting what it
+	   could not find names the place it is meant to be. */
+	return from_data;
 }
 
 /*

--- a/src/gui/gui_resources.h
+++ b/src/gui/gui_resources.h
@@ -25,7 +25,9 @@
 
 class wxFrame;
 
-/* The application logo, <resourcedir>/resources/rpcemu.png. Not every caller
+/* The application logo, <resourcedir>/resources/rpcemu.png, or the same file
+   under the application's own resources where the resource directory has none -
+   which is what a data directory named with --datadir gives. Not every caller
    wants it the same way - one rescales it, another falls back to a drawn one -
    so this is the path rather than the picture. */
 wxString AppLogoPath();


### PR DESCRIPTION
## The fault

The Manager's About window shows the RPCEmu logo. A machine started from a shortcut, sitting next to it, showed the drawn placeholder instead - which reads as the shortcut having started something else.

Reproduced before changing anything, by launching a machine the way a shortcut does (`--machine KB5 --datadir /tmp/rpcemu-scratch`) and opening its About window: blue placeholder square, no logo.

## Why

`AppLogoPath()` looked only under `rpcemu_get_resourcedir()`. That is usually the same folder as the application's own resources, so the two cannot be told apart - except when a data directory is named on the command line and holds a payload of its own. Then the resource directory becomes that folder (`ResourceDirForGivenDataDir`, which is deliberate and correct for finding podule ROMs), and that folder has `poduleroms/` and `roms/` but no `resources/rpcemu.png`, because nothing ever puts one there.

A shortcut passes `--datadir`, so every machine started from one lost the logo - in its About window and as its window icon. It is not limited to shortcuts: any launch with `--datadir` naming a payload tree did the same.

Confirmed on this machine: `~/RPCEmu` and the scratch data directory both have `poduleroms/` and neither has a `resources/` directory; the only `resources/rpcemu.png` is inside the bundle.

## The fix

The logo is part of the application, not part of anybody's data, so it is now looked for under the application's own resources as well: `wxStandardPaths::GetResourcesDir()`, which is `Contents/Resources` inside a bundle and the executable's own directory anywhere else. The resource directory is still tried first, so a portable tree that does ship a logo keeps using its own, and where neither has it the answer is unchanged so a caller reporting a missing file still names the place it is meant to be.

Same root cause as the shortcut's own missing icon in #189; this is the other half of it. Platform-neutral: the lookup applies everywhere, and Linux and Windows have the same split between resource directory and application directory.

## Testing

Built as a bundle and run as a shortcut would run it, `--machine` with `--datadir`: the About window now shows the logo. Full suite passes (77/77).

🤖 Generated with [Claude Code](https://claude.com/claude-code)