### PR TITLE
Full screen: the menu bar and tool bar have one owner again

### DIFF
--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -1414,22 +1414,40 @@ void MainFrame::EnterFullScreen()
 	if (panel_ != nullptr) {
 		panel_->SetFullScreen(true);
 	}
-	if (GetMenuBar() != nullptr) {
-		GetMenuBar()->Show(false);
-	}
-	if (tool_bar_ != nullptr) {
-		tool_bar_->Show(false);
-	}
+
+	/*
+	 * ★ THE MENU BAR AND THE TOOL BAR ARE NOT OURS TO HIDE.
+	 *
+	 * ShowFullScreen(wxFULLSCREEN_ALL) hides and restores both, on GTK and on
+	 * MSW, from the flags it is given. This used to hide them here as well, so
+	 * one piece of state had two owners, and on Windows the second owner does
+	 * not merely duplicate the first - it changes what it does. wxMSW's
+	 * ShowFullScreen reads IsShown() on the way in and, for a bar that is
+	 * already hidden, drops the flag "to prevent it from being restored later"
+	 * (src/msw/frame.cpp). Hiding the tool bar first therefore told wx not to
+	 * bring it back, and only the matching Show(true) on the way out covered
+	 * for it.
+	 *
+	 * Issue #206 is the menu bar not coming back on Windows after a round trip.
+	 * Leaving both bars to ShowFullScreen means there is one owner again and
+	 * nothing to get out of step, whichever half was failing.
+	 *
+	 * The status bar below is the genuine exception and stays.
+	 */
+
 	/* Removed rather than hidden. Hiding it leaves the space it occupied
 	   reserved - measurably so: the frame's client height does not change -
 	   and on macOS that shows as an empty strip along the bottom of the
-	   screen. BuildStatusBar() puts it back on the way out. */
+	   screen. BuildStatusBar() puts it back on the way out. And because it is
+	   gone rather than hidden, wxMSW finds no status bar to reason about and
+	   the flag interaction described above does not arise for it. */
 	if (wxStatusBar *bar = GetStatusBar()) {
 		SetStatusBar(nullptr);
 		bar->Destroy();
 	}
 	ShowFullScreen(true, wxFULLSCREEN_ALL);
 	full_screen_ = true;
+	LogBarState("entered");
 
 	/*
 	 * ★ Ask for the layout again, having changed what the frame contains.
@@ -1510,31 +1528,23 @@ void MainFrame::ExitFullScreen()
 	if (panel_ != nullptr) {
 		panel_->SetFullScreen(false);
 	}
+	/* Both bars come back with it: see the note in EnterFullScreen() for why
+	   nothing here shows them by hand any more. */
 	ShowFullScreen(false);
-	if (GetMenuBar() != nullptr) {
-		GetMenuBar()->Show(true);
-	}
-	/* Back to what it was, which in a minimal window is still hidden. */
-	if (tool_bar_ != nullptr) {
-		tool_bar_->Show(!minimal_ui_);
+	/*
+	 * Minimal UI is ours to enforce, and only in the one direction. The ports do
+	 * not agree about a bar that was already hidden when full screen started:
+	 * wxMSW and wxGTK decline to restore it, which is what we want here, but
+	 * that is their business and not a contract. Saying what a minimal window
+	 * should look like is cheaper than depending on which port is running.
+	 */
+	if (minimal_ui_ && tool_bar_ != nullptr) {
+		tool_bar_->Show(false);
 	}
 	if (!minimal_ui_ && GetStatusBar() == nullptr) {
 		BuildStatusBar();
 	}
-	/*
-	 * ★ Put the window back rather than trusting ShowFullScreen() to have done it.
-	 *
-	 * This was a bare Layout(), on the grounds that ShowFullScreen(false) had
-	 * already restored the size and that fitting would shrink-wrap the frame to a
-	 * panel with no minimum. Neither half held: the panel takes the guest's
-	 * screen size as its minimum, and leaving the geometry to the toolkit meant
-	 * leaving the window full-screen-sized on Windows, where leaving full screen
-	 * appeared to do nothing at all.
-	 *
-	 * Cleared first, because SizeWindowToGuest() does nothing while it is set.
-	 */
-	full_screen_ = false;
-	SizeWindowToGuest();
+	LogBarState("left");
 
 	/*
 	 * ★ Put the window back explicitly, rather than trusting ShowFullScreen().
@@ -1551,6 +1561,12 @@ void MainFrame::ExitFullScreen()
 	 *
 	 * Everything else that changes the window's size goes through here, so full
 	 * screen is no longer the one path with its own idea of how to get back.
+	 *
+	 * full_screen_ is cleared at the top of this function, because this does
+	 * nothing while it is set. It used to be cleared again here, and again in a
+	 * duplicate of this very comment, both left by a merge that kept two sides
+	 * of the same edit - along with a second SizeWindowToGuest(). Harmless, since
+	 * both are idempotent, but there is one of each now.
 	 */
 	SizeWindowToGuest();
 
@@ -1560,6 +1576,46 @@ void MainFrame::ExitFullScreen()
 	if (fullscreen_menu_item_ != nullptr) {
 		fullscreen_menu_item_->Check(false);
 	}
+}
+
+/*
+ * What the frame's bars are actually doing, in one log line.
+ *
+ * Issue #206 - the menu bar not coming back after a full-screen round trip on
+ * Windows - could not be seen from this end at all: RPCEMU_TEST_FULLSCREEN_AFTER
+ * logged the window size at each step and nothing about the bars, so a menu bar
+ * that never returned looked exactly like one that did. There is no Windows
+ * machine here, so the substitute for watching it is a line the reporter can
+ * send back.
+ *
+ * On Windows the native menu is asked for directly with ::GetMenu(). That is the
+ * question that matters there, and it is not the same question as
+ * wxMenuBar::IsShown(): the menu bar is an HMENU attached to the frame rather
+ * than a window that is shown or hidden, so wx can believe it is showing one
+ * that the frame no longer has.
+ */
+void MainFrame::LogBarState(const char *when) const
+{
+	const wxMenuBar *menu = GetMenuBar();
+	const bool tool_shown = tool_bar_ != nullptr && tool_bar_->IsShown();
+
+#ifdef __WXMSW__
+	const bool native_menu = GetHWND() != nullptr &&
+	    ::GetMenu((HWND) GetHWND()) != nullptr;
+
+	rpclog("MainFrame: full screen %s - menu bar %s (native menu %s), "
+	       "tool bar %s, status bar %s\n", when,
+	       menu == nullptr ? "absent" : (menu->IsShown() ? "shown" : "hidden"),
+	       native_menu ? "attached" : "GONE",
+	       tool_shown ? "shown" : "hidden",
+	       GetStatusBar() != nullptr ? "present" : "absent");
+#else
+	rpclog("MainFrame: full screen %s - menu bar %s, tool bar %s, "
+	       "status bar %s\n", when,
+	       menu == nullptr ? "absent" : (menu->IsShown() ? "shown" : "hidden"),
+	       tool_shown ? "shown" : "hidden",
+	       GetStatusBar() != nullptr ? "present" : "absent");
+#endif
 }
 
 void MainFrame::OnFullscreen(wxCommandEvent &)

