### PR TITLE
Mode switching: the window follows a deliberate change without the boot's half-second wait

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -53,10 +53,18 @@ machine starting:
 | `RPCEMU_TEST_CLOSE_AFTER` | Asks the window to close, exactly as the close button does, so the confirmation is put to the user rather than answered for them |
 | `RPCEMU_TEST_FULLSCREEN_AFTER` | Enters full screen and leaves it again, logging the window size and the state of the menu, tool and status bars at each step (issues #173, #206) |
 | `RPCEMU_TEST_INSPECTOR_AFTER` | Sets the machine trapping and tracing, opens the Machine Inspector, closes it, opens it again, and logs whether the Trace tab's controls agree with the machine each time (issue #221) |
+| `RPCEMU_TEST_DISPLAY_TIMING` | Not a delay: set it to 1 and every guest mode change logs where its time went - what the guest asked for, how long the window waited before following, each step of the resize, and whether the GPU or the CPU is drawing (issue #220) |
 
 They need a real display, so none of them work headless. Grep the machine's log
-for `TEST_` afterwards; the machine directory's `rpclog.txt` is the one with
-these lines in it, not the data directory's.
+for `TEST_` or `DISPLAY_TIMING` afterwards; the machine directory's `rpclog.txt`
+is the one with these lines in it, not the data directory's.
+
+`RPCEMU_TEST_DISPLAY_TIMING` is the one to reach for when somebody reports the
+display as slow, because it separates the three things that "slow" can mean:
+the guest taking a while to adopt the mode, the window waiting before it
+follows, and the resize itself. Measured on this Mac with RISC OS 4.39, those
+are about 300ms, 80ms and 2ms - so a report of anything much larger says which
+of the three to look at.
 
 ## Before pushing
 

--- a/src/gui/emulator_panel.cpp
+++ b/src/gui/emulator_panel.cpp
@@ -734,6 +734,15 @@ void EmulatorPanel::CalculateScaling()
 	RebuildGuestCursor();
 }
 
+bool EmulatorPanel::DrawingWithGpu() const
+{
+#if wxUSE_GLCANVAS
+	return GlActive();
+#else
+	return false;	/* built without a GL canvas at all */
+#endif
+}
+
 #if wxUSE_GLCANVAS
 bool EmulatorPanel::GlActive() const
 {

--- a/src/gui/emulator_panel.h
+++ b/src/gui/emulator_panel.h
@@ -108,6 +108,18 @@ private:
 	void ReleasePointerAfterDrag();
 
 	void CalculateScaling();
+public:
+	/**
+	 * Whether the GPU is drawing the guest's picture.
+	 *
+	 * Public because the display-timing diagnostic reports it: a machine on the
+	 * software path pays a full-frame blit where one on the GPU path does not,
+	 * and that is the first thing worth knowing about a display someone
+	 * describes as slow. See RPCEMU_TEST_DISPLAY_TIMING in docs/testing.md.
+	 */
+	bool DrawingWithGpu() const;
+
+private:
 #if wxUSE_GLCANVAS
 	void TryCreateGlCanvas();
 	void DestroyGlCanvas(const wxString &why);

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -209,6 +209,41 @@ bool MachineNeedsRestart(const Config *before, const Config *after)
 
 } // namespace
 
+/*
+ * RPCEMU_TEST_DISPLAY_TIMING: where the time goes when the guest changes mode.
+ *
+ * Issue #220 reported mode switching as slow, and slower the larger the mode,
+ * on Windows. It does not reproduce on macOS - measured flat at every size from
+ * 800x600 to 1920x1440 - so the numbers have to come from the machine that has
+ * the problem. This prints them: what the guest asked for, how long the window
+ * waited before following, how long each step of the resize took, and whether
+ * the GPU is drawing at all, since the software path pays a full-frame blit
+ * that the GPU path does not.
+ *
+ * Read once. Off, this costs one comparison per mode change.
+ */
+static bool
+display_timing_wanted(void)
+{
+	static int wanted = -1;
+
+	if (wanted < 0) {
+		const char *env = getenv("RPCEMU_TEST_DISPLAY_TIMING");
+
+		wanted = (env != NULL && env[0] != '\0' && env[0] != '0') ? 1 : 0;
+	}
+	return wanted != 0;
+}
+
+/** Milliseconds since the first call, for the diagnostic above. */
+static long
+display_timing_ms(void)
+{
+	static const wxLongLong start = wxGetLocalTimeMillis();
+
+	return (long) (wxGetLocalTimeMillis() - start).GetValue();
+}
+
 wxBEGIN_EVENT_TABLE(MainFrame, wxFrame)
 	EVT_CLOSE(MainFrame::OnClose)
 	EVT_ACTIVATE(MainFrame::OnActivate)
@@ -895,6 +930,9 @@ void MainFrame::StartEmulator()
 
 	AddRecentMachine(config_copy_.name);
 
+	/* The boot's run of mode changes starts here; see NoteGuestFrame(). */
+	machine_started_ms_ = wxGetLocalTimeMillis();
+
 	if (emulator_) {
 		emulator_->Start();
 	}
@@ -932,6 +970,9 @@ void MainFrame::OnReset(wxCommandEvent &)
 		return;
 	}
 	if (emulator_) {
+		/* A reset boots again, so the window goes back to waiting for the run
+		   of mode changes to finish rather than following each one. */
+		machine_started_ms_ = wxGetLocalTimeMillis();
 		emulator_->Reset();
 	}
 }
