### PR TITLE
Closing a machine, RISC OS switching one off, a reserved CPU mode, and the inspector's Trace tab

### DIFF
--- a/docs/debugcmd.md
+++ b/docs/debugcmd.md
@@ -195,7 +195,15 @@ way the first one after a boot is; send a throwaway command before trusting an
 empty result.
 
 `status.reason` / pause reasons: `0`=none `1`=user `2`=breakpoint `3`=watchpoint
-`4`=step `5`=exception `6`=SWI. Trace `type`: `0`=exception `1`=SWI `2`=watchpoint.
+`4`=step `5`=exception `6`=SWI `7`=reserved CPU mode. Trace `type`: `0`=exception
+`1`=SWI `2`=watchpoint; for an exception, `arg0` is `0`=undefined instruction
+`1`=prefetch abort `2`=data abort `3`=reserved CPU mode.
+
+Reason `7` is not a trap that can be switched on: writing one of the nine
+reserved mode values is always a fault, and the machine halts on it whatever the
+trace configuration says. `arg1` of its trace event carries the mode that was
+written. See *A reserved CPU mode* in
+[debugger-tracing.md](debugger-tracing.md).
 
 `step over`, `step out` and `runto` all report reason `4`, since all three are
 "stopped where you asked", not "stopped at a breakpoint".

--- a/docs/debugger-tracing.md
+++ b/docs/debugger-tracing.md
@@ -24,6 +24,27 @@ interrupts and are not trappable here; a SWI is caught by SWI tracing below.)
 Exceptions can also be **logged** to the Trace tab without halting — useful for
 seeing, for example, the harmless app-space probes RISC OS performs during boot.
 
