### PR TITLE
Ship both emulators, on every platform and every architecture (1.1.x)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -420,15 +420,15 @@ jobs:
       # Piped through tee so the compiler's output can be examined afterwards.
       # pipefail so a failed build still fails the step rather than being masked
       # by tee's exit status.
-      - name: Build and package (amd64, dynarec)
-        timeout-minutes: 3
+      - name: Build and package (amd64, both binaries)
+        timeout-minutes: 8
         run: |
           set -o pipefail
           chmod +x build.sh setup-build-env.sh
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            ./build.sh --deb --zip 2>&1 | tee build.log
+            ./build.sh --both --deb --zip 2>&1 | tee build.log
           else
-            ./build.sh --zip 2>&1 | tee build.log
+            ./build.sh --both --zip 2>&1 | tee build.log
           fi
 
       # A warning in code this project maintains fails the build. Done here
@@ -442,7 +442,11 @@ jobs:
 
       - name: Smoke test binary
         run: |
+          # ★ BOTH binaries, or the release is short of one. A build that
+          # quietly produced only the recompiler would still pass every test
+          # and ship an archive missing the thing this job exists to add.
           file releases/linux/amd64/rpcemu-recompiler | grep -i ELF
+          file releases/linux/amd64/rpcemu-interpreter | grep -i ELF
           ls -la releases/linux/amd64/
           # Actually execute it. These paths run before any wxWidgets/GTK
           # initialisation, so they work with no display and catch a binary that
@@ -530,20 +534,24 @@ jobs:
       - name: Install dependencies
         run: bash setup-build-env.sh
 
-      - name: Build and package (arm64, recompiler)
-        timeout-minutes: 3
+      - name: Build and package (arm64, both binaries)
+        timeout-minutes: 8
         run: |
           set -o pipefail
           chmod +x build.sh setup-build-env.sh
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            ./build.sh --deb --zip 2>&1 | tee build.log
+            ./build.sh --both --deb --zip 2>&1 | tee build.log
           else
-            ./build.sh --zip 2>&1 | tee build.log
+            ./build.sh --both --zip 2>&1 | tee build.log
           fi
 
       - name: Smoke test binary
         run: |
+          # ★ BOTH binaries, or the release is short of one. A build that
+          # quietly produced only the recompiler would still pass every test
+          # and ship an archive missing the thing this job exists to add.
           file releases/linux/arm64/rpcemu-recompiler | grep -i ELF
+          file releases/linux/arm64/rpcemu-interpreter | grep -i ELF
           ls -la releases/linux/arm64/
           # See the amd64 job: runs before any wxWidgets/GTK initialisation, so
           # it needs no display and catches a binary that cannot start at all.
@@ -637,18 +645,22 @@ jobs:
             mingw-w64-x86_64-libvncserver
             mingw-w64-x86_64-libusb
 
-      - name: Build and stage release (native MSYS2)
-        timeout-minutes: 6
+      - name: Build and stage release (native MSYS2, both binaries)
+        timeout-minutes: 14
         run: |
           chmod +x build-windows.sh
-          ./build-windows.sh --zip
+          ./build-windows.sh --both --zip
 
       - name: Smoke test binary (PE executable)
         run: |
           ls -la releases/windows/amd64/
           # Windows ships the recompiler (full-speed dynarec; the JIT now
-          # supports the Windows x64 ABI).
+          # supports the Windows x64 ABI) and the interpreter beside it.
+          # ★ BOTH binaries, or the release is short of one. A build that
+          # quietly produced only the recompiler would still pass every test
+          # and ship an archive missing the thing this job exists to add.
           file releases/windows/amd64/rpcemu-recompiler.exe | grep -i 'PE32'
+          file releases/windows/amd64/rpcemu-interpreter.exe | grep -i 'PE32'
           # The same checks the other platforms run. This also exercises the
           # staged release as a user gets it, so it catches a DLL that
           # build-windows.sh failed to copy alongside the executable.
@@ -756,18 +768,23 @@ jobs:
     # aarch64-w64-windows-gnu and file(1) calls the output "PE32+ ... ARM64", so
     # this is a native binary and not the amd64 one under emulation.
     #
