### PR TITLE
Access relay: choose the interface, and let the user name it

### DIFF
--- a/src/app_settings.c
+++ b/src/app_settings.c
@@ -138,6 +138,10 @@ apply(Config *cfg, const char *key, const char *value)
 		set_str(cfg->hostcmd_socket, sizeof(cfg->hostcmd_socket), value);
 		return 1;
 	}
+	if (strcmp(key, "relay_interface") == 0) {
+		set_str(cfg->relay_interface, sizeof(cfg->relay_interface), value);
+		return 1;
+	}
 
 	/* An unknown key is left alone rather than treated as an error: a settings
 	   file written by a later version should not stop this one starting. */
@@ -235,13 +239,20 @@ app_settings_save(const char *datadir, const Config *cfg)
 	    "vnc_password=%s\n"
 	    "vnc_password_readonly=%s\n"
 	    "hostcmd_enabled=%d\n"
-	    "hostcmd_socket=%s\n",
+	    "hostcmd_socket=%s\n"
+	    "\n"
+	    "# Which host interface the Access broadcast relay uses. Empty chooses one,\n"
+	    "# preferring a real wired or wireless adapter over a VPN or virtual one.\n"
+	    "# Set it to part of an interface name if that choice is wrong; the log\n"
+	    "# lists every candidate it considered at startup.\n"
+	    "relay_interface=%s\n",
 	    cfg->vnc_enabled ? 1 : 0,
 	    cfg->vnc_port,
 	    cfg->vnc_password,
 	    cfg->vnc_password_readonly,
 	    cfg->hostcmd_enabled ? 1 : 0,
-	    cfg->hostcmd_socket);
+	    cfg->hostcmd_socket,
+	    cfg->relay_interface);
 
 	if (fflush(f) != 0 || ferror(f)) {
 		fclose(f);

--- a/src/broadcast_relay.c
+++ b/src/broadcast_relay.c
@@ -36,6 +36,7 @@
  * exceeding Ethernet MTU are delivered via IP fragmentation.
  */
 
+#include <ctype.h>
 #include <errno.h>
 #include <string.h>
 #include <time.h>
@@ -387,21 +388,172 @@ find_socket_for_port(uint16_t port)
     return -1;
 }
 