+## A reserved CPU mode
+
+The mode field of the CPSR has sixteen possible values and the architecture
+defines seven of them. Writing one of the other nine is UNPREDICTABLE on real
+hardware, so it is always a fault in the guest, and there is no checkbox for it:
+the machine halts whenever it happens, with the pause reason given as *reserved
+CPU mode written* and the halt PC naming the instruction that wrote it. The mode
+itself is in the Trace tab entry beside it.
+
+The emulator used to report this with a fatal error and exit, which took the
+registers, the memory and the disassembly with it at exactly the moment somebody
+wanted to read them (issue #227). The halted machine can be inspected and then
+stepped or resumed like any other. Register banking in a reserved mode follows
+User and System mode, so what the inspector shows is defined rather than
+whatever happened to be in the banks.
+
+The one case that still ends the emulator is a machine with the debugger turned
+off (`debug_enabled=0`), where there is nothing to halt into: neither the
+inspector nor the debug socket is available, so a halt would be indistinguishable
+from a hang.
+
 ## SWI tracing
 
 SWI tracing records every operating-system call the guest makes. Options:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -39,6 +39,25 @@ quickest way to read a failure:
 
 Set `RPCEMU_TEST_LOG=1` to see what a unit under test is logging.
 
+## Driving the window without a pointer
+
+Some faults are only in the front end, and a wxWidgets control cannot be read or
+clicked by a script on every platform - on macOS a checkbox is invisible to
+accessibility. Three environment variables ask the window to do the thing
+itself and write what happened to the machine's `rpclog.txt`, so a GUI fault can
+be measured rather than only described. Each takes a delay in seconds from the
+machine starting:
+
+| Variable | What it does |
+| --- | --- |
+| `RPCEMU_TEST_CLOSE_AFTER` | Asks the window to close, exactly as the close button does, so the confirmation is put to the user rather than answered for them |
+| `RPCEMU_TEST_FULLSCREEN_AFTER` | Enters full screen and leaves it again, logging the window size and the state of the menu, tool and status bars at each step (issues #173, #206) |
+| `RPCEMU_TEST_INSPECTOR_AFTER` | Sets the machine trapping and tracing, opens the Machine Inspector, closes it, opens it again, and logs whether the Trace tab's controls agree with the machine each time (issue #221) |
+
+They need a real display, so none of them work headless. Grep the machine's log
+for `TEST_` afterwards; the machine directory's `rpclog.txt` is the one with
+these lines in it, not the data directory's.
+
 ## Before pushing
 
 A pre-push hook builds the tree and runs the suite, so a broken commit is caught

--- a/src/arm.c
+++ b/src/arm.c
@@ -158,7 +158,34 @@ void updatemode(uint32_t m)
                 break;
 
             default:
-                fatal("Bad mode %i\n", arm.mode);
+                /*
+                 * One of the nine reserved mode values (4, 5, 6, 8, 9, 10, 12,
+                 * 13, 14). Writing one is UNPREDICTABLE on real hardware, so
+                 * this is a fault in the guest - which is what somebody would
+                 * want to look at, and what fatal() used to take away with the
+                 * rest of the process. Issue #227.
+                 *
+                 * PC is read before r15_mask is updated below, so it is still
+                 * the mask of the mode the offending instruction ran in.
+                 */
+                if (!debugger_bad_mode(arm.mode, PC)) {
+                        fatal("Bad mode %i\n", arm.mode);
+                }
+
+                /*
+                 * Bank as User and System mode do, so the halted machine has
+                 * defined registers to show and can be stepped afterwards.
+                 *
+                 * The store-back switch above deliberately has no matching arm:
+                 * leaving a reserved mode discards whatever it did to R8-R14
+                 * rather than writing it into the user bank, so a guest that
+                 * strays into one and comes back does not find User mode's
+                 * registers rewritten underneath it. Both halves are undefined
+                 * behaviour on hardware; this is the half that damages less.
+                 */
+                for (c=8;c<15;c++) arm.reg[c] = arm.user_reg[c];
+                for (c=0;c<15;c++) usrregs[c] = &arm.reg[c];
+                break;
         }
 
         if (ARM_MODE_32(arm.mode)) {

--- a/src/arm_dynarec.c
+++ b/src/arm_dynarec.c
@@ -186,7 +186,34 @@ void updatemode(uint32_t m)
                 break;
 
             default:
-                fatal("Bad mode %i\n", arm.mode);
+                /*
+                 * One of the nine reserved mode values (4, 5, 6, 8, 9, 10, 12,
+                 * 13, 14). Writing one is UNPREDICTABLE on real hardware, so
+                 * this is a fault in the guest - which is what somebody would
+                 * want to look at, and what fatal() used to take away with the
+                 * rest of the process. Issue #227.
+                 *
+                 * PC is read before r15_mask is updated below, so it is still
+                 * the mask of the mode the offending instruction ran in.
+                 */
+                if (!debugger_bad_mode(arm.mode, PC)) {
+                        fatal("Bad mode %i\n", arm.mode);
+                }
+
+                /*
+                 * Bank as User and System mode do, so the halted machine has
+                 * defined registers to show and can be stepped afterwards.
+                 *
+                 * The store-back switch above deliberately has no matching arm:
+                 * leaving a reserved mode discards whatever it did to R8-R14
+                 * rather than writing it into the user bank, so a guest that
+                 * strays into one and comes back does not find User mode's
+                 * registers rewritten underneath it. Both halves are undefined
+                 * behaviour on hardware; this is the half that damages less.
+                 */
+                for (c=8;c<15;c++) arm.reg[c] = arm.user_reg[c];
+                for (c=0;c<15;c++) usrregs[c] = &arm.reg[c];
+                break;
         }
 
         if (ARM_MODE_32(arm.mode)) {

--- a/src/gui/emulator_host.cpp
+++ b/src/gui/emulator_host.cpp
@@ -469,6 +469,12 @@ void EmulatorHost::Stop()
 	vidcwakeupthread();
 }
 
+void EmulatorHost::SetExecutionSuspended(bool suspended)
+{
+	rpclog("RPCEmu: execution %s\n", suspended ? "suspended" : "resumed");
+	execution_suspended_.store(suspended, std::memory_order_release);
+}
+
 void EmulatorHost::Join()
 {
 	if (g_fatal_occurred.load()) {
@@ -1553,6 +1559,21 @@ void EmulatorHost::MainEmuLoop()
 
 	while (!quited) {
 		DrainCommands();
+
+		/*
+		 * Execution suspended from the front end, which is a different thing
+		 * from the debugger's pause and must not be reported as one: this is a
+		 * machine the user has finished with, sitting behind the machine list
+		 * while they choose another (issue #222). Commands are drained above,
+		 * so the switch that usually follows is still acted on, and the
+		 * debugger socket is kept serviced for the same reason it is while
+		 * paused.
+		 */
+		if (execution_suspended_.load(std::memory_order_acquire)) {
+			debugcmd_poll();
+			std::this_thread::sleep_for(std::chrono::milliseconds(1));
+			continue;
+		}
 
 		const bool paused = debugger_is_paused() != 0;
 		if (paused) {

--- a/src/gui/emulator_host.h
+++ b/src/gui/emulator_host.h
@@ -130,6 +130,27 @@ public:
 	void Stop();
 	void Join();
 
+	/**
+	 * Stop the guest executing without stopping the emulator thread.
+	 *
+	 * For a machine the user has finished with but which cannot be taken all
+	 * the way down yet: the machine list is shown over it, and if another
+	 * machine is chosen it is this same thread that switches to it, so Stop()
+	 * is not available. Suspended, the CPU runs no instructions, the sound it
+	 * was feeding runs dry and the core is given back to the host - which is
+	 * what closing a running machine failed to do (issue #222).
+	 *
+	 * Deliberately not the debugger's pause: that is a debugging state, it is
+	 * reported to the inspector as one, and a Run there would undo this. The
+	 * command queue is still drained while suspended, so the machine switch
+	 * that usually follows is acted on.
+	 */
+	void SetExecutionSuspended(bool suspended);
+	bool IsExecutionSuspended() const
+	{
+		return execution_suspended_.load(std::memory_order_acquire);
+	}
+
 	/* Notify every request condition variable so any GUI-thread wait wakes and
 	   re-evaluates its predicate. Called from fatal() when the emulator thread
 	   is about to spin forever and can no longer signal completion itself. */
@@ -284,6 +305,10 @@ private:
 	uint32_t trace_dropped_ = 0;
 
 	std::atomic<bool> flyback_pending_{false};
+
+	/* See SetExecutionSuspended(). Read by the emulator thread once per turn of
+	   its loop, written by the GUI thread. */
+	std::atomic<bool> execution_suspended_{false};
 };
 
 /*

--- a/src/gui/machine_inspector_window.cpp
+++ b/src/gui/machine_inspector_window.cpp
@@ -578,6 +578,7 @@ void MachineInspectorWindow::ApplySnapshot(const MachineSnapshot &snapshot)
 	PopulateBreakpointList(snapshot);
 	PopulateWatchpointList(snapshot);
 	UpdateDebuggerUi(snapshot);
+	SeedTraceConfig(snapshot);
 
 	/* Something useful in the memory pane on the first snapshot rather than an
 	   empty box: the stack is what a stopped machine is usually asked about. */
@@ -871,6 +872,80 @@ void MachineInspectorWindow::OnTraceClear(wxCommandEvent &)
 	trace_view_->Clear();
 	trace_dropped_total_ = 0;
 	trace_dropped_label_->SetLabel("Dropped: 0");
+}
+
+/*
+ * Show what the machine is actually doing, the first time this window sees it.
+ *
+ * The trapping and tracing settings live in the emulator, not in this window,
+ * and they outlive it: closing the inspector destroys the frame but leaves the
+ * machine trapping and tracing exactly as it was. Building the controls
+ * unticked and leaving them there meant a reopened inspector disagreed with its
+ * own machine - Halt on exception still halting with the box clear, and Log
+ * SWIs still filling the ring while DrainTraceEvents(), which gates on these
+ * same boxes, quietly stopped reading it, so the SWIs "stopped" being logged.
+ * That is issue #221, and both halves of it are this one omission.
+ *
+ * Once only. After the first snapshot these controls belong to the user, and a
+ * snapshot taken between a click and the emulator thread acting on it would
+ * put the box back.
+ */
+void MachineInspectorWindow::SeedTraceConfig(const MachineSnapshot &snapshot)
+{
+	if (trace_config_seeded_) {
+		return;
+	}
+	trace_config_seeded_ = true;
+
+	const DebugTraceConfig &cfg = snapshot.debug_trace_config;
+
+	trap_undefined_checkbox_->SetValue(cfg.trap_undefined != 0);
+	trap_prefetch_checkbox_->SetValue(cfg.trap_prefetch_abort != 0);
+	trap_data_abort_checkbox_->SetValue(cfg.trap_data_abort != 0);
+	log_exceptions_checkbox_->SetValue(cfg.log_exceptions != 0);
+	swi_trace_checkbox_->SetValue(cfg.swi_trace_enabled != 0);
+	swi_halt_checkbox_->SetValue(cfg.swi_trace_halt != 0);
+
+	/* The full range is "no filter", which is what an empty box means, so it
+	   is left showing its hint rather than 0 and FFFFFFFF. */
+	if (cfg.swi_filter_min != 0 || cfg.swi_filter_max != 0xffffffffu) {
+		swi_filter_min_input_->SetValue(wxString::Format("%X", cfg.swi_filter_min));
+		swi_filter_max_input_->SetValue(wxString::Format("%X", cfg.swi_filter_max));
+	}
+}
+
+bool MachineInspectorWindow::LogTraceControlsAgainstMachine(const char *when)
+{
+	const MachineSnapshot snapshot = emulator_.TakeSnapshot();
+	const DebugTraceConfig &cfg = snapshot.debug_trace_config;
+
+	const struct {
+		const char *name;
+		int shown;
+		int machine;
+	} controls[] = {
+		{ "undefined",  trap_undefined_checkbox_->GetValue() ? 1 : 0, cfg.trap_undefined != 0 },
+		{ "prefetch",   trap_prefetch_checkbox_->GetValue() ? 1 : 0,  cfg.trap_prefetch_abort != 0 },
+		{ "data-abort", trap_data_abort_checkbox_->GetValue() ? 1 : 0, cfg.trap_data_abort != 0 },
+		{ "log-exc",    log_exceptions_checkbox_->GetValue() ? 1 : 0,  cfg.log_exceptions != 0 },
+		{ "swi-log",    swi_trace_checkbox_->GetValue() ? 1 : 0,       cfg.swi_trace_enabled != 0 },
+		{ "swi-halt",   swi_halt_checkbox_->GetValue() ? 1 : 0,        cfg.swi_trace_halt != 0 },
+	};
+
+	bool agree = true;
+
+	for (const auto &c : controls) {
+		if (c.shown != c.machine) {
+			agree = false;
+		}
+		rpclog("TEST_INSPECTOR: %s: %-10s shown=%d machine=%d%s\n",
+		       when, c.name, c.shown, c.machine,
+		       c.shown != c.machine ? "  DISAGREE" : "");
+	}
+
+	rpclog("TEST_INSPECTOR: %s: controls %s the machine\n", when,
+	       agree ? "agree with" : "DISAGREE with");
+	return agree;
 }
 
 void MachineInspectorWindow::ApplyTraceConfig()

--- a/src/gui/machine_inspector_window.cpp
+++ b/src/gui/machine_inspector_window.cpp
@@ -826,6 +826,7 @@ void MachineInspectorWindow::UpdateDebuggerUi(const MachineSnapshot &snapshot)
 	case DebugPauseReason_Step: reason = "single step"; break;
 	case DebugPauseReason_Exception: reason = "exception trap"; break;
 	case DebugPauseReason_Swi: reason = "SWI trap"; break;
+	case DebugPauseReason_BadMode: reason = "reserved CPU mode written"; break;
 	default: reason = "unknown"; break;
 	}
 
@@ -908,6 +909,13 @@ void MachineInspectorWindow::DrainTraceEvents()
 			}
 		}
 	}
