### PR TITLE
Stopping a machine with a dialogue open aborted the process

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -151,22 +151,7 @@ void HandleQuitSignal(int signum)
 	   emulator would appear to ignore it. End the dialogue first, which
 	   unwinds that loop and lets the startup path fall through to its "no
 	   machine chosen" exit. */
-	/* The iterator is tested directly rather than against nullptr. wxWidgets
-	   defines wxWindowList::compatibility_iterator two different ways: with
-	   wxUSE_STL it is a class offering operator bool() and no comparison with
-	   nullptr_t, and without it a wrapper that converts to a node pointer. Only
-	   the second form compiles against nullptr, so a build with the STL
-	   containers enabled - which is what Homebrew's wx gives on macOS - failed
-	   here with "invalid operands to binary expression". Truth-testing works in
-	   both. Reported by Septercius, issue #30. */
-	for (auto node = wxTopLevelWindows.GetFirst(); node;
-	     node = node->GetNext()) {
-		auto *dialog = dynamic_cast<wxDialog *>(node->GetData());
-
-		if (dialog != nullptr && dialog->IsModal()) {
-			dialog->EndModal(wxID_CANCEL);
-		}
-	}
+	EndOpenModalDialogs(true);
 
 	wxTheApp->ExitMainLoop();
 }

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -475,8 +475,10 @@ void MainFrame::HandleIpcRequest(const IpcRequest &request)
 	case IpcRequestType::RequestExit:
 		/* Close() touches wx window state, so it has to run on the GUI
 		   thread; everything above is a plain EmulatorHost call and needs
-		   no hop. */
-		CallAfter([this]() { Close(true); });
+		   no hop. Through CloseWhenNothingIsModal() because the Manager's
+		   Stop arrives whatever this machine is showing, and a dialogue open
+		   in front of it is the case that aborts. */
+		CallAfter([this]() { CloseWhenNothingIsModal(); });
 		break;
 	case IpcRequestType::LoadDisc0:
 		emulator_->LoadDisc(0, request.path);
@@ -3616,6 +3618,60 @@ void MainFrame::OnClose(wxCloseEvent &event)
 	Destroy();
 }
 
+int EndOpenModalDialogs(bool cancel)
+{
+	int open = 0;
+
+	/* The iterator is tested directly rather than against nullptr. wxWidgets
+	   defines wxWindowList::compatibility_iterator two different ways: with
+	   wxUSE_STL it is a class offering operator bool() and no comparison with
+	   nullptr_t, and without it a wrapper that converts to a node pointer. Only
+	   the second form compiles against nullptr, so a build with the STL
+	   containers enabled - which is what Homebrew's wx gives on macOS - failed
+	   with "invalid operands to binary expression". Truth-testing works in
+	   both. Reported by Septercius, issue #30. */
+	for (auto node = wxTopLevelWindows.GetFirst(); node; node = node->GetNext()) {
+		auto *dialog = dynamic_cast<wxDialog *>(node->GetData());
+
+		if (dialog == nullptr || !dialog->IsModal()) {
+			continue;
+		}
+		open++;
+		if (cancel) {
+			dialog->EndModal(wxID_CANCEL);
+		}
+	}
+	return open;
+}
+
+void MainFrame::CloseWhenNothingIsModal()
+{
+	/* Asked once. A dialogue does not leave its loop when it is told to, it
+	   leaves when control next returns to it, so telling it again on every
+	   turn of this would be noise. */
+	if (!close_asked_modals_) {
+		close_asked_modals_ = EndOpenModalDialogs(true) > 0;
+		if (close_asked_modals_) {
+			rpclog("MainFrame: waiting for an open dialogue to close before "
+			       "shutting down\n");
+		}
+	}
+
+	if (EndOpenModalDialogs(false) > 0) {
+		/* Still up, so this window must not be destroyed yet: doing it from
+		   inside that dialogue's nested loop is the abort this exists to
+		   avoid. Queued, so the loop gets its turn. */
+		CallAfter([this]() { CloseWhenNothingIsModal(); });
+		return;
+	}
+
+	/* Close() rather than Destroy(), so the machine is taken down by the same
+	   OnClose() the window's own close button uses - the snapshot being the
+	   only part a signal skips. Forced, because neither a signal nor the
+	   Manager's Stop is a request the window may decline. */
+	Close(true);
+}
+
 void MainFrame::CloseForSignal()
 {
 	if (shutting_down_) {
@@ -3623,12 +3679,7 @@ void MainFrame::CloseForSignal()
 	}
 
 	closing_for_signal_ = true;
-
-	/* Close() rather than Destroy(), so the machine is taken down by the same
-	   OnClose() the window's own close button uses - the snapshot being the
-	   only part it skips. Forced, because a signal is not a request the window
-	   may decline. */
-	Close(true);
+	CloseWhenNothingIsModal();
 }
 
 void MainFrame::ResetForSignal()