+/*
+ * Choosing the interface the Access relay broadcasts on.
+ *
+ * "The first one that is not loopback" was the rule, and it is wrong on any
+ * machine with a VPN client, a hypervisor or a container runtime on it. Issue
+ * #205: with a VPN connected the relay bound to the VPN's adapter, so Access
+ * broadcasts went somewhere no Acorn can hear them, and disconnecting the VPN
+ * was the only way to get the real adapter back.
+ *
+ * There is no reliable way to ask a host "which interface is my LAN", so the
+ * candidates are scored and the best one wins. The scores are deliberately far
+ * apart, so the ordering is readable in the log rather than depending on a
+ * near-tie nobody can see. An explicit relay_interface setting skips all of it.
+ */
+
+#define RELAY_SCORE_REAL_MEDIA   100	/* Ethernet or wireless, per the OS */
+#define RELAY_SCORE_HAS_GATEWAY   10	/* On a network with a way off it */
+#define RELAY_SCORE_TUNNEL      (-100)	/* VPN, tunnel or point-to-point */
+
+/*
+ * Interface names that are a tunnel or a virtual link on some platform we build
+ * for. Matched as a prefix against a lowercased name.
+ *
+ * awdl and llw are Apple Wireless Direct Link and its low-latency sibling: both
+ * are up, running, broadcast-capable and completely useless for this, and awdl0
+ * sorts before en0 on a Mac, so without this the wrong one was picked there too.
+ */
+static const char *const relay_tunnel_prefixes[] = {
+	"utun", "tun", "tap", "ppp", "ipsec", "wg", "vpn", "gpd", "zt",
+	"awdl", "llw", "bridge", "vmnet", "docker", "veth", "vboxnet",
+};
+
+/* Case-insensitive substring, so a user need only give part of a name. */
+static int
+relay_name_contains(const char *haystack, const char *needle)
+{
+	size_t i, j;
+
+	if (haystack == NULL || needle == NULL || needle[0] == '\0') {
+		return 0;
+	}
+	for (i = 0; haystack[i] != '\0'; i++) {
+		for (j = 0; needle[j] != '\0'; j++) {
+			const char a = (char) tolower((unsigned char) haystack[i + j]);
+			const char b = (char) tolower((unsigned char) needle[j]);
+
+			if (haystack[i + j] == '\0' || a != b) {
+				break;
+			}
+		}
+		if (needle[j] == '\0') {
+			return 1;
+		}
+	}
+	return 0;
+}
+
+static int
+relay_name_is_tunnel(const char *name)
+{
+	size_t i;
+
+	if (name == NULL) {
+		return 0;
+	}
+	for (i = 0; i < sizeof(relay_tunnel_prefixes) / sizeof(relay_tunnel_prefixes[0]);
+	     i++)
+	{
+		const char *p = relay_tunnel_prefixes[i];
+		size_t j;
+
+		for (j = 0; p[j] != '\0'; j++) {
+			if (tolower((unsigned char) name[j]) != p[j]) {
+				break;
+			}
+		}
+		if (p[j] == '\0') {
+			return 1;
+		}
+	}
+	return 0;
+}
+
+/*
+ * The interface the user named, or empty for "choose one".
+ *
+ * Held here rather than read from the global config, because this file is
+ * linked on its own by tests/test_relay_datagram.c and tests/test_relay_reasm.c
+ * and touching `config` would drag the emulator in behind it. The caller hands
+ * it over before broadcast_relay_init(); see broadcast_relay_set_interface().
+ */
+static char relay_interface[128];
+
+void
+broadcast_relay_set_interface(const char *name)
+{
+	if (name == NULL) {
+		relay_interface[0] = '\0';
+		return;
+	}
+	snprintf(relay_interface, sizeof(relay_interface), "%s", name);
+}
+
+/* The setting, or NULL when it is empty and a choice has to be made. */
+static const char *
+relay_wanted_interface(void)
+{
+	if (relay_interface[0] == '\0') {
+		return NULL;
+	}
+	return relay_interface;
+}
+
+/*
+ * Said once, when the choice was made without being told. Names the setting and
+ * the file, because somebody reading the log after an Access share failed to
+ * appear needs to know there is a lever and where it is.
+ */
+static void
+relay_log_choice(const char *chosen, int scored, int by_name)
+{
+	const char *wanted = relay_wanted_interface();
+
+	if (by_name) {
+		rpclog("broadcast_relay: using %s, named by relay_interface\n", chosen);
+		return;
+	}
+
+	/* A setting that matched nothing must say so. Falling back to the best
+	   candidate is right - better a working relay on the wrong interface than
+	   none at all - but reporting it as the interface they asked for would send
+	   somebody looking for the fault everywhere except at their own typo. */
+	if (wanted != NULL) {
+		rpclog("broadcast_relay: relay_interface=\"%s\" matched no interface, "
+		       "so %s was chosen instead (score %d)\n", wanted, chosen, scored);
+		return;
+	}
+
+	rpclog("broadcast_relay: chose %s (score %d). If Access cannot see other "
+	       "machines, set relay_interface in the application settings file to "
+	       "part of the name of the adapter you want.\n", chosen, scored);
+}
+
 /**
- * Find the broadcast address for the first suitable network interface.
- * Skips loopback and interfaces without broadcast capability.
+ * Find the broadcast address for the most suitable network interface.
+ * Skips loopback and interfaces without broadcast capability; prefers a real
+ * wired or wireless adapter over a tunnel. See the scoring note above.
  */
 #ifdef _WIN32
 static int
 get_broadcast_address(struct in_addr *bcast, struct in_addr *host)
 {
-    /* Enumerate IPv4 adapters via GetAdaptersInfo() (iphlpapi). For the first
-       non-loopback adapter with a real address, derive the directed broadcast
-       address from the IP and subnet mask (bcast = ip | ~mask). */
+    /* Enumerate IPv4 adapters via GetAdaptersInfo() (iphlpapi). Every adapter
+       with a real address is a candidate; the best-scoring one wins, and the
+       directed broadcast address comes from the IP and subnet mask
+       (bcast = ip | ~mask). */
     IP_ADAPTER_INFO *adapters = NULL, *ad;
     ULONG size = 0;
     DWORD ret;
+    const char *wanted = relay_wanted_interface();
+    int best_score = 0;
     int found = 0;
+    int found_by_name = 0;
+    char best_name[256];
+
+    best_name[0] = '\0';
 
     ret = GetAdaptersInfo(NULL, &size);
     if (ret != ERROR_BUFFER_OVERFLOW) {
@@ -421,7 +573,7 @@ get_broadcast_address(struct in_addr *bcast, struct in_addr *host)
         return -1;
     }
 
-    for (ad = adapters; ad != NULL && !found; ad = ad->Next) {
+    for (ad = adapters; ad != NULL; ad = ad->Next) {
         IP_ADDR_STRING *ip;
 
         if (ad->Type == MIB_IF_TYPE_LOOPBACK) {
@@ -429,6 +581,8 @@ get_broadcast_address(struct in_addr *bcast, struct in_addr *host)
         }
         for (ip = &ad->IpAddressList; ip != NULL; ip = ip->Next) {
             struct in_addr ipaddr, mask;
+            int score = 0;
+            int wanted_this;
 
             ipaddr.s_addr = inet_addr(ip->IpAddress.String);
             mask.s_addr = inet_addr(ip->IpMask.String);
@@ -438,18 +592,73 @@ get_broadcast_address(struct in_addr *bcast, struct in_addr *host)
                 continue;
             }
 
-            host->s_addr = ipaddr.s_addr;
-            bcast->s_addr = ipaddr.s_addr | ~mask.s_addr;
-            found = 1;
+            /* Windows names an adapter twice: a GUID-ish AdapterName and the
+               Description the user actually recognises. Match on either. */
+            wanted_this = wanted != NULL &&
+                (relay_name_contains(ad->Description, wanted) ||
+                 relay_name_contains(ad->AdapterName, wanted));
 
-            rpclog("broadcast_relay: using adapter %s, host %s, ",
-                   ad->Description, inet_ntoa(*host));
-            rpclog("broadcast %s\n", inet_ntoa(*bcast));
-            break;
+            /* The OS's own idea of the medium is the strongest signal there is,
+               and it is the one that separates a Realtek WiFi adapter from a
+               VPN's virtual one without having to recognise either by name. */
+            if (ad->Type == MIB_IF_TYPE_ETHERNET || ad->Type == IF_TYPE_IEEE80211) {
+                score += RELAY_SCORE_REAL_MEDIA;
+            }
+            if (ad->Type == MIB_IF_TYPE_PPP || ad->Type == IF_TYPE_TUNNEL ||
+                relay_name_is_tunnel(ad->AdapterName) ||
+                relay_name_contains(ad->Description, "VPN") ||
+                relay_name_contains(ad->Description, "Virtual") ||
+                relay_name_contains(ad->Description, "Pseudo") ||
+                relay_name_contains(ad->Description, "TAP-"))
+            {
+                score += RELAY_SCORE_TUNNEL;
+            }
+            if (ad->GatewayList.IpAddress.String[0] != '\0' &&
+                inet_addr(ad->GatewayList.IpAddress.String) != 0)
+            {
+                score += RELAY_SCORE_HAS_GATEWAY;
+            }
+
+            rpclog("broadcast_relay: candidate \"%s\" host %s type %u score %d%s\n",
+                   ad->Description, ip->IpAddress.String,
+                   (unsigned) ad->Type, score, wanted_this ? " (named)" : "");
+
+            /* An adapter the user named is taken outright, whatever it scores.
+               They know something the scoring does not. */
+            if (wanted_this) {
+                *host = ipaddr;
+                bcast->s_addr = ipaddr.s_addr | ~mask.s_addr;
+                snprintf(best_name, sizeof(best_name), "%s", ad->Description);
+                best_score = score;
+                found = 1;
+                found_by_name = 1;
+                goto done;
+            }
+
+            if (!found || score > best_score) {
+                *host = ipaddr;
+                bcast->s_addr = ipaddr.s_addr | ~mask.s_addr;
+                snprintf(best_name, sizeof(best_name), "%s", ad->Description);
+                best_score = score;
+                found = 1;
+            }
         }
     }
 
+done:
     free(adapters);
+
+    if (found) {
+        char host_str[INET_ADDRSTRLEN];
+
+        snprintf(host_str, sizeof(host_str), "%s", inet_ntoa(*host));
+        rpclog("broadcast_relay: using adapter %s, host %s, broadcast %s\n",
+               best_name, host_str, inet_ntoa(*bcast));
+        relay_log_choice(best_name, best_score, found_by_name);
+    } else if (wanted != NULL) {
+        rpclog("broadcast_relay: no adapter is usable at all, so "
+               "relay_interface=\"%s\" could not be honoured\n", wanted);
+    }
     return found ? 0 : -1;
 }
 #else
