### PR TITLE
Screen size: budget a size the user names at 8bpp, not 32

### DIFF
--- a/src/display_mode.h
+++ b/src/display_mode.h
@@ -51,6 +51,26 @@ extern int display_mode_fit(unsigned max_width, unsigned max_height,
                             unsigned bytes_per_pixel, size_t budget_bytes,
                             unsigned *width, unsigned *height);
 
+/*
+ * The two depths worth budgeting for, named rather than written as bare numbers
+ * at each call, because which one a caller wants is a decision and 1 or 4 on its
+ * own does not read as one.
+ *
+ * DISPLAY_BPP_SAFE is 32bpp, for choosing a size on the user's behalf: whatever
+ * is picked automatically should still work when RISC OS lands in the deepest
+ * mode it has.
+ *
+ * DISPLAY_BPP_SHALLOWEST is 8bpp, for a size the user has asked for by name.
+ * The depth is the guest's choice, not ours, and budgeting a request at 32bpp
+ * refuses modes that work perfectly well in 256 colours - which is issue #207,
+ * where 3840x2160 needs 33MB at 32bpp and 8MB at 8bpp, so it was filtered out of
+ * every machine we can configure while being entirely displayable on a 16MB one.
+ * Someone who names a size is telling us what they want; the deeper modes at
+ * that size may not be available, and that is theirs to find out.
+ */
+#define DISPLAY_BPP_SAFE        4
+#define DISPLAY_BPP_SHALLOWEST  1
+
 /**
  * How many standard modes there are, for walking the list.
  *

--- a/src/gui/display_options.h
+++ b/src/gui/display_options.h
@@ -57,7 +57,8 @@ inline const char *ScreenSizeHelp()
 {
 	return "The size of the RISC OS desktop. Only modes this machine's display "
 	       "memory can hold are offered; fit more VRAM, or the graphics card, for "
-	       "the larger ones.";
+	       "the larger ones. The biggest sizes need a lower colour depth to fit, "
+	       "so RISC OS may not offer 32 thousand or 16 million colours there.";
 }
 
 /* --- how that desktop is drawn in the window ----------------------------- */
@@ -126,8 +127,14 @@ inline void FixedModes(size_t display_memory,
 		if (!display_mode_get(i, &w, &h)) {
 			continue;
 		}
+		/* Budgeted at the shallowest depth, not the deepest. The user is
+		   choosing a size, and the colour depth at that size is the guest's
+		   choice afterwards - see DISPLAY_BPP_SHALLOWEST. Budgeting the list at
+		   32bpp hid 3840x2160 from every machine we can configure, including
+		   16MB VRAM ones that display it quite happily in 256 colours, which is
+		   issue #207. What stays out is a mode that fits at no depth at all. */
 		if (display_memory != 0 &&
-		    (size_t) w * (size_t) h * 4u > display_memory)
+		    (size_t) w * (size_t) h * DISPLAY_BPP_SHALLOWEST > display_memory)
 		{
 			continue;
 		}

--- a/src/rom_patch.c
+++ b/src/rom_patch.c
@@ -489,13 +489,21 @@ rom_patch_monitor_edid(size_t rom_bytes)
 	   it cannot display: RISC OS answers "not suitable for displaying the
 	   desktop", which is how a Kinetic (clamped to 2MB) reacts to being offered
 	   2560x1440. With the graphics card fitted the budget is the card's own