--- a/src/gui/main_frame.h
+++ b/src/gui/main_frame.h
@@ -697,6 +697,10 @@ private:
 	wxTimer test_close_timer_;
 
 	/* RPCEMU_TEST_FULLSCREEN_AFTER only. */
+	/* Whether the menu bar, tool bar and status bar are where they should be,
+	   logged either side of a full-screen transition. See issue #206. */
+	void LogBarState(const char *when) const;
+
 	wxTimer test_fullscreen_timer_;
 	int test_fullscreen_step_ = 0;
 


### PR DESCRIPTION
Addresses #206, reported against 1.1.17 on Windows 11: the menu bar does not
come back after a full screen round trip. The tool bar does, which is the clue.

**Draft until I have run a full-screen round trip on macOS here.** This is the
area that produced the regression behind #173, so it is not going in on reading
alone.

## The fault

`EnterFullScreen()` hid the menu bar and the tool bar by hand and then called
`ShowFullScreen(wxFULLSCREEN_ALL)`, which hides them itself. Two owners for one
piece of state, and on Windows the second does not merely duplicate the first,
it changes what the first does. From `src/msw/frame.cpp` in wxWidgets 3.3.3:

```cpp
if ( theToolBar->IsShown() )
{
    theToolBar->SetSize(wxDefaultCoord,0);
    theToolBar->Show(false);
}
else // prevent it from being restored later
{
    style &= ~wxFULLSCREEN_NOTOOLBAR;
}
```

So hiding the tool bar first told wx not to bring it back, and the matching
`Show(true)` on the way out was covering for that rather than being harmless
belt and braces.

Both bars are left to `ShowFullScreen` now, in and out. One owner, nothing to
get out of step, whichever half was failing on Windows.

The status bar stays as it was: destroyed rather than hidden, because hiding it
leaves its space reserved and that shows as a strip along the bottom on macOS.
Being gone rather than hidden also means wxMSW finds no status bar and the flag
interaction above never arises for it.

Minimal UI keeps one explicit line, in one direction only. wxMSW and wxGTK
decline to restore a bar that was already hidden, which happens to be what a
minimal window wants, but that is their business and not a contract worth
depending on.

## The other half: it could not be seen from here

`RPCEMU_TEST_FULLSCREEN_AFTER` logged the window size at each step and nothing
about the bars, so a menu bar that never returned looked exactly like one that
did. `LogBarState()` now reports all three either side of the transition, and on
Windows asks `::GetMenu()` directly. That is the question that matters there and
it is not the same question as `wxMenuBar::IsShown()`: the menu bar is an HMENU
attached to the frame, not a window that is shown or hidden, so wx can believe
it is showing one the frame no longer has. With no Windows machine here, that
log line is also what the reporter can send back.

## Also cleaned up

`ExitFullScreen()` on main had `full_screen_ = false;` three times, two
near-identical copies of the same long comment, and `SizeWindowToGuest()` twice,
left by a merge that kept both sides of one edit. Idempotent, so harmless, but
there is one of each now.

## What is verified where

Builds clean and all 77 tests pass, but none of them exercise a real window.
Windows rests on CI and on the reporter. macOS verification is what this draft
is waiting on.

The 1.x backport is 215.