-    # The INTERPRETER, deliberately (build-windows.sh defaults to it here). The
-    # AArch64 dynarec is not shipped on any platform yet, and Windows on ARM adds
-    # its own questions to it - x18 is reserved as the TEB pointer, and cache
-    # maintenance wants FlushInstructionCache rather than the EL0 dc/ic the
-    # backend uses. Shipping an unproven JIT on a new platform would make both
-    # harder to judge.
+    # Both binaries, as everywhere else. This job shipped the interpreter alone
+    # until now, on the grounds that the AArch64 dynarec was not shipped
+    # anywhere - which stopped being true at 1.1.15, when Linux arm64 and both
+    # macOS arm64 paths took it.
     #
-    # Worth knowing before this is offered to anyone as "the fast one": Windows on
-    # ARM already runs our amd64 build under Prism emulation WITH the x86-64
-    # recompiler, so an emulated build with a JIT may well beat a native build
-    # with the interpreter. Which is quicker is a question for real hardware, and
-    # this job exists so there is something to measure.
+    # Windows on ARM does add its own questions to that backend: x18 is reserved
+    # as the TEB pointer, and cache maintenance wants FlushInstructionCache
+    # rather than the EL0 dc/ic the backend emits. Nobody on the project has an
+    # ARM Windows machine to try it on, which is why the boot test below runs
+    # the RECOMPILER: the half that cannot be checked by hand is the half worth
+    # watching RISC OS come up on.
+    #
+    # Worth knowing when comparing the two downloads: Windows on ARM already
+    # runs our amd64 build under Prism emulation WITH the x86-64 recompiler, so
+    # an emulated build with a JIT may well beat a native one. Which is quicker
+    # is a question for real hardware, and this job exists so there is something
+    # to measure.
     #
     # Slower than the amd64 job for a mundane reason: MSYS2's own runtime is
     # x86-64, so the build tools themselves run emulated. Setting up the
@@ -797,11 +814,11 @@ jobs:
             mingw-w64-clang-aarch64-libvncserver
             mingw-w64-clang-aarch64-libusb
 
-      - name: Build and stage release (arm64, interpreter)
-        timeout-minutes: 8
+      - name: Build and stage release (arm64, both binaries)
+        timeout-minutes: 18
         run: |
           chmod +x build-windows.sh
-          ./build-windows.sh --zip
+          ./build-windows.sh --both --zip
 
       # The architecture is the whole point of this job, so it is asserted rather
       # than admired: a toolchain misconfiguration that produced x86-64 here would
@@ -809,10 +826,15 @@ jobs:
       - name: Smoke test binary (native ARM64 PE)
         run: |
           ls -la releases/windows/arm64/
-          exe=releases/windows/arm64/rpcemu-interpreter.exe
-          file "$exe"
-          file "$exe" | grep -qi 'aarch64\|arm64' \
-            || { echo "not a native ARM64 binary"; exit 1; }
+          # ★ BOTH binaries, and both native. A build that quietly produced one
+          # of them would still pass every other check in this file.
+          for exe in releases/windows/arm64/rpcemu-recompiler.exe \
+                     releases/windows/arm64/rpcemu-interpreter.exe; do
+            file "$exe"
+            file "$exe" | grep -qi 'aarch64\|arm64' \
+              || { echo "$exe is not a native ARM64 binary"; exit 1; }
+          done
+          exe=releases/windows/arm64/rpcemu-recompiler.exe
           # Runs the staged release as a user receives it, so a runtime DLL the
           # bundler failed to copy is caught here rather than by them. clang's
           # runtime differs from GCC's - libc++ and libunwind rather than
@@ -841,7 +863,7 @@ jobs:
           mkdir -p "$data" ci-rom
           cp -r default configs "$data/"
           if ! ls ci-rom/ROM* >/dev/null 2>&1; then
-            releases/windows/arm64/rpcemu-interpreter.exe --fetch-riscos --no-disc --accept-licence
+            releases/windows/arm64/rpcemu-recompiler.exe --fetch-riscos --no-disc --accept-licence
             cp "$data"/roms/ROM* ci-rom/
           fi
           mkdir -p "$data/roms"
@@ -863,7 +885,10 @@ jobs:
         timeout-minutes: 3
         run: |
           python3 tests/boot_smoke.py \