--- a/src/gui/main_frame.h
+++ b/src/gui/main_frame.h
@@ -188,6 +188,21 @@ enum StatusBarField {
 	STATUS_FIELD_COUNT
 };
 
+/*
+ * Ask every modal dialogue that is open to close, and say how many were found.
+ *
+ * Shared because two shutdown paths need it and only one of them had it: the
+ * signal handler's "no machine window yet" case (see HandleQuitSignal) and the
+ * machine window's own close. See MainFrame::CloseWhenNothingIsModal() for what
+ * goes wrong without it.
+ *
+ * @param cancel Whether to ask them to end, as opposed to only counting them.
+ *               Asking again is harmless but pointless: a dialogue leaves its
+ *               loop when control returns to it, not when it is told to.
+ * @return How many modal dialogues are open
+ */
+int EndOpenModalDialogs(bool cancel);
+
 class MainFrame : public wxFrame, public GuiBridge {
 public:
 	MainFrame();
@@ -222,6 +237,26 @@ public:
 	   not want to lose and closes, without writing a snapshot - see
 	   closing_for_signal_. */
 	void CloseForSignal();
+
+	/*
+	 * Close as soon as nothing modal is in the way, which is how anything that
+	 * closes this window without being asked by the user must do it.
+	 *
+	 * ★ A modal dialogue here is a STACK object parented to this window - see
+	 * OnSettingsMachine, and every other dialogue in this file. Closing the
+	 * window while one is up destroys it from inside that dialogue's own nested
+	 * event loop, and wxWindowBase::DestroyChildren() then calls delete on a
+	 * stack address: "pointer being freed was not allocated", and the process
+	 * aborts at the very end of an otherwise clean shutdown.
+	 *
+	 * So the dialogue is cancelled first and the close is queued, because its
+	 * scope only unwinds once control returns to it.
+	 */
+	void CloseWhenNothingIsModal();
+
+	/* Whether the dialogues have already been asked to close, so the wait above
+	   asks once rather than on every turn of the event loop. */
+	bool close_asked_modals_ = false;
 
 	/* Reset the running machine because the process was signalled. Does
 	   nothing when no machine is running, there being nothing to reset. */


### PR DESCRIPTION
## The fault

"RPCEmu Extended quit unexpectedly", at the end of a shutdown that had otherwise gone perfectly: CMOS written, discs flushed, printer stopped, and then `SIGABRT` from inside `MainFrame::~MainFrame()`.

```
___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED
wxWindowBase::Destroy()
wxWindowBase::DestroyChildren()
wxNonOwnedWindow::~wxNonOwnedWindow()
MainFrame::~MainFrame()
```

Not new: the identical stack is in a crash report from a build of the day before this branch.

## Why

Every dialogue this window opens is a **stack object** parented to it:

```cpp
MachineEditDialog dlg(this, old_config_path, ...);
PrepareMachineWindow(&dlg, "Machine Settings");
if (dlg.ShowModal() != wxID_OK) {
```

A signal, or the Manager's Stop, closed the window from inside that dialogue's own nested event loop. The frame was destroyed while the dialogue was still alive on the stack below it, `DestroyChildren()` called `delete` on a stack address, and malloc aborted the process.

It needed a dialogue to be open, which is why it read as intermittent. With one open it happens every time: a plain SIGTERM is clean, and SIGTERM with **Settings ▸ Machine…** up crashed on every attempt.

## The fix

The repair was already written for the other shutdown path and had never been applied to this one. `HandleQuitSignal()` ends every modal dialogue before `ExitMainLoop()` when there is no machine window, with a comment explaining exactly this; the machine window's own close never learned it.

- That loop becomes `EndOpenModalDialogs(bool cancel)`, used by both paths, with the wxWidgets iterator comment (issue #30) moved to live with the code it explains rather than stranded at the old call site.
- The window closes through `CloseWhenNothingIsModal()`: cancel what is modal, then **wait**, because a dialogue leaves its loop when control returns to it rather than when it is told to. The close is queued until nothing modal is left, and the wait is logged once.
- `IpcRequestType::RequestExit` goes the same way. The Manager's Stop had the identical hazard for the identical reason: it arrives whatever the machine happens to be showing.

## Testing

The sequence that crashed, run three times against the fix: launch a machine, open **Settings ▸ Machine…**, confirm the dialogue is up, send SIGTERM.

- three clean exits, no new crash reports (8 before, 8 after);
- the log shows the wait, then the close, then the printer stopping, with `cmos.ram` written afterwards;
- a plain SIGTERM with no dialogue open still exits cleanly.

Full suite 77/77. The one warning `tests/check-warnings.sh` reports is the pre-existing `netcap_dialog.h` one, not from these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)