-	   framestore, which is the point of it. Budget 32bpp, since that is the
-	   deepest the desktop may choose and the advertised mode has to work
-	   whichever depth is configured. A machine with no VRAM fitted takes screen
-	   memory from DRAM instead, so there is no figure to reason about and the
-	   limit is skipped. */
-	if (!display_mode_fit(bound_x, bound_y, 4, rpcemu_display_memory(),
-	                             &native_x, &native_y))
+	   framestore, which is the point of it. A machine with no VRAM fitted takes
+	   screen memory from DRAM instead, so there is no figure to reason about and
+	   the limit is skipped.
+
+	   Budgeted at the shallowest depth, and it has to be: rpcemu_edid_bound()
+	   hands a size the user named straight through, and re-fitting it at 32bpp
+	   here would advertise a smaller preferred timing than the one they chose.
+	   RISC OS validates against the monitor definition in force, so the mode
+	   they asked for would then be refused and the setting would appear to do
+	   nothing - issue #207. The size still cannot exceed what the framestore
+	   holds at any depth; what it no longer does is demand room for a depth
+	   nobody asked for. The fallback is unaffected, since the default size has
+	   already been fitted at DISPLAY_BPP_SAFE before it arrives here. */
+	if (!display_mode_fit(bound_x, bound_y, DISPLAY_BPP_SHALLOWEST,
+	                             rpcemu_display_memory(), &native_x, &native_y))
 	{
 		rpclog("rom_patch: no standard mode fits %zu KB of display memory "
 		       "within %ux%u - leaving the monitor EDID alone\n",

--- a/src/rpcemu.c
+++ b/src/rpcemu.c
@@ -161,8 +161,11 @@ rpcemu_default_screen_size(unsigned *width, unsigned *height)
 		return 0;
 	}
 
-	return display_mode_fit(max_w, max_h, 4, rpcemu_display_memory(),
-	                        width, height);
+	/* Chosen for the user, so budgeted at the deepest mode RISC OS might land
+	   in. A size the user names themselves is a different question - see
+	   rpcemu_guest_size_for(). */
+	return display_mode_fit(max_w, max_h, DISPLAY_BPP_SAFE,
+	                        rpcemu_display_memory(), width, height);
 }
 
 int
@@ -185,8 +188,16 @@ rpcemu_guest_size_for(unsigned width, unsigned height,
 		return 0;
 	}
 
-	return display_mode_fit(width, height, 4, rpcemu_display_memory(),
-	                        fitted_width, fitted_height);
+	/*
+	 * A size somebody asked for by name, so budgeted at the shallowest depth
+	 * rather than the deepest. Issue #207: 3840x2160 needs 33MB at 32bpp and
+	 * 8MB at 8bpp, so budgeting the request at 32bpp quietly substituted a
+	 * smaller mode for one the machine could display perfectly well in 256
+	 * colours - and did it after the size had been offered and chosen, which is
+	 * worse than not offering it.
+	 */
+	return display_mode_fit(width, height, DISPLAY_BPP_SHALLOWEST,
+	                        rpcemu_display_memory(), fitted_width, fitted_height);
 }
 
 void
@@ -208,8 +219,8 @@ rpcemu_request_guest_size_ex(unsigned width, unsigned height, int force)
 	   width, and all but a few of those land on the same standard mode; bumping
 	   the generation for each would have the guest reflowing its desktop over
 	   and over to arrive where it already was. */
-	if (!display_mode_fit(width, height, 4, rpcemu_display_memory(),
-	                      &fitted_w, &fitted_h))
+	if (!display_mode_fit(width, height, DISPLAY_BPP_SHALLOWEST,
+	                      rpcemu_display_memory(), &fitted_w, &fitted_h))
 	{
 		return;
 	}

--- a/tests/test_mode_fit.c
+++ b/tests/test_mode_fit.c
@@ -446,6 +446,28 @@ main(void)
 	expect_mode("Kinetic 2MB at 16bpp", 1920, 1080, 2, 2, 1360, 768);
 	expect_mode("8MB at 16bpp", 1920, 1080, 2, 8, 1920, 1080);
 