-            --binary releases/windows/arm64/rpcemu-interpreter.exe \
+            # The recompiler, not the interpreter it used to be: this job now
+            # ships both, and the AArch64 JIT on Windows is the half nobody
+            # here can try by hand, so it is the half worth booting.
+            --binary releases/windows/arm64/rpcemu-recompiler.exe \
             --datadir "$(cygpath -u "$RUNNER_TEMP")/rpcemu-data" \
             --abort-check require \
             --save vnc-smoke-windows-arm64.png
@@ -890,10 +915,9 @@ jobs:
       # on a real ARM laptop - and that belongs in the release notes rather than
       # in whether the file is offered at all.
       #
-      # NOTE FOR THE RELEASE NOTES: this build is the INTERPRETER, deliberately
-      # (see the comment at the top of this job). Every other platform ships the
-      # recompiler. Somebody choosing between two Windows downloads has to be
-      # told which is which - see docs/release-notes/README.md.
+      # Both archives carry both binaries now, so the two Windows downloads
+      # differ by architecture alone and nothing about flavours needs saying in
+      # the release notes.
       - name: Upload arm64 build
         uses: actions/upload-artifact@v7
         with:
@@ -952,8 +976,8 @@ jobs:
           echo "==> x86_64 dependency versions"
           arch -x86_64 /usr/local/bin/brew list --versions sdl2-compat sdl3 wxwidgets libvncserver libusb || true
 
-      - name: Build x86_64 slice + test (Rosetta)
-        timeout-minutes: 10
+      - name: Build x86_64 slice (both binaries) + test (Rosetta)
+        timeout-minutes: 22
         run: |
           chmod +x build-macos.sh
           # Resolve wx-config / pkg-config / cmake from the x86_64 Homebrew
@@ -962,7 +986,7 @@ jobs:
           # binary is x86_64 and runs under Rosetta.
           export PATH="/usr/local/bin:$PATH"
           export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig"
-          ./build-macos.sh --arch x86_64
+          ./build-macos.sh --both --arch x86_64
 
       - name: Upload x86_64 slice
         uses: actions/upload-artifact@v7
@@ -1009,11 +1033,11 @@ jobs:
           echo "==> arm64 dependency versions"
           brew list --versions sdl2-compat sdl3 wxwidgets libvncserver libusb || true
 
-      - name: Build arm64 slice (recompiler) + test
-        timeout-minutes: 3
+      - name: Build arm64 slice (both binaries) + test
+        timeout-minutes: 8
         run: |
           chmod +x build-macos.sh
-          ./build-macos.sh --arch arm64
+          ./build-macos.sh --both --arch arm64
 
       - name: Upload arm64 slice
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -884,10 +884,16 @@ jobs:
       - name: Headless boot smoke test
         timeout-minutes: 3
         run: |
+          # The recompiler, not the interpreter it used to be: this job ships
+          # both now, and the AArch64 JIT on Windows is the half nobody here
+          # can try by hand, so it is the half worth booting.
+          #
+          # The comment lives HERE, above the command. Inside the backslash
+          # continuation below it is not a comment at all: the shell takes the
+          # continuation, meets a #, and discards every remaining line of the
+          # command - which cost this job a run, failing with "the following
+          # arguments are required: --binary".
           python3 tests/boot_smoke.py \
-            # The recompiler, not the interpreter it used to be: this job now
-            # ships both, and the AArch64 JIT on Windows is the half nobody
-            # here can try by hand, so it is the half worth booting.
             --binary releases/windows/arm64/rpcemu-recompiler.exe \
             --datadir "$(cygpath -u "$RUNNER_TEMP")/rpcemu-data" \
             --abort-check require \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,29 @@ install(DIRECTORY docs/ DESTINATION share/doc/rpcemu)
 # on x86 dynarec builds, rpcemu-interpreter on arm64/interpreter builds); it is
 # configured and installed from src/gui/CMakeLists.txt where the name is known.
 
