### PR TITLE
macOS: erratic trackpad scrolling (#197), and the shutdown path's close (#194)

### DIFF
--- a/src/gui/emulator_panel.cpp
+++ b/src/gui/emulator_panel.cpp
@@ -1309,8 +1309,50 @@ void EmulatorPanel::OnLeaveWindow(wxMouseEvent &event)
 	event.Skip();
 }
 
+/*
+ * ★ A wheel click is a quantity of rotation, not the sign of an event.
+ *
+ * The guest gets one scroll click per event whose rotation is non-zero, in the
+ * direction of its sign (podulerom_mouse_wheel_change). For a mouse that is
+ * exactly right: one detent is one event carrying a full delta, usually 120.
+ *
+ * A trackpad does not work like that. It sends a stream of small rotations as
+ * the fingers move, and around the ends of a gesture - the start, the stop, the
+ * momentum - the sign flickers. Turning each of those into a whole click gives
+ * a view that lurches up and down instead of scrolling, which is issue #197.
+ *
+ * So rotation is accumulated and a click is emitted per GetWheelDelta() worth,
+ * with the remainder kept for the next event. A genuine change of direction
+ * throws the remainder away rather than letting it cancel the new movement.
+ */
 void EmulatorPanel::OnMouseWheel(wxMouseEvent &event)
 {
-	emulator_.MouseWheel(event.GetWheelRotation());
+	/* Horizontal gestures are not this wheel. A trackpad sends them as a
+	   separate axis, and treating them as vertical is scrolling nobody asked
+	   for. */
+	if (event.GetWheelAxis() != wxMOUSE_WHEEL_VERTICAL) {
+		event.Skip();
+		return;
+	}
+
+	const int rotation = event.GetWheelRotation();
+	int delta = event.GetWheelDelta();
+
+	if (delta <= 0) {
+		delta = 120;	/* what a mouse reports; a sane fallback if wx cannot say */
+	}
+	if ((rotation < 0) != (wheel_accumulator_ < 0)) {
+		wheel_accumulator_ = 0;
+	}
+	wheel_accumulator_ += rotation;
+
+	while (wheel_accumulator_ >= delta) {
+		emulator_.MouseWheel(1);
+		wheel_accumulator_ -= delta;
+	}
+	while (wheel_accumulator_ <= -delta) {
+		emulator_.MouseWheel(-1);
+		wheel_accumulator_ += delta;
+	}
 	event.Skip();
 }

--- a/src/gui/emulator_panel.h
+++ b/src/gui/emulator_panel.h
@@ -97,6 +97,10 @@ private:
 	void OnMouseDoubleClick(wxMouseEvent &event);
 	void ForwardMousePress(const wxMouseEvent &event);
 	void OnMouseWheel(wxMouseEvent &event);
+
+	/* Wheel rotation not yet turned into a scroll click. A trackpad sends far
+	   less than a click at a time; see OnMouseWheel. */
+	int wheel_accumulator_ = 0;
 	void OnEnterWindow(wxMouseEvent &event);
 	void OnLeaveWindow(wxMouseEvent &event);
 	void OnMouseCaptureLost(wxMouseCaptureLostEvent &event);

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -3397,9 +3397,18 @@ void MainFrame::PostMachineSwitched(const std::string &machine_name)
 
 void MainFrame::PostQuit()
 {
-	/* Called from the emulator thread; hop to the GUI thread and close the
-	   window, which runs the normal shutdown (stop + join the emu threads). */
-	CallAfter([this]() { Close(true); });
+	/*
+	 * Called from the emulator thread; hop to the GUI thread and close the
+	 * window, which runs the normal shutdown (stop + join the emu threads).
+	 *
+	 * Through CloseWhenNothingIsModal() rather than straight to Close(true),
+	 * for the reason set out there: every dialogue this window opens is a stack
+	 * object parented to it, and destroying the window from inside a dialogue's
+	 * own event loop aborts the process. This path is the guest asking to be
+	 * powered off - the desktop's Shutdown, via OS_Reset - which can arrive
+	 * while anything at all is on screen.
+	 */
+	CallAfter([this]() { CloseWhenNothingIsModal(); });
 }
 
 /*

--- a/src/gui/remote_emulator_panel.cpp
+++ b/src/gui/remote_emulator_panel.cpp
@@ -1296,16 +1296,42 @@ void RemoteEmulatorPanel::OnMouseUp(wxMouseEvent &event)
 	SendRequest(request);
 }
 
+/*
+ * The same accumulation as the machine window's own panel, and for the same
+ * reason (issue #197): the machine turns any non-zero rotation into one scroll
+ * click, and a trackpad sends a stream of small ones whose sign flickers. The
+ * counting is done here rather than in the machine so that what crosses the
+ * control channel is whole clicks.
+ */
 void RemoteEmulatorPanel::OnMouseWheel(wxMouseEvent &event)
 {
 	if (!live_) {
 		return;
 	}
+	if (event.GetWheelAxis() != wxMOUSE_WHEEL_VERTICAL) {
+		return;
+	}
 
-	IpcRequest request;
-	request.type = IpcRequestType::MouseWheel;
-	request.arg1 = event.GetWheelRotation();
-	SendRequest(request);
+	const int rotation = event.GetWheelRotation();
+	int delta = event.GetWheelDelta();
+
+	if (delta <= 0) {
+		delta = 120;
+	}
+	if ((rotation < 0) != (wheel_accumulator_ < 0)) {
+		wheel_accumulator_ = 0;
+	}
+	wheel_accumulator_ += rotation;
+
+	while (wheel_accumulator_ >= delta || wheel_accumulator_ <= -delta) {
+		IpcRequest request;
+		const int click = wheel_accumulator_ > 0 ? 1 : -1;
+
+		request.type = IpcRequestType::MouseWheel;
+		request.arg1 = click;
+		SendRequest(request);
+		wheel_accumulator_ -= click * delta;
+	}
 }
 
 void RemoteEmulatorPanel::OnKeyDown(wxKeyEvent &event)

