### PR TITLE
Machine editor: a new machine's HostFS is empty, so stop offering to move it

### DIFF
--- a/default/hostfs/Network/ReadMe,fff
+++ b/default/hostfs/Network/ReadMe,fff
@@ -1,9 +1,0 @@
-
-This directory used to contain files for setting up networking on RPCEmu, but
-these are no longer needed as of version 0.9.1.
-
-Please refer to the guide at
-
-http://www.marutan.net/rpcemu/manual/network.html
-
-for full instructions on how to configure networking.

--- a/src/gui/folder_transfer.cpp
+++ b/src/gui/folder_transfer.cpp
@@ -247,16 +247,30 @@ FolderTransferGatherFacts(const wxString &from, const wxString &to, bool in_use,
 	f.dest_is_dir = wxDirExists(to) ? 1 : 0;
 	f.dest_empty = f.dest_is_dir ? (DirIsEmpty(to) ? 1 : 0) : 1;
 
+	/*
+	 * Walked once and remembered. This used to call ListTree(from) here and
+	 * again on the way out for the caller's byte count, so every file in the
+	 * source was stat'ed twice for one question - which on a full HardDisc4 is
+	 * the difference between a pause and a window that looks dead. Issue #204.
+	 *
+	 * It is kept separate from f.bytes_needed deliberately: bytes_needed is
+	 * cleared below when the free space cannot be measured, and the caller's
+	 * figure is the size of the tree either way.
+	 */
+	unsigned long long tree_bytes = 0;
+
+	if (f.source_is_dir) {
+		const TreeListing listing = ListTree(from);
+
+		tree_bytes = listing.ok ? listing.bytes : 0;
+	}
+
 	{
 		const wxString anchor = f.dest_is_dir ? to : NearestExisting(to);
 
 		f.dest_parent_writable = (!anchor.empty() && CanWriteIn(anchor)) ? 1 : 0;
 
-		if (f.source_is_dir) {
-			const TreeListing listing = ListTree(from);
-
-			f.bytes_needed = listing.ok ? listing.bytes : 0;
-		}
+		f.bytes_needed = tree_bytes;
 		/*
 		 * Free space where the files are going. Left at zero when it cannot be
 		 * had: folder_move_space_is_enough() treats a pair of zeroes as "not
@@ -273,7 +287,7 @@ FolderTransferGatherFacts(const wxString &from, const wxString &to, bool in_use,
 	}
 
 	if (bytes != NULL) {
-		*bytes = f.source_is_dir ? ListTree(from).bytes : 0;
+		*bytes = tree_bytes;
 	}
 	return f;
 }

--- a/src/gui/machine_edit_dialog.cpp
+++ b/src/gui/machine_edit_dialog.cpp
@@ -42,6 +42,7 @@ extern "C" {
 #include <wx/artprov.h>
 #include <wx/statbmp.h>
 
+#include <wx/busyinfo.h>
 #include <wx/dir.h>
 #include <wx/fileconf.h>
 #include <wx/bmpbuttn.h>
@@ -3217,8 +3218,37 @@ bool MachineEditDialog::OfferToBringHostfsFilesAcross()
 	const wxString from = ResolveHostfsValue(original_hostfs_);
 	const wxString to = ResolveHostfsValue(now);
 	unsigned long long bytes = 0;
-	const folder_move_facts facts =
-	    FolderTransferGatherFacts(from, to, emulator_running_, &bytes);
+
+	/*
+	 * A machine that has never been used is not an empty folder. It carries the
+	 * seed copied out of default/hostfs, so "is there anything in there" answers
+	 * yes and the user was offered the chance to move files they had never put
+	 * anywhere - reported as issue #204, on a machine created minutes earlier.
+	 *
+	 * Only for the machine's own default folder, which is the case that can hold
+	 * a seed and nothing else. Somewhere the user named themselves is their own
+	 * disc and is asked about however little is in it.
+	 */
+	if (original_hostfs_.empty() && RiscosFetchHostfsIsPristine(from)) {
+		return true;
+	}
+
+	folder_move_facts facts;
+
+	{
+		/*
+		 * Both trees are walked and sized here, which on a full HardDisc4 is
+		 * tens of thousands of files and takes long enough that the window
+		 * stops repainting and Windows calls it dead. Also #204. wxBusyInfo
+		 * paints a window of its own, so there is something on screen that is
+		 * demonstrably still alive.
+		 */
+		wxBusyCursor busy;
+		wxBusyInfo info("Checking the HostFS folders...", this);
+
+		facts = FolderTransferGatherFacts(from, to, emulator_running_, &bytes);
+	}
+
 	folder_move_reason why = FOLDER_MOVE_OK;
 	const folder_move_offer offer = folder_move_decide(&facts, &why);
 

--- a/src/gui/riscos_fetch.cpp
+++ b/src/gui/riscos_fetch.cpp
@@ -1039,6 +1039,11 @@ bool RiscosFetchMachineDiscIsEmpty(const wxString &machine_name)
 	                        wxFileName::GetPathSeparator() + "hostfs");
 }
 