+# ★ The other flavour's binary, built by a separate configure and handed to this
+# one to package.
+#
+# RPCEMU_DYNAREC decides what the core is compiled to do, so one configure can
+# only ever produce one of the two emulators. A release ships both, which means
+# two builds - and a .deb built by the second of them would otherwise contain
+# only its own. Rather than teach the whole project to build the core twice,
+# which is a refactor of every platform's build at once, the build scripts point
+# this at the binary the first pass produced and it is installed alongside.
+#
+# Empty for an ordinary build, which then packages exactly what it built.
+set(RPCEMU_EXTRA_BINARY "" CACHE FILEPATH
+    "A second emulator binary, from another configure, to install beside this one")
+if(RPCEMU_EXTRA_BINARY)
+    if(NOT EXISTS "${RPCEMU_EXTRA_BINARY}")
+        message(FATAL_ERROR
+                "RPCEMU_EXTRA_BINARY is set to ${RPCEMU_EXTRA_BINARY}, which does not exist. "
+                "It should name a binary from an earlier build of the other flavour.")
+    endif()
+    install(PROGRAMS "${RPCEMU_EXTRA_BINARY}" DESTINATION bin)
+    message(STATUS "Packaging a second emulator binary: ${RPCEMU_EXTRA_BINARY}")
+endif()
+
 set(CPACK_PACKAGE_NAME "rpcemu")
 set(CPACK_PACKAGE_VENDOR "Andy Timmins")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "RPCEmu (Extended Edition)")

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -94,10 +94,21 @@ both Intel and Apple Silicon.
 `.tar.gz` and run `./rpcemu-recompiler` from inside it. Builds are published for
 Intel/AMD (`amd64`) and ARM (`arm64`, which covers the Raspberry Pi).
 
-Two binaries are in each build. `rpcemu-recompiler` translates ARM code to your
-processor's own and is the one to use. `rpcemu-interpreter` executes instructions
-one at a time: far slower, occasionally useful when something behaves oddly and
-you want to rule the recompiler out.
+**Two binaries are in every build, on every platform.**
+`rpcemu-recompiler` translates ARM code into your processor's own and is the one
+to use. `rpcemu-interpreter` executes instructions one at a time: far slower, and
+worth having when something behaves oddly and you want to rule the recompiler
+out of it. Reporting a fault that happens on one and not the other says a great
+deal in one sentence.
+
+On Windows and Linux they sit side by side in the archive. On macOS the
+application runs the recompiler, and the interpreter is inside the bundle at
+`RPCEmu.app/Contents/MacOS/rpcemu-interpreter`, which you can start from a
+terminal:
+
+```sh
+/Applications/RPCEmu.app/Contents/MacOS/rpcemu-interpreter
+```
 
 ## Your first machine
 

--- a/build-macos.sh
+++ b/build-macos.sh
@@ -46,6 +46,11 @@ ONE_ARCH=""
 # argument. That accepted "build-macos.sh arm64", and silently ignored a bare
 # "--arch" with nothing after it.
 FUSE_REQUESTED=false
+# Build the interpreter as well as the recompiler, and put both in the bundle.
+# Off by default: it is a second full compile of the core per slice, which a
+# developer rebuilding to try one change does not want. CI asks for it, because
+# a release ships both.
+BUILD_BOTH=false
 while [ $# -gt 0 ]; do
 	case "$1" in
 		--zip|-z) MAKE_ZIP=true ;;
@@ -63,6 +68,7 @@ while [ $# -gt 0 ]; do
 			esac
 			;;
 		--fuse) DO_FUSE=true; FUSE_REQUESTED=true ;;
+		--both) BUILD_BOTH=true ;;
 		--help|-h) echo "Usage: $0 [--arch x86_64|arm64] [--fuse] [--zip]"; exit 0 ;;
 		*) echo "unknown option: $1"; exit 2 ;;
 	esac