+	/* A halted machine is drained whatever the boxes say. Nothing is running
+	   to flood the ring, and the events that put it here - a reserved CPU
+	   mode, which nobody switches on because it is never wanted - would
+	   otherwise sit unread while the Trace tab showed an empty box. */
+	if (!active && last_snapshot_.debug_paused != 0) {
+		active = true;
+	}
 	if (!active) {
 		return;
 	}
@@ -947,10 +955,16 @@ void MachineInspectorWindow::DrainTraceEvents()
 			case TraceException_Undefined: kind = "undefined instruction"; break;
 			case TraceException_PrefetchAbort: kind = "prefetch abort"; break;
 			case TraceException_DataAbort: kind = "data abort"; break;
+			case TraceException_BadMode: kind = "reserved CPU mode"; break;
 			default: break;
 			}
 			line = wxString::Format("%08u  PC=%s  EXCEPTION  %s",
 			                        ev.seq, FormatHex(ev.pc), kind);
+			/* A reserved mode carries the mode written where a fault
+			   address would be; there is no fault status. */
+			if (ev.arg0 == TraceException_BadMode) {
+				line += wxString::Format("  mode=%02X", ev.arg1 & 0xffu);
+			}
 			/* Only a data abort carries a fault address and status; the
 			   others leave them zero on purpose (see DebugTraceEvent). */
 			if (ev.arg0 == TraceException_DataAbort) {

--- a/src/gui/machine_inspector_window.h
+++ b/src/gui/machine_inspector_window.h
@@ -37,6 +37,21 @@ public:
 
 	void ShowAndRaise();
 
+	/**
+	 * Log the Trace tab's controls beside the machine's own trapping and
+	 * tracing settings, and say whether they agree.
+	 *
+	 * For RPCEMU_TEST_INSPECTOR_AFTER. A checkbox cannot be read from a script
+	 * on macOS, so the window is asked instead - which is the only way to get
+	 * evidence for issue #221, where the controls came up clear on a machine
+	 * that was still trapping and tracing.
+	 *
+	 * @param when Short label for the log line, so before and after are
+	 *             distinguishable
+	 * @return true if every control matches the machine
+	 */
+	bool LogTraceControlsAgainstMachine(const char *when);
+
 private:
 	enum {
 		ID_AUTO_REFRESH = wxID_HIGHEST + 1,
@@ -94,6 +109,11 @@ private:
 	void PopulateBreakpointList(const MachineSnapshot &snapshot);
 	void PopulateWatchpointList(const MachineSnapshot &snapshot);
 	void ApplyTraceConfig();
+
+	/* Fill the Trace tab in from the machine's own settings, once, when the
+	   window first sees a snapshot. */
+	void SeedTraceConfig(const MachineSnapshot &snapshot);
+
 	void DrainTraceEvents();
 
 	uint32_t ParseAddress(const wxString &text, bool *ok) const;
@@ -157,6 +177,12 @@ private:
 	wxCheckBox *trace_autoscroll_checkbox_ = nullptr;
 	wxStaticText *trace_dropped_label_ = nullptr;
 	uint32_t trace_dropped_total_ = 0;
+
+	/* Cleared until the Trace tab has been filled in from the machine. Only
+	   the first snapshot may write to those controls; after that they are the
+	   user's, and a snapshot taken before a click reached the emulator thread
+	   would undo it. */
+	bool trace_config_seeded_ = false;
 
 	uint32_t disasm_current_address_ = 0;
 	uint32_t memory_current_address_ = 0;

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -2737,17 +2737,16 @@ void MainFrame::PostMachineSwitched(const std::string &machine_name)
 void MainFrame::PostQuit()
 {
 	/*
-	 * Called from the emulator thread; hop to the GUI thread and close the
-	 * window, which runs the normal shutdown (stop + join the emu threads).
+	 * Called from the emulator thread; hop to the GUI thread and deal with the
+	 * guest having powered itself off - the desktop's Shutdown, via OS_Reset.
 	 *
-	 * Through CloseWhenNothingIsModal() rather than straight to Close(true),
-	 * for the reason set out there: every dialogue this window opens is a stack
-	 * object parented to it, and destroying the window from inside a dialogue's
-	 * own event loop aborts the process. This path is the guest asking to be
-	 * powered off - the desktop's Shutdown, via OS_Reset - which can arrive
-	 * while anything at all is on screen.
+	 * Through WhenNothingIsModal() rather than acting straight away, for the
+	 * reason set out there: every dialogue this window opens is a stack object
+	 * parented to it, destroying the window from inside a dialogue's own event
+	 * loop aborts the process, and this request can arrive while anything at
+	 * all is on screen.
 	 */
-	CallAfter([this]() { CloseWhenNothingIsModal(); });
+	CallAfter([this]() { WhenNothingIsModal([this]() { GuestPoweredOff(); }); });
 }
 
 /*
@@ -2875,8 +2874,40 @@ void MainFrame::AskAboutClosing()
 		}
 	}
 
+	if (StopMachineAndOfferList()) {
+		return;
+	}
+
+	/* The list was closed without choosing, so there is no machine to go to and
+	   the close stands. Flagged so it is not questioned a second time, and the
+	   guard is dropped here rather than by the destructor above, because Close()
+	   runs the close handler before this function returns. */
+	close_confirmed_ = true;
+	close_question_pending_ = false;
+	Close(true);
+}
+
+bool MainFrame::StopMachineAndOfferList()
+{
 	/*
-	 * The window goes first, then the list.
+	 * ★ Execution stops BEFORE anything is shown.
+	 *
+	 * The window used to be hidden with the emulator still running, so a
+	 * machine the user had just agreed to shut down went on executing behind
+	 * the machine list: a host core at full tilt, and - which is how it was
+	 * noticed - a game's music still playing out of a machine that was
+	 * supposedly closed. Issue #222.
+	 *
+	 * Suspended rather than stopped, because if another machine is chosen it is
+	 * this same emulator thread that switches to it; Stop() would leave nothing
+	 * to do the switching. See EmulatorHost::SetExecutionSuspended().
+	 */
+	if (emulator_ != nullptr) {
+		emulator_->SetExecutionSuspended(true);
+	}
+
+	/*
+	 * The window goes next, then the list.
 	 *
 	 * Hidden rather than destroyed, because it has to be able to come back.
 	 * Destroying it would take the emulator thread with it, and starting a
@@ -2898,19 +2929,45 @@ void MainFrame::AskAboutClosing()
 
 	if (!self) {
 		rpclog("MainFrame: the frame went while the machine list was open\n");
-		return;
+		return true;	/* nothing left here to close */
 	}
 
 	if (switching) {
+		/* The switch is a command on the emulator thread, and commands are
+		   drained whether or not execution is suspended, so this can be lifted
+		   now: the new machine runs as soon as the switch has been done. */
+		if (emulator_ != nullptr) {
+			emulator_->SetExecutionSuspended(false);
+		}
 		Show();
 		Raise();
+		return true;
+	}
+
+	return false;
+}
+
+void MainFrame::GuestPoweredOff()
+{
+	rpclog("MainFrame: the guest powered the machine off\n");
+
+	/* Already on the way down for some other reason, so there is nothing to
+	   offer a machine list to. */
+	if (shutting_down_ || close_confirmed_) {
+		rpclog("MainFrame: already closing, so the power-off is ignored\n");
 		return;
 	}
 
-	/* The list was closed without choosing, so there is no machine to go to and
-	   the close stands. Flagged so it is not questioned a second time, and the
-	   guard is dropped here rather than by the destructor above, because Close()
-	   runs the close handler before this function returns. */
+	/*
+	 * No confirmation. RISC OS has just been through its own shutdown, which
+	 * asked about unsaved work and dismounted the discs, and asking "are you
+	 * sure you wish to shut down this machine" after that is asking twice about
+	 * one decision.
+	 */
+	if (StopMachineAndOfferList()) {
+		return;
+	}
+
 	close_confirmed_ = true;
 	close_question_pending_ = false;
 	Close(true);
@@ -3081,7 +3138,7 @@ int EndOpenModalDialogs(bool cancel)
 	return open;
 }
 