+bool RiscosFetchHostfsIsPristine(const wxString &hostfs_dir)
+{
+	return HostfsIsPristine(hostfs_dir);
+}
+
 long long RiscosFetchApproximateSize(const RiscosFetchRequest &request)
 {
 	return (request.include_rom ? kRomApproxBytes : 0) +

--- a/src/gui/riscos_fetch.h
+++ b/src/gui/riscos_fetch.h
@@ -205,4 +205,16 @@ long long RiscosFetchApproximateSize(const RiscosFetchRequest &request);
  */
 bool RiscosFetchMachineDiscIsEmpty(const wxString &machine_name);
 
+/**
+ * The same test against a HostFS folder named directly, rather than by the
+ * machine that owns it.
+ *
+ * The machine editor needs it for a folder the user has just typed, which has
+ * no machine name attached to it yet. See issue #204: a machine created moments
+ * ago carries the seed, so "is this folder empty" and "has anything been put on
+ * this disc" are not the same question, and the second is the one worth asking
+ * before offering to move files.
+ */
+bool RiscosFetchHostfsIsPristine(const wxString &hostfs_dir);
+
 #endif /* RISCOS_FETCH_H */

--- a/tests/test_folder_transfer.cpp
+++ b/tests/test_folder_transfer.cpp
@@ -316,6 +316,65 @@ test_manual_and_cancel_do_nothing(const wxString &tmp)
 	check("and there is always a message to show", !r.message.empty());
 }
 
+/*
+ * The facts the decision is made from, which is the half that reads the disc.
+ *
+ * Added with the issue #204 fix, which stopped this walking the source tree
+ * twice for one answer. The size has to come out right whichever field is
+ * asked for it, and the two must agree, because they used to be two separate
+ * walks and could not disagree by construction. Now they can.
+ */
+static void
+test_gather_facts(const wxString &tmp)
+{
+	const wxString from = tmp + Sep() + "facts-from";
+	const wxString to = tmp + Sep() + "facts-to";
+	unsigned long long bytes = 0;
+
+	puts("Gathering the facts about a pair of folders:");
+
+	Nuke(from);
+	Nuke(to);
+	MakeSourceTree(from);
+
+	folder_move_facts f = FolderTransferGatherFacts(from, to, false, &bytes);
+
+	check("the source is seen, and seen as a directory",
+	    f.source_exists && f.source_is_dir);
+	check("a source with files in it is not empty", !f.source_empty);
+	check("the destination is correctly reported as not there yet",
+	    !f.dest_exists);
+	check("the tree is sized, not reported as nothing", bytes > 0);
+	check("and the caller's figure matches the one used for free space",
+	    bytes == f.bytes_needed);
+
+	/* "boot" + "draw" + "deep", with no separators or padding: the sizes are
+	   the file contents from MakeSourceTree() and nothing else. */
+	check("the size is the sum of the files, and the empty directory adds none",
+	    bytes == 4 + 4 + 4);
+
+	/* An empty source is the case the machine editor leans on: a machine that
+	   has nothing on its disc must not be offered a move. Since #204 a new
+	   machine's HostFS really is empty, so this is the state it is in. */
+	Nuke(from);
+	wxDir::Make(from, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+
+	bytes = 1;	/* Not zero, so a figure that is never written shows up. */
+	f = FolderTransferGatherFacts(from, to, false, &bytes);
+
+	folder_move_reason why = FOLDER_MOVE_OK;
+	const folder_move_offer offer = folder_move_decide(&f, &why);
+
+	check("an empty source is reported empty", f.source_empty);
+	check("its size is nothing", bytes == 0);
+	check("nothing is offered for it", offer == FOLDER_MOVE_OFFER_NOTHING);
+	check("and the reason given is that the source is empty",
+	    why == FOLDER_MOVE_SOURCE_EMPTY);
+
+	Nuke(from);
+	Nuke(to);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -337,6 +396,7 @@ main(int argc, char **argv)
 	test_failure_leaves_everything_as_it_was(tmp);
 	test_move_never_destroys(tmp);
 	test_manual_and_cancel_do_nothing(tmp);
+	test_gather_facts(tmp);
 
 	/* Tidy up, whatever happened. */
 	{


### PR DESCRIPTION
Addresses #204, reported against 1.1.17 on Windows 11.

A machine created minutes earlier, pointed at a HostFS folder elsewhere, offered
to move files the user had never put anywhere, and the window sat unresponsive
for a minute or two before saying so. Three separate things on that one path.

**The seed.** `default/hostfs` held one file, `Network/ReadMe,fff`, inherited
from upstream. It says networking no longer needs setting up there "as of
version 0.9.1" and links a manual that is not ours. It was also the only thing
in the seed, so every new machine's HostFS was non-empty from creation and the
transfer logic correctly reported there was something in it. Deleted.
`ConfigPathsCreateMachineDirectory()` already falls back to making the folder
when there is no seed to copy, so a new machine simply gets an empty HostFS.

**Folders that still hold a seed.** Deleting the file does nothing for anyone
who already has it extracted in their data directory, so the machine editor now
asks whether anything has been *put on* the disc rather than whether the folder
has anything in it. That test already existed for the ROM download, which has
the same question to answer before writing to somebody's disc; exported here as
`RiscosFetchHostfsIsPristine()`. Applied only to the machine's own default
folder, since that is the one that can hold a seed and nothing else. A folder
the user named themselves is their own disc and is still asked about.

**The wait.** `FolderTransferGatherFacts()` walked and sized the source tree
twice for one answer, once for the free-space check and once for the caller's
figure. On a full HardDisc4 that is tens of thousands of files stat'ed twice
with nothing on screen. It walks once now, and the machine editor puts a
`wxBusyInfo` up while it does.

## Tests

`tests/test_folder_transfer.cpp` had no coverage of `GatherFacts` at all, which
is how one walk could quietly become two. It now checks the tree is sized, that
the caller's figure and the free-space figure agree, and that an empty source is
reported empty and offered nothing, which is the state a new machine's HostFS is
now actually in.

All 77 tests pass here, and the payload was checked to confirm the stale file is
no longer embedded.

## What is verified where

Built and tested on macOS arm64. The report is from Windows 11 and there is no
Windows machine here, so the Windows behaviour rests on CI. The `wxBusyInfo`
in particular is the part I cannot watch: it is there so the window keeps
painting during the scan, and halving the scan is the change that does the real
work either way.

The 1.x backport is 209.