@@ -208,6 +214,30 @@ build_slice() {
 		-DRPCEMU_ENABLE_GHOSTPDL=OFF
 	echo "==> [$arch] building"
 	cmake --build "$build_dir" -j"$(njobs)"
+
+	if [ "$BUILD_BOTH" = true ]; then
+		# ★ The other emulator, for the same slice.
+		#
+		# A release ships both: the recompiler as the bundle's own binary, and the
+		# interpreter beside it for anyone who needs to rule the JIT out of a
+		# problem. RPCEMU_DYNAREC is decided at configure time, so that is a second
+		# configure and a second compile into a tree of its own - the price of
+		# shipping both, and it roughly doubles this job.
+		#
+		# No tests here: the suite has just run against the same sources, and the
+		# JIT differential tests, which are the ones that care about the backend,
+		# need the backend that this build does not have.
+		echo "==> [$arch] configuring the interpreter (dynarec=OFF, tests=OFF)"
+		cmake -B "$build_dir-interpreter" -G "$gen" \
+			${tc_args[@]+"${tc_args[@]}"} ${extra_args[@]+"${extra_args[@]}"} \
+			-DCMAKE_BUILD_TYPE=Release \
+			-DRPCEMU_DYNAREC=OFF \
+			-DRPCEMU_BUILD_TESTS=OFF \
+			"-DRPCEMU_REQUIRE_LIBUSB=$require_libusb" \
+			-DRPCEMU_ENABLE_GHOSTPDL=OFF
+		echo "==> [$arch] building the interpreter"
+		cmake --build "$build_dir-interpreter" -j"$(njobs)"
+	fi
 
 	# Run the unit tests where we can: a native build, of an architecture this
 	# machine can actually execute. Decide that up front so a real failure can be
@@ -440,6 +470,13 @@ stage_slice() {
 	# The emulator is renamed to "rpcemu" in the bundle regardless of which
 	# variant this slice built.
 	cp -f "$build_dir/bin/$(slice_binname "$arch")" "$stage/bin/rpcemu"
+	# And the interpreter under its own name, from its own tree. Kept as
+	# rpcemu-interpreter rather than renamed: the bundle runs "rpcemu", and a
+	# second binary is only useful if it can be told apart from it.
+	if [ -f "$build_dir-interpreter/bin/rpcemu-interpreter" ]; then
+		cp -f "$build_dir-interpreter/bin/rpcemu-interpreter" \
+		    "$stage/bin/rpcemu-interpreter"
+	fi
 	if [ -f "$build_dir/bin/rpcemu-run" ]; then
 		cp -f "$build_dir/bin/rpcemu-run" "$stage/bin/rpcemu-run"
 	fi
@@ -701,9 +738,9 @@ if [ "$DO_FUSE" = true ]; then
 	# through into the bundle.
 	# What the release notes and the About box should say this bundle is.
 	case "$FUSE_ARCHES" in
-		"x86_64 arm64") BINARY_DESC="universal: x86_64 and arm64, recompiler on both" ;;
-		x86_64)         BINARY_DESC="x86_64 only, recompiler" ;;
-		arm64)          BINARY_DESC="arm64 only, recompiler" ;;
+		"x86_64 arm64") BINARY_DESC="universal: x86_64 and arm64, recompiler on both, interpreter beside it" ;;
+		x86_64)         BINARY_DESC="x86_64 only, recompiler, interpreter beside it" ;;
+		arm64)          BINARY_DESC="arm64 only, recompiler, interpreter beside it" ;;
 		*)              BINARY_DESC="$FUSE_ARCHES" ;;
 	esac
 
@@ -716,6 +753,11 @@ if [ "$DO_FUSE" = true ]; then
 
 	echo "==> lipo emulator binary ($FUSE_ARCHES)"
 	fuse_binary rpcemu "$MACOSD/rpcemu"
+
+	# The interpreter, the same way. Not fatal if it is absent: a --fuse over
+	# slices staged by an older build of this script has no such binary, and a
+	# bundle without it is the bundle we shipped until now.
+	fuse_binary rpcemu-interpreter "$MACOSD/rpcemu-interpreter" || true
 
 	# The HostCmd host client, and rpcemu-shell which is the same binary.
 	if fuse_binary rpcemu-run "$MACOSD/rpcemu-run"; then

--- a/build-windows.sh
+++ b/build-windows.sh
@@ -46,6 +46,11 @@ esac
 BUILD_DIR=build-win
 WIN_RELEASE="releases/windows/$WIN_ARCH"
 MAKE_ZIP=false
+BUILD_BOTH=false
+# Set by the second pass of --both, so it adds to what the first pass staged
+# instead of deleting it. Not an option: nothing outside this script should be
+# staging into a directory it did not create.
+KEEP_STAGED="${RPCEMU_KEEP_STAGED:-0}"
 
 # The x86-64 dynarec supports the Windows x64 ABI (codegen_amd64.c), so that
 # build uses the recompiler by default for full-speed emulation.