+	/*
+	 * The same machines with the desktop in 256 colours, which is what a size
+	 * asked for by name is budgeted at since issue #207.
+	 *
+	 * 3840x2160 is the case in the report: 33MB at 32bpp, so no machine we can
+	 * configure could reach it, against 8MB at 8bpp, which a 16MB VRAM machine
+	 * holds with room to spare. The mode was there in the list all along and
+	 * the budget was the only thing keeping it out.
+	 */
+	printf("\nand the same machines at 8bpp, which is what a named size gets\n");
+	expect_mode("16MB at 8bpp reaches 4K", 3840, 2160, 1, 16, 3840, 2160);
+	/* The same machine budgeted at 32bpp stops at 1440p, which is the case
+	   asserted above and the whole of the difference the report was about. */
+	/* 8MB gets there too, with 92KB to spare: 3840x2160 is 8100KB against a
+	   budget of 8192KB. Worth pinning, because it is the closest fit in the
+	   whole table and an off-by-a-little in the budget arithmetic would move
+	   it. */
+	expect_mode("8MB at 8bpp reaches 4K, barely", 3840, 2160, 1, 8, 3840, 2160);
+	/* Depth buys headroom, it does not remove the limit: 2MB still cannot show
+	   4K in 256 colours, and stops at the largest mode under two megabytes. */
+	expect_mode("2MB at 8bpp is still bounded", 3840, 2160, 1, 2, 1920, 1080);
+
 	printf("\nbounds are respected exactly\n");
 	expect_mode("host exactly 800x600", 800, 600, 4, 8, 800, 600);
 	expect_mode("host one pixel under 800x600", 799, 599, 4, 8, 640, 480);


### PR DESCRIPTION
Addresses #207, reported against 1.1.17 on Windows 11 with RISC OS 4.02.

**The report blames the wrong thing, and so did I at first.** The greyed-out
graphics card checkbox is a red herring, and so is the RISC OS version. The mode
was being filtered out by a colour depth nobody had asked for, on every machine
and every OS.

The screen size list budgeted every mode at four bytes per pixel:

```
w * h * 4 > display_memory   ->  drop the mode
```

3840x2160 at 32bpp needs 33.2MB. The largest VRAM we offer is 16MB and the
graphics card is 15MB, so that mode was hidden from every machine this emulator
can be configured to be. At 8bpp, which is what the reporter asked for with
`C256`, it needs 8.3MB and sits comfortably inside 16MB. He could do it in
1.1.13 because this list did not exist then.

## The change

Two questions were sharing one number, so they are separated and named in
`display_mode.h`:

- `DISPLAY_BPP_SAFE` (4) for a size the emulator chooses on the user's behalf.
  RISC OS may land in the deepest mode it has, and an automatic choice should
  still work when it does. `rpcemu_default_screen_size()` keeps this.
- `DISPLAY_BPP_SHALLOWEST` (1) for a size the user asked for by name. The depth
  at that size is the guest's business afterwards.

Three places take the shallow depth, and **all three had to move together** or
the setting would have gone on appearing not to work:

1. The list filter in `display_options.h`, which is what hid the mode.
2. `rpcemu_guest_size_for()`, or the mode would be offered, chosen, and then
   quietly substituted for a smaller one that fits at 32bpp.
3. The EDID preferred timing in `rom_patch.c`. This is the one that would have
   been missed. `rpcemu_edid_bound()` hands a named size straight through, so
   re-fitting it at 32bpp there would advertise a smaller monitor than the user
   chose, and RISC OS validates modes against the monitor definition in force.
   The mode would have been refused with everything else correct.

What still cannot be chosen is a mode that fits at no depth at all. 2MB of VRAM
stops at 1920x1080 in 256 colours, and the message pointing at more VRAM or the
graphics card is unchanged. The help text now says the largest sizes need a
lower colour depth, since that is the trade being made.

The graphics card gate is untouched and remains RISC OS 5 only. That is a
separate question from the resolution, and the report conflates the two.

## Tests

`tests/test_mode_fit.c` gains the 8bpp ladder alongside the 32bpp one it already
had. 8MB reaching 3840x2160 with 92KB to spare is the closest fit in the entire
table and is pinned deliberately, because an off-by-a-little in the budget
arithmetic would move it. All 77 tests pass.

## What is verified where

The arithmetic and the mode selection are covered by unit tests and are exact.
What has **not** been done here is an end-to-end boot of RISC OS 4.02 at
3840x2160 - there is no Windows machine here, and no 4.02 machine set up to try
it on. The mechanism is unambiguous from the code, but the reporter is the one
who can confirm the symptom is gone, and I would want that before calling it
closed.

The 1.x backport is 211.