@@ -457,7 +666,13 @@ static int
 get_broadcast_address(struct in_addr *bcast, struct in_addr *host)
 {
     struct ifaddrs *ifaddr, *ifa;
+    const char *wanted = relay_wanted_interface();
+    int best_score = 0;
     int found = 0;
+    int found_by_name = 0;
+    char best_name[IFNAMSIZ + 1];
+
+    best_name[0] = '\0';
 
     if (getifaddrs(&ifaddr) < 0) {
         rpclog("broadcast_relay: getifaddrs() failed: %s\n", strerror(errno));
@@ -465,6 +680,10 @@ get_broadcast_address(struct in_addr *bcast, struct in_addr *host)
     }
 
     for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
+        struct sockaddr_in *bcast_sa, *host_sa;
+        int score = 0;
+        int wanted_this;
+
         if (ifa->ifa_addr == NULL) {
             continue;
         }
@@ -501,22 +720,64 @@ get_broadcast_address(struct in_addr *bcast, struct in_addr *host)
         /* Get broadcast address. Use the standard ifa_broadaddr spelling: on
            glibc it is a macro over the ifa_ifu union; on macOS/BSD it is a
            direct struct member (there is no ifa_ifu union there). */
-        if (ifa->ifa_broadaddr != NULL) {
-            struct sockaddr_in *bcast_sa = (struct sockaddr_in *)ifa->ifa_broadaddr;
-            struct sockaddr_in *host_sa = (struct sockaddr_in *)ifa->ifa_addr;
+        if (ifa->ifa_broadaddr == NULL) {
+            continue;
+        }
 
+        wanted_this = wanted != NULL &&
+            relay_name_contains(ifa->ifa_name, wanted);
+
+        /* There is no medium to ask about here as there is on Windows, so the
+           name and the point-to-point flag are what is left. Both catch a
+           tunnel; neither is certain, which is why the setting exists. */
+        if (relay_name_is_tunnel(ifa->ifa_name) ||
+            (ifa->ifa_flags & IFF_POINTOPOINT))
+        {
+            score += RELAY_SCORE_TUNNEL;
+        } else {
+            score += RELAY_SCORE_REAL_MEDIA;
+        }
+
+        bcast_sa = (struct sockaddr_in *) ifa->ifa_broadaddr;
+        host_sa = (struct sockaddr_in *) ifa->ifa_addr;
+
+        rpclog("broadcast_relay: candidate %s host %s score %d%s\n",
+               ifa->ifa_name, inet_ntoa(host_sa->sin_addr), score,
+               wanted_this ? " (named)" : "");
+
+        /* An interface the user named is taken outright, whatever it scores. */
+        if (wanted_this) {
             *bcast = bcast_sa->sin_addr;
             *host = host_sa->sin_addr;
+            snprintf(best_name, sizeof(best_name), "%s", ifa->ifa_name);
+            best_score = score;
             found = 1;
-
-            rpclog("broadcast_relay: using interface %s, host %s, ",
-                   ifa->ifa_name, inet_ntoa(*host));
-            rpclog("broadcast %s\n", inet_ntoa(*bcast));
+            found_by_name = 1;
             break;
+        }
+
+        if (!found || score > best_score) {
+            *bcast = bcast_sa->sin_addr;
+            *host = host_sa->sin_addr;
+            snprintf(best_name, sizeof(best_name), "%s", ifa->ifa_name);
+            best_score = score;
+            found = 1;
         }
     }
 
     freeifaddrs(ifaddr);
+
+    if (found) {
+        char host_str[INET_ADDRSTRLEN];
+
+        snprintf(host_str, sizeof(host_str), "%s", inet_ntoa(*host));
+        rpclog("broadcast_relay: using interface %s, host %s, broadcast %s\n",
+               best_name, host_str, inet_ntoa(*bcast));
+        relay_log_choice(best_name, best_score, found_by_name);
+    } else if (wanted != NULL) {
+        rpclog("broadcast_relay: no interface is usable at all, so "
+               "relay_interface=\"%s\" could not be honoured\n", wanted);
+    }
     return found ? 0 : -1;
 }
 #endif /* _WIN32 */