-void MainFrame::CloseWhenNothingIsModal()
+void MainFrame::WhenNothingIsModal(std::function<void()> action)
 {
 	/* Asked once. A dialogue does not leave its loop when it is told to, it
 	   leaves when control next returns to it, so telling it again on every
@@ -3089,8 +3146,7 @@ void MainFrame::CloseWhenNothingIsModal()
 	if (!close_asked_modals_) {
 		close_asked_modals_ = EndOpenModalDialogs(true) > 0;
 		if (close_asked_modals_) {
-			rpclog("MainFrame: waiting for an open dialogue to close before "
-			       "shutting down\n");
+			rpclog("MainFrame: waiting for an open dialogue to close first\n");
 		}
 	}
 
@@ -3098,15 +3154,25 @@ void MainFrame::CloseWhenNothingIsModal()
 		/* Still up, so this window must not be destroyed yet: doing it from
 		   inside that dialogue's nested loop is the abort this exists to
 		   avoid. Queued, so the loop gets its turn. */
-		CallAfter([this]() { CloseWhenNothingIsModal(); });
+		CallAfter([this, action]() { WhenNothingIsModal(action); });
 		return;
 	}
 
+	/* Dropped before the action runs, not after: the guest powering the machine
+	   off no longer ends the session, so a later close has to be able to ask
+	   the dialogues of that session to end as well. Left latched, that close
+	   would wait for ever for dialogues nothing had asked to go. */
+	close_asked_modals_ = false;
+	action();
+}
+
+void MainFrame::CloseWhenNothingIsModal()
+{
 	/* Close() rather than Destroy(), so the machine is taken down by the same
 	   OnClose() the window's own close button uses - the snapshot being the
 	   only part a signal skips. Forced, because neither a signal nor the
 	   Manager's Stop is a request the window may decline. */
-	Close(true);
+	WhenNothingIsModal([this]() { Close(true); });
 }
 
 void MainFrame::CloseForSignal()

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -223,6 +223,7 @@ wxBEGIN_EVENT_TABLE(MainFrame, wxFrame)
 	EVT_TIMER(ID_TIMER_GUEST_RESIZE, MainFrame::OnGuestResizeTimer)
 	EVT_TIMER(ID_TIMER_TEST_CLOSE, MainFrame::OnTestCloseTimer)
 	EVT_TIMER(ID_TIMER_TEST_FULLSCREEN, MainFrame::OnTestFullscreenTimer)
+	EVT_TIMER(ID_TIMER_TEST_INSPECTOR, MainFrame::OnTestInspectorTimer)
 	EVT_DISPLAY_CHANGED(MainFrame::OnDisplayChanged)
 wxEND_EVENT_TABLE()
 
@@ -242,6 +243,7 @@ MainFrame::MainFrame()
 	, guest_resize_timer_(this, ID_TIMER_GUEST_RESIZE)
 	, test_close_timer_(this, ID_TIMER_TEST_CLOSE)
 	, test_fullscreen_timer_(this, ID_TIMER_TEST_FULLSCREEN)