@@ -945,6 +986,9 @@ void MainFrame::RestartMachine()
 	if (emulator_ == nullptr || !emulator_->IsRunning()) {
 		return;
 	}
+	/* Boots again, so the window waits out the boot's modes once more rather
+	   than following each of them; see NoteGuestFrame(). */
+	machine_started_ms_ = wxGetLocalTimeMillis();
 	emulator_->Restart();
 }
 
@@ -1772,11 +1816,33 @@ void MainFrame::SizeWindowToGuest()
 		return;
 	}
 
+	if (!display_timing_wanted()) {
+		panel_->SizeToGuest();
+		Layout();
+		Fit();
+		CentreWindowOnScreen();
+		ForcePanelRedraw();
+		return;
+	}
+
+	/* The same sequence, timed step by step. Kept as a separate copy rather
+	   than sprinkling clocks through the live path: this runs once per mode
+	   change and clarity is worth more here than the duplication costs. */
+	const long t0 = display_timing_ms();
+
 	panel_->SizeToGuest();
+	const long t1 = display_timing_ms();
 	Layout();
 	Fit();
+	const long t2 = display_timing_ms();
 	CentreWindowOnScreen();
+	const long t3 = display_timing_ms();
 	ForcePanelRedraw();
+
+	rpclog("DISPLAY_TIMING %ld resized: SizeToGuest %ldms, Layout+Fit %ldms, "
+	       "Centre %ldms, window now %dx%d, drawing on the %s\n",
+	       t0, t1 - t0, t2 - t1, t3 - t2, GetSize().x, GetSize().y,
+	       panel_->DrawingWithGpu() ? "GPU" : "CPU");
 }
 
 
@@ -2096,12 +2162,35 @@ void MainFrame::NoteGuestFrame()
 	 * How long the guest's screen mode has to hold still before the window is
 	 * resized to it.
 	 *
-	 * Long enough to swallow the run of mode changes RISC OS makes while booting -
-	 * and the graphics card's display handover in the middle of them - so the
-	 * window is sized once at the end rather than at every step. Short enough that
-	 * a mode change the user asked for feels immediate.
+	 * TWO DIFFERENT WAITS, because there are two different things going on and
+	 * one number cannot serve both.
+	 *
+	 * While the machine is starting, RISC OS changes mode several times in quick
+	 * succession - and the graphics card hands the display over in the middle of
+	 * them - so the window has to wait for the run to finish or it marches
+	 * through three or four sizes on the way to the desktop. That is what the
+	 * half second was for, and it is still right during a boot.
+	 *
+	 * A mode change afterwards is a deliberate one. It arrives on its own,
+	 * whether from the Screen Size menu or from *WimpMode or the Display
+	 * manager inside RISC OS, and the whole half second is then dead time the
+	 * user sits through: measured here on RISC OS 4.39, the guest adopts a new
+	 * mode in about 300ms and the window then waited another 500 before
+	 * following, at every size from 800x600 to 1920x1440. Resizing the window
+	 * itself takes 2ms. Issue #220.
+	 *
+	 * The short wait is not zero because a deliberate change can still be seen
+	 * as two steps if a frame arrives mid-switch, and 80ms costs nothing that
+	 * can be felt.
 	 */
-	static const int kGuestSettleMs = 500;
+	static const int kGuestSettleBootMs = 500;
+	static const int kGuestSettleMs = 80;
+
+	/* How long after starting or resetting a machine mode changes are still
+	   treated as part of its boot. Generous: the cost of being wrong this way
+	   is one extra window resize, and the cost of being wrong the other way is
+	   the window marching through the boot's modes. */
+	static const long kBootWindowMs = 20000;
 
 	if (panel_ == nullptr) {
 		return;
@@ -2113,7 +2202,19 @@ void MainFrame::NoteGuestFrame()
 		return;
 	}
 	guest_size_seen_ = guest;