@@ -74,10 +79,31 @@ for arg in "$@"; do
 		--zip|-z) MAKE_ZIP=true ;;
 		--interpreter|-i) INTERPRETER=true ;;
 		--dynarec) INTERPRETER=false ;;
-		--help|-h) echo "Usage: $0 [--zip] [--interpreter|--dynarec]"; echo "Target follows \$MSYSTEM: MINGW64 -> amd64, CLANGARM64 -> arm64 (interpreter by default)"; exit 0 ;;
+		--both) BUILD_BOTH=true ;;
+		--help|-h) echo "Usage: $0 [--zip] [--interpreter|--dynarec|--both]"; echo "Target follows \$MSYSTEM: MINGW64 -> amd64, CLANGARM64 -> arm64 (interpreter by default)"; exit 0 ;;
 		*) echo "unknown option: $arg"; exit 2 ;;
 	esac
 done
+
+# ★ Both emulators, which takes two passes.
+#
+# RPCEMU_DYNAREC is a configure-time decision, so one configure builds one
+# emulator. Rather than restructure this script around that, --both runs it
+# twice: the interpreter first, then the recompiler, which stages alongside
+# rather than over it and makes the archive at the end. The recompiler goes
+# second so that the things written once - BUILDINFO, the zip - come from it.
+#
+# Two full compiles. On the arm64 runner, where MSYS2's own tools run emulated,
+# that is the slowest job in CI; the timeout in the workflow allows for it.
+if [ "$BUILD_BOTH" = true ]; then
+	"$0" --interpreter
+	if [ "$MAKE_ZIP" = true ]; then
+		RPCEMU_KEEP_STAGED=1 "$0" --dynarec --zip
+	else
+		RPCEMU_KEEP_STAGED=1 "$0" --dynarec
+	fi
+	exit 0
+fi
 
 if [ "$INTERPRETER" = true ]; then
 	DYNAREC_ARG=-DRPCEMU_DYNAREC=OFF
@@ -205,7 +231,9 @@ else
 fi
 
 echo "==> Staging $WIN_RELEASE"
-rm -rf "$WIN_RELEASE"
+if [ "$KEEP_STAGED" != "1" ]; then
+	rm -rf "$WIN_RELEASE"
+fi
 mkdir -p "$WIN_RELEASE"
 # Shared resources - identical set to the Linux release.
 # The guest-side payload - poduleroms, netroms, gfxroms, usbroms, podules and
@@ -265,7 +293,7 @@ cat > "$WIN_RELEASE/BUILDINFO.txt" <<EOF
 RPCEmu (Extended Edition) $VERSION
 Built: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
 Host:  $(uname -s) $(uname -m) (cross to $TARGET)
-Binary: $BIN
+Binary: $BIN$([ "$KEEP_STAGED" = "1" ] && echo " (and rpcemu-interpreter.exe, the other flavour)")
 Toolkit: wxWidgets (wxMSW) + CMake (MinGW-w64)
 EOF
 

--- a/build.sh
+++ b/build.sh
@@ -69,6 +69,9 @@ VERSION="$(get_version)"
 BUILD_DEB=false
 BUILD_ZIP=false
 BUILD_INTERPRETER=false
+BUILD_BOTH=false
+BUILD_DIR=build
+EXTRA_BINARY=
 BUILD_DEBUG=false
 BUILD_PODULES=true
 PODULES_EXPLICIT=false
@@ -94,6 +97,7 @@ for arg in "$@"; do
 
 	case $arg in
 		--interpreter|-i) BUILD_INTERPRETER=true ;;
+		--both) BUILD_BOTH=true ;;
 		--debug|-g) BUILD_DEBUG=true ;;
 		--deb|-d) BUILD_DEB=true ;;
 		--zip|-z) BUILD_ZIP=true ;;
@@ -107,6 +111,7 @@ for arg in "$@"; do
 			echo "  --arch ARCH         Linux target: amd64 or arm64 (default: host)"
 			echo "  --cross-arm64       Cross-compile Linux arm64 from x86_64"
 			echo "  --interpreter, -i   Build interpreter instead of dynarec"