+	, test_inspector_timer_(this, ID_TIMER_TEST_INSPECTOR)
 {
 	config_deep_copy(&config_copy_, &config);
 	pconfig_copy = &config_copy_;
@@ -426,6 +428,15 @@ void MainFrame::StartEmulator()
 		if (seconds > 0) {
 			rpclog("MainFrame: RPCEMU_TEST_CLOSE_AFTER=%ld\n", seconds);
 			test_close_timer_.StartOnce((int) (seconds * 1000));
+		}
+	}
+
+	if (const char *after = getenv("RPCEMU_TEST_INSPECTOR_AFTER")) {
+		const long seconds = strtol(after, nullptr, 10);
+
+		if (seconds > 0) {
+			rpclog("MainFrame: RPCEMU_TEST_INSPECTOR_AFTER=%ld\n", seconds);
+			test_inspector_timer_.StartOnce((int) (seconds * 1000));
 		}
 	}
 
@@ -1552,6 +1563,73 @@ void MainFrame::OnTestFullscreenTimer(wxTimerEvent &event)
 		ExitFullScreen();
 		rpclog("TEST_FULLSCREEN: left, window now %dx%d, guest %dx%d\n",
 		       GetSize().x, GetSize().y, guest.x, guest.y);
+		break;
+
+	default:
+		break;
+	}
+}
+
+void MainFrame::OnTestInspectorTimer(wxTimerEvent &event)
+{
+	(void)event;
+
+	switch (test_inspector_step_++) {
+	case 0: {
+		/*
+		 * Something for the controls to disagree with. Set through the emulator
+		 * the way the debug socket would, so this is the machine's own state and
+		 * not something the window was told.
+		 */
+		DebugTraceConfig cfg{};
+
+		cfg.trap_data_abort = 1;
+		cfg.swi_trace_enabled = 1;
+		cfg.swi_filter_max = 0xffffffffu;
+		emulator_->SetDebugTraceConfig(cfg);
+		rpclog("TEST_INSPECTOR: machine set to trap data aborts and log SWIs\n");
+		test_inspector_timer_.StartOnce(2000);
+		break;
+	}
+
+	case 1: {
+		wxCommandEvent open(wxEVT_MENU);
+
+		OnMachineInspector(open);
+		rpclog("TEST_INSPECTOR: opened\n");
+		test_inspector_timer_.StartOnce(2000);
+		break;
+	}
+
+	case 2:
+		if (machine_inspector_window_ != nullptr) {
+			machine_inspector_window_->LogTraceControlsAgainstMachine("first open");
+			machine_inspector_window_->Close(true);
+			rpclog("TEST_INSPECTOR: closed\n");
+		} else {
+			rpclog("TEST_INSPECTOR: no inspector window to close\n");
+		}
+		test_inspector_timer_.StartOnce(2000);
+		break;
+
+	case 3: {
+		/* Destroy() is deferred, so the window from step 2 has gone by now and
+		   this really is a new one - which is the case #221 is about. */
+		wxCommandEvent open(wxEVT_MENU);
+
+		OnMachineInspector(open);
+		rpclog("TEST_INSPECTOR: reopened\n");
+		test_inspector_timer_.StartOnce(2000);
+		break;
+	}
+
+	case 4:
+		if (machine_inspector_window_ != nullptr) {
+			machine_inspector_window_->LogTraceControlsAgainstMachine("reopened");
+		} else {
+			rpclog("TEST_INSPECTOR: no inspector window on reopen\n");
+		}
+		rpclog("TEST_INSPECTOR: done\n");
 		break;
 
 	default:

--- a/src/gui/main_frame.h
+++ b/src/gui/main_frame.h
@@ -138,6 +138,7 @@ enum TimerId {
 	ID_TIMER_GUEST_RESIZE,
 	ID_TIMER_TEST_CLOSE,
 	ID_TIMER_TEST_FULLSCREEN,
+	ID_TIMER_TEST_INSPECTOR,
 };
 
 enum StatusBarField {
@@ -392,6 +393,21 @@ private:
 	void OnTestFullscreenTimer(wxTimerEvent &event);
 
 	/**
+	 * RPCEMU_TEST_INSPECTOR_AFTER: open the Machine Inspector, close it, open it
+	 * again, and log whether its Trace tab agrees with the machine each time.
+	 *
+	 * The trapping and tracing settings live in the emulator and outlive the
+	 * window, so a reopened inspector has to be filled in from the machine
+	 * rather than from the defaults its controls were built with. It was not,
+	 * which is issue #221: Halt on exception went on halting with the box clear,
+	 * and Log SWIs went on filling the ring with nothing reading it.
+	 *
+	 * A checkbox cannot be read by a script on macOS, so the window reports its
+	 * own controls - see MachineInspectorWindow::LogTraceControlsAgainstMachine().
+	 */
+	void OnTestInspectorTimer(wxTimerEvent &event);
+
+	/**
 	 * A frame arrived from the guest. Notices a change of desktop size and, for
 	 * ScreenSize_MatchWindow, waits for it to settle before acting.
 	 */
@@ -557,6 +573,10 @@ private:
 
 	wxTimer test_fullscreen_timer_;
 	int test_fullscreen_step_ = 0;
+
+	/* RPCEMU_TEST_INSPECTOR_AFTER only. */
+	wxTimer test_inspector_timer_;
+	int test_inspector_step_ = 0;
 
 	/** The size last asked of the guest, or (0,0) when nothing is outstanding. */
 	wxSize mode_requested_ = wxSize(0, 0);

--- a/src/gui/main_frame.h
+++ b/src/gui/main_frame.h
@@ -23,6 +23,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <functional>
 #include <list>
 #include <memory>
 #include <string>
@@ -200,6 +201,14 @@ public:
 	 */
 	void CloseWhenNothingIsModal();
 
+	/*
+	 * The same wait, for anything other than a close: runs `action` as soon as
+	 * nothing modal is in the way. The guest powering the machine off arrives
+	 * while any dialogue at all may be on screen, and what follows it opens a
+	 * dialogue of its own.
+	 */
+	void WhenNothingIsModal(std::function<void()> action);
+
 	/* Whether the dialogues have already been asked to close, so the wait above
 	   asks once rather than on every turn of the event loop. */
 	bool close_asked_modals_ = false;
@@ -241,6 +250,32 @@ private:
 
 	/** Ask whether to close, then offer the machine list. */
 	void AskAboutClosing();
+
+	/**
+	 * The machine is finished with: stop it running, hide the window and offer
+	 * the machine list.
+	 *
+	 * Shared by the confirmed close and by the guest powering itself off, which
+	 * are the same thing reached from two directions.
+	 *
+	 * @return true if this has been dealt with - another machine was chosen and
+	 *         is now running, or the frame went while the list was open - and
+	 *         false if the list was dismissed without choosing, so the caller
+	 *         should go on and close.
+	 */
+	bool StopMachineAndOfferList();
+
+	/**
+	 * RISC OS switched the machine off.
+	 *
+	 * RISC OS 5 powers the machine down at the end of its own Shutdown, which
+	 * used to end the application: the machine list did not come back and a
+	 * user who wanted another machine had to start RPCEmu again (issue #224).
+	 * It now behaves as the close button does once the question has been
+	 * answered - the question itself is skipped, because RISC OS has already
+	 * asked it.
+	 */
+	void GuestPoweredOff();
 
 	/** Show the machine list and switch to whatever is chosen. */
 	bool SwitchToChosenMachine();

--- a/src/rpcemu.c
+++ b/src/rpcemu.c
@@ -1420,6 +1420,63 @@ debugger_swi_hook(uint32_t swinum, uint32_t opcode)
 }
 
 /**
+ * Called from updatemode() when a guest write has asked for one of the nine
+ * CPU mode values the architecture reserves.
+ *
+ * Writing a reserved mode is UNPREDICTABLE on real hardware, so the guest is
+ * where the fault is - and the guest is what somebody would want to look at.
+ * The emulator used to answer with fatal(), which ended the process and took
+ * the registers, the memory and the disassembly with it: issue #227 asked for
+ * the machine to be halted for inspection instead.
+ *
+ * The halt is immediate rather than deferred, unlike the exception and SWI
+ * traps above. Those want the vector set up first, so that the machine stops
+ * at the handler's first instruction; here there is no handler to reach and
+ * the instruction that made the write is the whole of the interesting part,
+ * so debugger_halt_pc is made to name it. The current instruction still
+ * finishes - nothing here unwinds it - and the core stops at the next fetch,
+ * where it checks debugger_paused.
+ *
+ * @param mode The full mode value written, including the 32-bit bit
+ * @param pc   Address of the instruction that wrote it
+ * @return 1 if the machine has been halted, 0 if the caller should treat the
+ *         mode as fatal because nothing could be halted into
+ */
+int
+debugger_bad_mode(uint32_t mode, uint32_t pc)
+{
+	/* Recorded whatever happens next, since with debug_enabled off this log
+	   line is the only account of it that survives. */
+	rpclog("ARM: reserved CPU mode %02x written at %08x\n",
+	       (unsigned) mode, (unsigned) pc);
+
+	debugger_trace_push(TraceEvent_Exception, pc, 0, TraceException_BadMode,
+	    mode, 0);
+
+	/* With the debugger switched off there is nowhere to halt into: the
+	   inspector cannot be opened and the debug socket is not listening, so a
+	   halt would be an emulator that had silently stopped. */
+	if (!config.debug_enabled) {
+		return 0;
+	}
+
+	if (debugger_paused) {
+		return 1;	/* already stopped; nothing to add */
+	}
+
+	debugger_enter_pause(DebugPauseReason_BadMode, pc, 0);
+
+	/* Said out loud, because a machine that has stopped dead with no
+	   inspector open looks like a hang rather than a diagnosis. Non-fatal:
+	   the front end shows it and the machine stays up. */
+	error("The machine has been halted: a reserved CPU mode (%02x) was written "
+	      "at %08x.\n\nUse the Machine Inspector to look at it, or Run to carry "
+	      "on.", (unsigned) mode, (unsigned) pc);
+
+	return 1;
+}
+
+/**
  * Write a message to the RPCEmu log file rpclog.txt
  *
  * @param format printf style format of message

--- a/src/rpcemu.h
+++ b/src/rpcemu.h
@@ -115,7 +115,11 @@ typedef enum {
 	DebugPauseReason_Watchpoint = 3,
 	DebugPauseReason_Step = 4,
 	DebugPauseReason_Exception = 5,
-	DebugPauseReason_Swi = 6
+	DebugPauseReason_Swi = 6,
+	/* A guest write asked for one of the nine mode values the architecture
+	   reserves. Not a trap the user turns on: it is always wrong, and the
+	   emulator used to answer it by ending the process. */
+	DebugPauseReason_BadMode = 7
 } DebugPauseReason;
 
 typedef struct {
@@ -184,7 +188,11 @@ typedef enum {
 typedef enum {
 	TraceException_Undefined = 0,
 	TraceException_PrefetchAbort = 1,
-	TraceException_DataAbort = 2
+	TraceException_DataAbort = 2,
+	/* Not an ARM exception - a reserved CPU mode. It travels with these
+	   because it is the same shape of event, and arg1 carries the mode
+	   that was asked for in place of a fault address. */
+	TraceException_BadMode = 3
 } TraceExceptionKind;
 
 /** A single entry in the debug trace ring. Pure POD, copied between threads. */
@@ -654,6 +662,7 @@ extern uint32_t debugger_trace_pending(void);
 extern uint32_t debugger_drain_trace_events(DebugTraceEvent *out, uint32_t max, uint32_t *dropped);
 extern void debugger_exception_hook(uint32_t mmode, uint32_t address, uint32_t pc);
 extern int debugger_swi_hook(uint32_t swinum, uint32_t opcode);
+extern int debugger_bad_mode(uint32_t mode, uint32_t pc);
 
 /* host GUI bridge */
 extern void rpcemu_video_update(const uint32_t *buffer, int xsize, int ysize, int yl, int yh, int double_size, int host_xsize, int host_ysize);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -162,6 +162,19 @@ add_executable(test_debugger_gate test_debugger_gate.c test_stubs.c)
 target_link_libraries(test_debugger_gate PRIVATE rpcemu_core m)
 rpcemu_add_test(test_debugger_gate)
 
+# A reserved CPU mode. Nine of the sixteen mode values the CPSR can hold are
+# reserved, and writing one is UNPREDICTABLE on hardware; updatemode() used to
+# answer with fatal(), so the emulator exited and took the state that would have
+# explained it (issue #227). It now halts into the debugger instead.
+#
+# All nine reserved values are covered rather than the one that was tried by
+# hand, and so are the seven legal modes: this is a new arm on a switch that
+# every mode change in the emulator passes through, and the way to get it wrong
+# is to catch a mode that used to work.
+add_executable(test_bad_mode test_bad_mode.c test_stubs.c)
+target_link_libraries(test_bad_mode PRIVATE rpcemu_core m)
+rpcemu_add_test(test_bad_mode)
+
 # Breakpoint condition expressions. Compiles debugexpr.c directly - it reads the
 # machine only through a caller-supplied environment, so a test substitutes its
 # own registers and memory and needs no emulator.
@@ -699,7 +712,7 @@ rpcemu_add_test(test_unzip)
 #
 # Raise RPCEMU_EXPECTED_TESTS when adding a test. If that feels like a chore, it
 # is the only line in the file that cannot go stale without being noticed.
-set(RPCEMU_EXPECTED_TESTS 43)	# tests that build on every platform
+set(RPCEMU_EXPECTED_TESTS 44)	# tests that build on every platform
 if(RPCEMU_JIT_TESTS)
     math(EXPR RPCEMU_EXPECTED_TESTS "${RPCEMU_EXPECTED_TESTS} + 8")	# JIT differential
 endif()

--- a/tests/test_bad_mode.c
+++ b/tests/test_bad_mode.c
@@ -1,0 +1,280 @@
+/*
+  RPCEmu - An Acorn system emulator
+
+  Copyright (C) 2026 Andy Timmins
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+/*
+ * A CPU mode the architecture reserves, and what the emulator does about it.
+ *
+ * WHY THIS EXISTS. Nine of the sixteen values the mode field can hold are
+ * reserved: 4, 5, 6, 8, 9, 10, 12, 13 and 14. Writing one is UNPREDICTABLE on
+ * real hardware, so anything that does it is a bug in the guest - and the guest
+ * is exactly where somebody would be looking when it happens. updatemode() used
+ * to answer with fatal(), which took the whole emulator down and with it the
+ * registers, the memory and the disassembly that would have said which
+ * instruction did it. That is issue #227.
+ *
+ * The machine now halts into the debugger instead, so the state at the moment
+ * of the write survives to be looked at. This checks the halt happens, that it
+ * names the reserved mode and the instruction, and - the half that is easy to
+ * lose - that the register banks are still coherent afterwards, because a halt
+ * the user cannot single-step away from is not much better than an exit.
+ *
+ * ALL NINE reserved values are covered, not the one that was hand-tested, and
+ * so are the seven legal modes: the change is a new arm of a switch that every
+ * mode change in the emulator runs through, and the way to get that wrong is to
+ * catch a mode that was working before.
+ *
+ * Links rpcemu_core for the real updatemode(), register banks and debugger
+ * state, all of which are file-static; the public API is the only way in.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "rpcemu.h"
+#include "arm.h"
+#include "arm_common.h"
+#include "mem.h"
+
+/* Where the test pretends the offending instruction is. R15 leads the
+   instruction by eight in a 32-bit mode, which is what PC in arm.h undoes. */
+#define TEST_PC		0x00108000u
+#define TEST_R15	(TEST_PC + 8u)
+
+/* Values planted in the user bank, to be found again in a reserved mode. */
+#define USER_R13	0x0d0d0d0du
+#define USER_R14	0x0e0e0e0eu
+
+static int failures;
+
+static void
+check(const char *what, int ok)
+{
+	printf("  %-64s %s\n", what, ok ? "ok" : "FAIL");
+	if (!ok) {
+		failures++;
+	}
+}
+
+static void
+check_hex(const char *what, uint32_t got, uint32_t want)
+{
+	const int ok = (got == want);
+
+	printf("  %-64s %s", what, ok ? "ok" : "FAIL");
+	if (!ok) {
+		printf("  (got %08x, want %08x)", got, want);
+		failures++;
+	}
+	printf("\n");
+}
+
+/**
+ * A 32-bit Supervisor machine with a known PC and a known user bank, and a
+ * debugger that is enabled, idle and holding no trace events.
+ */
+static void
+reset_machine(void)
+{
+	DebugTraceConfig cfg;
+	DebugTraceEvent drain[8];
+	uint32_t dropped;
+
+	arm_reset(CPUModel_SA110);
+	prog32 = 1;
+	updatemode(0x10 | SUPERVISOR);
+	arm.reg[15] = TEST_R15;
+	arm.reg[16] = 0x10 | SUPERVISOR;
+
+	/* R13 and R14 of the user bank are not aliased in Supervisor mode, so
+	   these survive until something switches to a mode that uses them. */
+	arm.user_reg[13] = USER_R13;
+	arm.user_reg[14] = USER_R14;
+
+	config.debug_enabled = 1;
+
+	debugger_resume();
+	debugger_clear_breakpoints();
+	debugger_clear_watchpoints();
+	memset(&cfg, 0, sizeof(cfg));
+	debugger_set_trace_config(&cfg);
+
+	while (debugger_drain_trace_events(drain, 8, &dropped) > 0) {
+		/* discard whatever an earlier case left behind */
+	}
+}
+
+/**
+ * One reserved mode value: the machine must halt rather than exit, and must
+ * still be a machine afterwards.
+ */
+static void
+test_reserved_mode(uint32_t mode_bits)
+{
+	DebuggerStatus status;
+	DebugTraceEvent events[8];
+	uint32_t dropped = 0;
+	uint32_t count;
+	char what[128];
+
+	printf("Reserved mode %u (CPSR mode %02x)\n", mode_bits, 0x10u | mode_bits);
+
+	reset_machine();
+
+	/* Reaching the next line at all is the fix: this used to call fatal(),
+	   which the test stub turns into exit(2). */
+	updatemode(0x10 | mode_bits);
+
+	debugger_get_status(&status);
+
+	snprintf(what, sizeof(what), "mode %02x: the machine is halted", 0x10u | mode_bits);
+	check(what, status.paused != 0);
+
+	snprintf(what, sizeof(what), "mode %02x: halted because of the mode", 0x10u | mode_bits);
+	check(what, status.reason == DebugPauseReason_BadMode);
+
+	snprintf(what, sizeof(what), "mode %02x: halt names the instruction", 0x10u | mode_bits);
+	check_hex(what, status.halt_pc, TEST_PC);
+
+	/* The trace ring carries the mode itself, which the halt PC cannot. */
+	count = debugger_drain_trace_events(events, 8, &dropped);
+	snprintf(what, sizeof(what), "mode %02x: one trace event, no drops", 0x10u | mode_bits);
+	check(what, count == 1 && dropped == 0);
+
+	if (count == 1) {
+		snprintf(what, sizeof(what), "mode %02x: event is an exception", 0x10u | mode_bits);
+		check(what, events[0].type == TraceEvent_Exception);
+
+		snprintf(what, sizeof(what), "mode %02x: event kind is the reserved mode",
+		         0x10u | mode_bits);
+		check(what, events[0].arg0 == TraceException_BadMode);
+
+		snprintf(what, sizeof(what), "mode %02x: event carries the mode asked for",
+		         0x10u | mode_bits);
+		check_hex(what, events[0].arg1, 0x10u | mode_bits);
+
+		snprintf(what, sizeof(what), "mode %02x: event carries the PC", 0x10u | mode_bits);
+		check_hex(what, events[0].pc, TEST_PC);
+	}
+
+	/*
+	 * Coherence. A halt is only useful if the machine can be looked at and
+	 * then stepped, so the banked registers must hold something defined: the
+	 * user bank, as User and System mode get.
+	 */
+	snprintf(what, sizeof(what), "mode %02x: R13 comes from the user bank", 0x10u | mode_bits);
+	check_hex(what, arm.reg[13], USER_R13);
+
+	snprintf(what, sizeof(what), "mode %02x: R14 comes from the user bank", 0x10u | mode_bits);
+	check_hex(what, arm.reg[14], USER_R14);
+
+	snprintf(what, sizeof(what), "mode %02x: usrregs point at the live registers",
+	         0x10u | mode_bits);
+	check(what, usrregs[13] == &arm.reg[13] && usrregs[14] == &arm.reg[14]);
+
+	/* Leaving again must work, or a halt cannot be recovered from. */
+	updatemode(0x10 | SUPERVISOR);
+	snprintf(what, sizeof(what), "mode %02x: Supervisor can be re-entered", 0x10u | mode_bits);
+	check_hex(what, arm.mode, 0x10u | SUPERVISOR);
+}
+
+/**
+ * The seven legal modes, which this change must not have caught.
+ */
+static void
+test_legal_modes(void)
+{
+	static const struct {
+		uint32_t bits;
+		const char *name;
+	} modes[] = {
+		{ USER,		"User" },
+		{ FIQ,		"FIQ" },
+		{ IRQ,		"IRQ" },
+		{ SUPERVISOR,	"Supervisor" },
+		{ ABORT,	"Abort" },
+		{ UNDEFINED,	"Undefined" },
+		{ SYSTEM,	"System" },
+	};
+
+	printf("Legal modes\n");
+
+	for (size_t i = 0; i < sizeof(modes) / sizeof(modes[0]); i++) {
+		DebuggerStatus status;
+		char what[128];
+
+		reset_machine();
+		updatemode(0x10 | modes[i].bits);
+		debugger_get_status(&status);
+
+		snprintf(what, sizeof(what), "%s: entered", modes[i].name);
+		check_hex(what, arm.mode, 0x10u | modes[i].bits);
+
+		snprintf(what, sizeof(what), "%s: the machine keeps running", modes[i].name);
+		check(what, status.paused == 0 && status.pause_requested == 0);
+
+		snprintf(what, sizeof(what), "%s: nothing recorded in the trace ring",
+		         modes[i].name);
+		check(what, debugger_trace_pending() == 0);
+	}
+}
+
+/**
+ * With the debugger switched off there is nothing to halt into, so the old
+ * behaviour has to stand: debugger_bad_mode() declines and its caller ends the
+ * emulator. Checked through the return value rather than by provoking fatal(),
+ * which would take this process with it.
+ */
+static void
+test_debugger_disabled(void)
+{
+	printf("Debugger disabled\n");
+
+	reset_machine();
+	config.debug_enabled = 0;
+
+	check("declines the halt, leaving the caller to end the emulator",
+	      debugger_bad_mode(0x14, TEST_PC) == 0);
+	check("and does not halt the machine", debugger_is_paused() == 0);
+
+	config.debug_enabled = 1;
+	check("enabled again, it takes the halt", debugger_bad_mode(0x14, TEST_PC) == 1);
+	check("and the machine is halted", debugger_is_paused() != 0);
+}
+
+int
+main(void)
+{
+	/* The reserved values, all nine of them. */
+	static const uint32_t reserved[] = { 4, 5, 6, 8, 9, 10, 12, 13, 14 };
+
+	arm_init();
+	mem_init();
+	machine.model = Model_RPCSA110;
+	mem_reset(16, 2);
+
+	for (size_t i = 0; i < sizeof(reserved) / sizeof(reserved[0]); i++) {
+		test_reserved_mode(reserved[i]);
+	}
+	test_legal_modes();
+	test_debugger_disabled();
+
+	printf("\n%s\n", failures == 0 ? "all ok" : "FAILURES");
+	return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
All four of this week's inspector and shutdown reports. #227 and #221 are
backports of #228 on `main`; #222 and #224 are specific to this line, where one
process runs one machine and the machine selector is a dialogue inside it.

### #227 - a reserved CPU mode no longer ends the emulator

`updatemode()` answered a reserved CPSR mode value with `fatal()`, so the
emulator exited and took the registers, the memory and the disassembly with it.
It now halts into the debugger, with the halt PC naming the instruction that
made the write. Still fatal with `debug_enabled=0`, where there is nothing to
halt into.

### #221 - the inspector's Trace tab shows what the machine is doing

The Trace tab's controls were built unticked and never filled in from the
machine, so a reopened inspector disagreed with its own machine. Halt on
exception went on halting with the box clear, and Log SWIs looked as though the
setting had been lost because `DrainTraceEvents()` gates on those same controls
and stopped reading the ring.

### #222 - closing a machine stops it

The window was hidden and the machine list shown with nothing having asked the
emulator to stop, so a machine the user had just agreed to shut down went on
executing behind the list. The reporter noticed because a game's music kept
playing.

### #224 - RISC OS switching the machine off comes back to the list

RISC OS 5 powers the machine down at the end of its own Shutdown, and that ended
the application, so the machine list did not come back.

Both now go through `StopMachineAndOfferList()`, which stops the machine before
anything is shown. They are the same thing reached from two directions and the
only difference is the question: the close button asks, the power-off does not,
because RISC OS has just asked it.

Suspended rather than stopped, because if another machine is chosen it is the
same emulator thread that switches to it. `SetExecutionSuspended()` is
deliberately not the debugger's pause: that is a debugging state, the inspector
reports it as one, and a Run there would undo it. Commands are still drained
while suspended, so the switch is acted on.

### Evidence

Guest PC read over the debug socket while the machine list was on screen:

```
#222, before   pc=fc15b170  fc03b234  fc15b170  fc15b1a4     still running
#222, after    pc=fc15b170  fc15b170  fc15b170  fc15b170     five samples
```

Cancelling the list still closes the application, and choosing a machine still
switches to it and runs it.

For #224 the power-off was provoked by planting `SWI OS_Reset` with R0 = "&OFF"
over the debug socket, which is what the desktop's Shutdown ends by doing.
Before, the process was gone within three seconds. After, the process is alive,
the window is "RPCEmu Extended - Select Machine", and the machine is suspended
with its PC parked.

For #227, `updatemode(0x14)` against the unmodified core died with
`test stub: fatal() called: Bad mode 20`, exit 2; afterwards a booted 5.31 halts
with `reason=7 halt_pc=fa200000` and single-steps on. For #221 the new
`RPCEMU_TEST_INSPECTOR_AFTER` hook reported `shown=0 machine=1 DISAGREE` on both
openings before, and agreement on both after.

### Tests

`tests/test_bad_mode.c` covers all nine reserved mode values and the seven legal
ones, against both cores. 53/53, and every commit builds on its own.

### What is not covered

All four reports are from Windows 11 and the three GUI behaviours have not been
run there. The `#227` unit test does run in the Windows job; the window does
not, since the boot test runs headless.

### One behaviour change worth naming

A guest shutdown now returns to the machine list rather than quitting. Somebody
who wants RPCEmu to close on shutdown gets there in one more click, by
dismissing the list. That is the same thing the close button has always done on
this line, so the two are consistent now rather than disagreeing.