--- a/src/gui/remote_emulator_panel.h
+++ b/src/gui/remote_emulator_panel.h
@@ -190,6 +190,10 @@ private:
 	void OnMouseDown(wxMouseEvent &event);
 	void OnMouseUp(wxMouseEvent &event);
 	void OnMouseWheel(wxMouseEvent &event);
+
+	/* Wheel rotation not yet turned into a scroll click. A trackpad sends far
+	   less than a click at a time; see OnMouseWheel. */
+	int wheel_accumulator_ = 0;
 	void OnKeyDown(wxKeyEvent &event);
 	void OnKeyUp(wxKeyEvent &event);
 	void OnKillFocus(wxFocusEvent &event);


### PR DESCRIPTION
Closes #197. Related to #194, which it does **not** claim to close — see below.

## #197 — trackpad scrolling jumps up and down

The guest gets one scroll click for any event with non-zero rotation, in the direction of its sign:

```c
if (dy > 0)      { message[0] = 1; message[1] = 1;    }
else if (dy < 0) { message[0] = 1; message[1] = 0xff; }
```

For a mouse that is exactly right — one detent is one event carrying a full delta. A trackpad sends a stream of small rotations as the fingers move, and around the edges of a gesture the sign flickers, so each of those became a whole click. That is the reporter's "almost as if the scroll does not know which way to go".

Rotation is now accumulated and a click emitted per `GetWheelDelta()`, keeping the remainder; a real change of direction discards the remainder rather than letting it cancel the new movement. Horizontal gestures are ignored — a trackpad sends them on a separate axis and they were being treated as vertical scrolling.

Both panels do it: the machine's own window, and the Manager's, which counts on its side so whole clicks cross the control channel instead of trackpad noise.

## #194 — the shutdown crash: a real hazard fixed, the report not yet settled

The desktop's Shutdown ends in `OS_Reset` with the power-off request, which the ROM patch turns into `rpcemu_request_poweroff()` and so into `PostQuit()`:

```cpp
CallAfter([this]() { Close(true); });
```

That is the pattern that aborted in #192 — every dialogue here is a stack object parented to the window, and forcing the window closed from inside a dialogue's event loop destroys it underneath. The guest can ask to be powered off while anything at all is on screen. It now goes through `CloseWhenNothingIsModal()`, like the signal and Manager-stop paths.

**I am not claiming this fixes the reported crash.** The report is truncated above the backtrace, and reproducing it needs a desktop, which the scratch machines here do not have. What can be said: the signature matches (SIGABRT on the main thread, during shutdown, every time), and this was the one remaining unfixed instance of the pattern. I have asked the reporter for the frames.

## For the backport

The reporter is on **1.1.16**, and `1.x` has neither this change nor #192. Both want backporting, and #197 applies there too — the wheel handling is the same.

## Testing

Builds clean, 77/77. The trackpad change is behavioural and wants a trackpad in front of it: I have no way to generate genuine high-resolution scroll events here, so the reasoning is from the event contract rather than from a reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)