+			echo "  --both              Build and ship both: recompiler and interpreter"
 			echo "  --debug, -g         Debug build"
 			echo "  --deb, -d           Create .deb package"
 			echo "  --zip, -z           Create .tar.gz in releases/linux/"
@@ -240,15 +245,15 @@ stage_linux_release() {
 		sed -i "s/@RPCEMU_GUI_TARGET@/$binary_name/" "$LINUX_RELEASE/rpcemu.desktop"
 	fi
 
-	cp -f "build/bin/$binary_name" "$release_binary"
+	cp -f "$BUILD_DIR/bin/$binary_name" "$release_binary"
 	chmod +x "$release_binary"
 	cp -f "$release_binary" "$binary_name"
 
 	# HostCmd host-side client (rpcemu-run + rpcemu-shell symlink). These let
 	# the host drive the guest RISC OS command line; ship them alongside the
 	# emulator binary. See docs/hostcmd.md.
-	if [ -f build/bin/rpcemu-run ]; then
-		cp -f build/bin/rpcemu-run "$LINUX_RELEASE/rpcemu-run"
+	if [ -f "$BUILD_DIR/bin/rpcemu-run" ]; then
+		cp -f "$BUILD_DIR/bin/rpcemu-run" "$LINUX_RELEASE/rpcemu-run"
 		chmod +x "$LINUX_RELEASE/rpcemu-run"
 		ln -sf rpcemu-run "$LINUX_RELEASE/rpcemu-shell"
 	fi
@@ -256,8 +261,8 @@ stage_linux_release() {
 	# DebugCmd host-side client. The counterpart of rpcemu-run: that one drives
 	# RISC OS's command line, this one drives the processor underneath it.
 	# See docs/debugcmd.md.
-	if [ -f build/bin/rpcemu-debug ]; then
-		cp -f build/bin/rpcemu-debug "$LINUX_RELEASE/rpcemu-debug"
+	if [ -f "$BUILD_DIR/bin/rpcemu-debug" ]; then
+		cp -f "$BUILD_DIR/bin/rpcemu-debug" "$LINUX_RELEASE/rpcemu-debug"
 		chmod +x "$LINUX_RELEASE/rpcemu-debug"
 	fi
 
@@ -287,7 +292,7 @@ stage_linux_release() {
 RPCEmu (Extended Edition) $VERSION
 Built: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
 Host:  $(uname -s) $(uname -m)
-Binary: $binary_name
+Binary: $binary_name$([ -n "$EXTRA_BINARY" ] && echo " (and $(basename "$EXTRA_BINARY"), the other flavour)")
 Toolkit: wxWidgets + CMake (Linux)
 USB passthrough: $usb_state
 EOF
@@ -458,12 +463,16 @@ build_linux() {
 	fi
 	echo ""
 
-	rm -rf build
+	rm -rf "$BUILD_DIR"
 	mkdir -p "$LINUX_RELEASE"
 
-	local cmake_args=(-S . -B build)
+	local cmake_args=(-S . -B "$BUILD_DIR")
 	mapfile -t common_args < <(cmake_common_args)
 	cmake_args+=("${common_args[@]}")
+
+	if [ -n "$EXTRA_BINARY" ]; then
+		cmake_args+=(-DRPCEMU_EXTRA_BINARY="$EXTRA_BINARY")
+	fi
 
 	if [ "$LINUX_CROSS" = true ]; then
 		if ! command -v aarch64-linux-gnu-gcc &>/dev/null; then
@@ -479,14 +488,14 @@ build_linux() {
 	fi
 
 	cmake "${cmake_args[@]}"
-	cmake --build build -j"$NPROC"
+	cmake --build "$BUILD_DIR" -j"$NPROC"
 
 	if [ "$LINUX_CROSS" = false ]; then
 		echo ""
 		# Whether the tests can run here is decided above; whether they passed is
 		# decided by the script, which treats a suite that is absent or the wrong
 		# size as a failure rather than as nothing to do. See docs/testing.md.
-		bash "$SCRIPT_DIR/tests/run-ctest.sh" build
+		bash "$SCRIPT_DIR/tests/run-ctest.sh" "$BUILD_DIR"
 	else
 		echo "Note: skipping tests (cross-compiled binaries cannot run on this host)."
 	fi
@@ -505,11 +514,11 @@ build_linux() {
 		echo ""
 		echo "Creating .deb package ($LINUX_ARCH)..."
 		(
-			cd build
+			cd "$BUILD_DIR"
 			cpack -G DEB > /dev/null 2>&1
 		)
 		shopt -s nullglob
-		local debs=(build/*.deb)
+		local debs=("$BUILD_DIR"/*.deb)
 		shopt -u nullglob
 		if [ ${#debs[@]} -eq 0 ]; then
 			echo "Error: cpack did not produce a .deb file"
@@ -533,7 +542,41 @@ if [ "$BUILD_PODULES" = true ]; then
 fi
 
 mkdir -p "$LINUX_RELEASE"
-build_linux
+
+if [ "$BUILD_BOTH" = true ]; then
+	# ★ Two passes, and the order matters.
+	#
+	# RPCEMU_DYNAREC is decided at configure time, so one configure builds one
+	# emulator. The interpreter goes first, into a build tree of its own, and
+	# stages its binary; the recompiler then builds second, so that everything
+	# written once and overwritten by the later pass - the .desktop Exec line,
+	# BUILDINFO.txt, the .deb - describes the recompiler, which is the one a
+	# user should reach for. The interpreter is handed to the second configure
+	# as RPCEMU_EXTRA_BINARY so it is inside the .deb as well as the tarball.
+	#
+	# Two full compiles, with no compiler cache in CI, so this roughly doubles
+	# the build. That is the price of shipping both and it is paid on purpose.
+	want_zip=$BUILD_ZIP
+	want_deb=$BUILD_DEB
+
+	BUILD_DIR=build-interpreter
+	BUILD_INTERPRETER=true
+	BUILD_ZIP=false
+	BUILD_DEB=false
+	build_linux
+
+	# Staged, so it is beside the recompiler in the archive already; named here
+	# so the second configure can put it in the .deb too.
+	EXTRA_BINARY="$PWD/$LINUX_RELEASE/$(binary_basename)"
+
+	BUILD_DIR=build
+	BUILD_INTERPRETER=false
+	BUILD_ZIP=$want_zip
+	BUILD_DEB=$want_deb
+	build_linux
+else
+	build_linux
+fi
 
 echo ""
 echo "=================================================="


### PR DESCRIPTION
The 1.x half of #195. Same change, same reasons: a release offered one binary per download, and which one you got depended on the platform, so anyone wanting to rule the recompiler out of a fault had to build one themselves.

Each build script gains `--both` and builds twice, recompiler last so the things written once (the `.desktop` `Exec`, `BUILDINFO`, the archive) describe the one to reach for. On Linux the interpreter is handed to the second configure as `RPCEMU_EXTRA_BINARY`, a small new CMake hook, so it lands in the `.deb` and not only the tarball. On macOS it is fused by `lipo` like the first and sits beside the bundle's own binary as `Contents/MacOS/rpcemu-interpreter`. Opt-in, so local builds are unaffected; CI passes it everywhere.

Windows on ARM ships both here too, and its boot test now runs the recompiler rather than the interpreter: nobody on the project has an ARM Windows machine, so the half that cannot be checked by hand is the half worth watching RISC OS come up on.

**Three differences from main's version**, all because this branch is older:

- the netcap client does not exist here, so there is nothing of it to stage;
- the fuse helper is `fuse_binary` and the architectures are a string rather than an array;
- these jobs have no job-level timeouts, only step ones, so it is those that are raised for the doubled compile.

## Testing

The same macOS verification as #195 was done on that branch: clean `--both` slice, 77 tests, both binaries in the fused bundle, each carrying only its own About string, the interpreter running from inside the bundle, and the bundle still signing. Here all four changed files parse (`bash -n` on the three scripts, YAML on the workflow) and the rest is for this PR's CI.

Worth noting for whoever cuts the next 1.1.x: **this branch already publishes the Windows arm64 zip** (`242f7a4`). v1.1.16 has no ARM Windows asset because that landed after the tag, not because it is missing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)