-	guest_resize_timer_.StartOnce(kGuestSettleMs);
+
+	const bool booting = machine_started_ms_ == 0 ||
+	    (wxGetLocalTimeMillis() - machine_started_ms_).GetValue() < kBootWindowMs;
+
+	const int settle = booting ? kGuestSettleBootMs : kGuestSettleMs;
+
+	if (display_timing_wanted()) {
+		rpclog("DISPLAY_TIMING %ld guest mode now %dx%d, waiting %dms (%s)\n",
+		       display_timing_ms(), guest.x, guest.y, settle,
+		       booting ? "still booting" : "a deliberate change");
+	}
+
+	guest_resize_timer_.StartOnce(settle);
 
 	/* The tick follows the desktop, so it has to move when RISC OS changes mode
 	   from its own end and not only when the change was asked for here. */

--- a/src/gui/main_frame.h
+++ b/src/gui/main_frame.h
@@ -709,6 +709,18 @@ private:
 	 */
 	wxTimer guest_resize_timer_;
 
+	/*
+	 * When the machine last started or was reset, from wxGetLocalTimeMillis().
+	 *
+	 * The window waits for the guest's mode to hold still before following it,
+	 * and how long it should wait depends entirely on which of two things is
+	 * happening. RISC OS changes mode several times in quick succession while
+	 * booting, and following each step would march the window through three or
+	 * four sizes; a mode change some time later is a deliberate one, arrives on
+	 * its own, and every millisecond of waiting is felt. See NoteGuestFrame().
+	 */
+	wxLongLong machine_started_ms_ = 0;
+
 	/* RPCEMU_TEST_CLOSE_AFTER only; never started otherwise. */
 	wxTimer test_close_timer_;
 


### PR DESCRIPTION
The half of issue #220 that measures, and a diagnostic for the half that does
not.

### What changed since 1.1.13, measured

The reporter has mode switching in RISC OS 4 as instantaneous on unextended
RPCEmu, responsive in 1.1.13 and slow in 1.1.18. He is right that something
changed, and this is it: **1.1.13 has no `NoteGuestFrame()`, no
`SizeWindowToGuest()` and no `kGuestSettleMs` at all.** The window did not follow
the guest's mode, so a mode change involved no host-side work to wait for. The
feature that followed it brought a flat half second with it, because the guest's
mode has to be seen to hold still before the window is resized.

That is right for a boot, where RISC OS changes mode several times in quick
succession and the card hands the display over in the middle of them. It is
wrong afterwards, where a mode change arrives on its own and the half second is
dead time.

Two waits now: 500ms while the machine is within twenty seconds of starting,
resetting, restarting (and on `1.x`, switching to another machine, which boots
from cold), and 80ms after that.

### The numbers

RISC OS 4.39, 8MB VRAM, VIDC20, booted to its desktop, the mode read back off
the framebuffer over VNC rather than believed:

| mode | guest adopts it | window settles, before | after |
| --- | --- | --- | --- |
| 800x600 | 0.30s | 0.50s | 0.08s |
| 1280x1024 | 0.30s | 0.50s | 0.08s |
| 1600x1200 | 0.31s | 0.50s | 0.08s |
| 1920x1440 | 0.30s | 0.50s | 0.08s |

The resize itself is 1 to 4ms at every one of those sizes.

### What this does NOT fix

His "as soon as things get bigger it starts to take a long time" **does not
reproduce here**. The table above is flat from 800x600 to 1920x1440. Whatever is
size-dependent on his Windows machine is not something this Mac does, and rather
than reason to a fix and ship it unverified - which is how #206 came back as
#219 - the measurement ships instead.

`RPCEMU_TEST_DISPLAY_TIMING=1` logs the whole timeline of a mode change:

```
DISPLAY_TIMING 20714 guest mode now 1600x1200, waiting 80ms (a deliberate change)
DISPLAY_TIMING 20795 resized: SizeToGuest 1ms, Layout+Fit 1ms, Centre 1ms, window now 1600x1280, drawing on the GPU
```

That last field is the one I most want from him. It separates the three things
"slow" can mean - the guest adopting the mode, the window waiting, the resize
itself - and says whether the GPU or the CPU is drawing, because a machine on
the software path pays a full-frame blit that a machine on the GPU path does
not. `EmulatorPanel::DrawingWithGpu()` is public for that; `GlActive()` was
private and is what it answers with.

### The other half of #220

The colour-depth asymmetry he raises second - 32K on RISC OS 4, 64K on RISC OS
5, nothing in common - is untouched here and is a separate piece of work. It is
real: `pixel_formats` in `rpcemugfx.s` offers 256, 64K and 16M with no 555
entry, and `vidc20.c`'s 16bpp converter is hard-wired to 565, while VIDC20's own
framestore is 555. The protocol for fixing it exists (the kernel passes
`ControlList_ModeFlags` in the VIDC list type 3, so a driver can tell which
16bpp format the OS chose), but it needs a card register, a converter arm, a
savestate bump and a rebuilt guest module, so it is not being bolted onto this.

### Tests

78/78 on this line. The change is in the front end, where the suite cannot
reach, so the evidence is the measurements above and they were taken on both
lines.