--- a/src/broadcast_relay.h
+++ b/src/broadcast_relay.h
@@ -52,6 +52,16 @@ extern "C" {
  *
  * @return 0 on success, -1 on failure (relay disabled, emulator continues)
  */
+/**
+ * Name the host interface the relay should broadcast on, before init.
+ *
+ * Empty or NULL means choose one, preferring a real wired or wireless adapter
+ * over a tunnel. Matched case-insensitively as a substring, against the
+ * interface name on Unix and against both the adapter name and its description
+ * on Windows. See issue #205, where a connected VPN took the relay with it.
+ */
+void broadcast_relay_set_interface(const char *name);
+
 int broadcast_relay_init(void);
 
 /**

--- a/src/network-nat.c
+++ b/src/network-nat.c
@@ -321,6 +321,7 @@ network_nat_init(void)
 	}
 
 	if (app_settings_relay_enabled()) {
+		broadcast_relay_set_interface(config.relay_interface);
 		broadcast_relay_init();
 	} else {
 		rpclog("network: Access broadcast relay disabled for this instance "

--- a/src/rpcemu.c
+++ b/src/rpcemu.c
@@ -350,6 +350,7 @@ Config config = {
 	"",			/* vnc_password */
 	"",			/* vnc_password_readonly */
 	1,			/* hostcmd_enabled (ON by default) */
+	"",			/* relay_interface (empty => choose one; see issue #205) */
 	"",			/* hostcmd_socket (empty => <machinedir>hostcmd.sock) */
 	1,			/* netcap_enabled (ON by default, like the other two sockets) */
 	"",			/* netcap_socket (empty => <machinedir>rpcemu-netcap.sock) */

--- a/src/rpcemu.h
+++ b/src/rpcemu.h
@@ -406,6 +406,18 @@ typedef struct {
 	char vnc_password[64];	/**< Password for VNC authentication (empty = no auth) */
 	char vnc_password_readonly[64];	/**< Password for view-only VNC clients (empty = disabled) */
 	int hostcmd_enabled;	/**< Enable the HostCmd control socket (host drives the RISC OS CLI) */
+	/**
+	 * Which host interface the Access broadcast relay should use, or empty to
+	 * choose one. An application setting rather than a machine one, because the
+	 * relay is claimed once per host - see app_settings.h.
+	 *
+	 * Matched against the interface name on Unix (en0, eth0) and against both
+	 * the adapter name and its description on Windows, case-insensitively, as a
+	 * substring so "Realtek" is enough. Issue #205: with a VPN connected the
+	 * automatic choice took the VPN's adapter, where no Access peer can hear it.
+	 */
+	char relay_interface[128];
+
 	char hostcmd_socket[512];	/**< Socket spec: empty = <machinedir>hostcmd.sock (AF_UNIX); a path = AF_UNIX; a bare port = TCP 127.0.0.1:port */
 	int netcap_enabled;	/**< Enable the NetCapCmd control socket (host captures and reads network frames) */
 	char netcap_socket[512];	/**< Socket spec: empty = <machinedir>rpcemu-netcap.sock (AF_UNIX); a path = AF_UNIX; a bare port = TCP 127.0.0.1:port */

--- a/tests/test_app_settings.c
+++ b/tests/test_app_settings.c
@@ -156,12 +156,13 @@ main(int argc, char *argv[])
 	    "watch round trip");
 	cfg.hostcmd_enabled = 0;
 	snprintf(cfg.hostcmd_socket, sizeof(cfg.hostcmd_socket), "/tmp/hc.sock");
+	snprintf(cfg.relay_interface, sizeof(cfg.relay_interface), "Realtek");
 	check("save succeeds", app_settings_save(dir, &cfg) == 0);
 	{
 		Config back;
 
 		memset(&back, 0, sizeof(back));
-		check("all six keys come back", app_settings_load(dir, &back) == 6);
+		check("all seven keys come back", app_settings_load(dir, &back) == 7);
 		check("vnc_enabled", back.vnc_enabled == 1);
 		check("vnc_port", back.vnc_port == 5910);
 		check("vnc_password", strcmp(back.vnc_password, "round trip") == 0);
@@ -170,6 +171,11 @@ main(int argc, char *argv[])
 		check("hostcmd_enabled", back.hostcmd_enabled == 0);
 		check("hostcmd_socket",
 		    strcmp(back.hostcmd_socket, "/tmp/hc.sock") == 0);
+		/* Issue #205. A name with a space in it is the normal case on Windows,
+		   where the adapter is described as "Realtek RTL8852BE WiFi 6 ...", and
+		   the parser keeps spaces inside a value - checked above. */
+		check("relay_interface",
+		    strcmp(back.relay_interface, "Realtek") == 0);
 	}
 
 	/*

--- a/tests/test_net_tx.c
+++ b/tests/test_net_tx.c
@@ -121,6 +121,7 @@ int net_slot_acquire(void) { return 0; }
 void net_slot_release(void) { }
 int app_settings_relay_enabled(void) { return 0; }
 int broadcast_relay_init(void) { return 0; }
+void broadcast_relay_set_interface(const char *name) { (void) name; }
 void broadcast_relay_close(void) { }
 void broadcast_relay_poll(void) { }
 


### PR DESCRIPTION
Addresses #205, reported against 1.1.17 on Windows 11.

With a VPN connected the Access broadcast relay bound to the VPN's adapter, so
broadcasts went where no Acorn could hear them, and disconnecting the VPN was
the only way to get the real adapter back. The reporter read the code and found
there was no way to say which adapter to use.

## Why this is a Windows report

Worth recording, because it explains why nobody hit it on a Mac with four
tunnels up. The Unix side filters candidates on `IFF_BROADCAST`, and a VPN's
`utun` is point-to-point rather than broadcast, so it never becomes a candidate
there at all. `GetAdaptersInfo()` has no such flag, so on Windows every adapter
is a candidate and the VPN is as good as the WiFi until something says otherwise.

## The change

**A scored choice instead of "the first one that is not loopback"**, which is
wrong on any machine with a VPN client, a hypervisor or a container runtime on
it. A real wired or wireless medium counts for a lot, a gateway for a little,
and a tunnel counts heavily against. On Windows the adapter `Type` does most of
the work: `MIB_IF_TYPE_ETHERNET` and `IF_TYPE_IEEE80211` score well, `PPP` and
`IF_TYPE_TUNNEL` badly, and the description is checked for the usual words. The
reporter's own two adapters separate cleanly on `Type` alone.

**`relay_interface` in the application settings**, because no heuristic is going
to be right on every machine. An application setting rather than a machine one,
since the relay is claimed once per host. Matched case-insensitively as a
substring against the interface name on Unix and against both the adapter name
and its description on Windows, so `Realtek` is enough for
`Realtek RTL8852BE WiFi 6 802.11ax PCIe Adapter`.

**Every candidate logged with its score, and the decision explained.** The
reporter found this by reading `rpclog.txt` and had one line to go on, naming
the adapter but not why it had been picked or what to do about it. A setting
that matches nothing now says so and falls back to the best candidate: better a
working relay on the wrong interface than none at all, but reporting it as the
interface they asked for would send somebody hunting everywhere except at their
own typo.

The name is handed to `broadcast_relay.c` rather than read from the global
config there, because that file is linked on its own by
`tests/test_relay_datagram.c` and `tests/test_relay_reasm.c` and touching
`config` drags the emulator in behind it.

## What is verified where

Exercised on macOS, which is the Unix path, with a real headless machine boot:

```
broadcast_relay: candidate en0 host 192.168.1.32 score 100
broadcast_relay: using interface en0, host 192.168.1.32, broadcast 192.168.1.255
broadcast_relay: chose en0 (score 100). If Access cannot see other machines, ...
```

All three routes were run: the automatic choice, `relay_interface=EN0` matching
case-insensitively, and `relay_interface=nosuchadapter` reporting the miss and
falling back. `tests/test_app_settings.c` pins the new key through a save and
load round trip; it already asserted the exact number of keys, which is what
caught the addition.

The Windows path is compiled by CI and read carefully, but not run - there is no
Windows machine here. The reporter is well placed to confirm it, and the
candidate log is designed so he can.

The 1.x backport is 213.
