### PR TITLE
macOS universal build: a Homebrew version drift is not a different library

### DIFF
--- a/build-macos.sh
+++ b/build-macos.sh
@@ -310,6 +310,68 @@ INSTALL_NAME_TOOL=$(command -v install_name_tool || \
 # "cd $(dirname) && pwd -P" alone resolves the directory only, so Homebrew's
 # lib/libSDL3.dylib -> libSDL3.0.dylib still came back under the link's name and
 # looked like a different library from the same file reached directly.
+# Do the two slices' copies of a library with the same basename come from the
+# same place?
+#
+# Prints one of:
+#   same     - the same library under each slice's own Homebrew prefix
+#   version  - the same formula, but a different version in each slice
+#   differ   - not the same library at all
+#
+# WHY THE MIDDLE ANSWER EXISTS. The two macOS runners are separate images with
+# separate Homebrew installations, and they drift: on 2 September 2026 the
+# x86_64 runner had pcre2 10.48 while the arm64 one had 10.47_1, and every
+# build on main and 1.x failed because the check compared the whole path tail -
+# version directory included - and called that a different library. It is not,
+# and fusing them is sound: a fat dylib is two independent binaries in one
+# file, the x86_64 half built against 10.48 and the arm64 half against
+# 10.47_1, and a process loads only the half matching its own architecture.
+# Neither half ever sees the other's code.
+#
+# What must still fail is a genuinely different library sharing a name - a
+# /opt/local libfoo staged against a Homebrew one - because that says the two
+# halves of the bundle are not the same software. So the formula name and the
+# path below the version are compared, and only the version is forgiven.
+staged_library_agreement() {
+	local x86_src="$1" arm_src="$2"
+	local x86_tail arm_tail
+
+	# Strip each slice's expected Homebrew prefix. What remains should be the
+	# same path under both, e.g. "Cellar/webp/1.6.0/lib/libwebp.7.dylib".
+	x86_tail=${x86_src#/usr/local/}
+	arm_tail=${arm_src#/opt/homebrew/}
+
+	if [ "$x86_tail" = "$arm_tail" ]; then
+		echo same
+		return
+	fi
+
+	# Cellar/<formula>/<version>/<rest>: compare the formula and the rest, and
+	# let the version differ. Anything not shaped like a Cellar path (an
+	# opt/ symlink, a non-Homebrew prefix) falls through to "differ", which is
+	# the safe answer.
+	case "$x86_tail" in Cellar/*) ;; *) echo differ; return ;; esac
+	case "$arm_tail" in Cellar/*) ;; *) echo differ; return ;; esac
+
+	local x86_rest=${x86_tail#Cellar/} arm_rest=${arm_tail#Cellar/}
+	local x86_formula=${x86_rest%%/*} arm_formula=${arm_rest%%/*}
+
+	if [ "$x86_formula" != "$arm_formula" ]; then
+		echo differ
+		return
+	fi
+
+	# Drop the formula, then the version, from each.
+	x86_rest=${x86_rest#*/}; x86_rest=${x86_rest#*/}
+	arm_rest=${arm_rest#*/}; arm_rest=${arm_rest#*/}
+
+	if [ "$x86_rest" = "$arm_rest" ]; then
+		echo version
+	else
+		echo differ
+	fi
+}
+
 canon_path() {
 	local p="$1" d f
 	while [ -L "$p" ]; do
@@ -784,8 +846,7 @@ if [ "$DO_FUSE" = true ]; then
 			# machine with, say, /opt/local alongside could stage a different
 			# libfoo for each. Comparing the files is no use - thin slices for
 			# different architectures always differ - so compare where they
-			# came from, which the per-slice maps record. Anything below the
-			# slice's own prefix is expected to differ only in that prefix.
+			# came from, which the per-slice maps record.
 			# The maps are per-slice build output, so they are present for a
 			# local two-arch build but not when the fusing job only downloaded
 			# the staged appstage directories. Missing maps mean the check
@@ -797,18 +858,28 @@ if [ "$DO_FUSE" = true ]; then
 				x86_src=$(awk -F'\t' -v b="$base" '$1 == b { print $2; exit }' "$X86_STAGE/deps.map")
 				arm_src=$(awk -F'\t' -v b="$base" '$1 == b { print $2; exit }' "$ARM_STAGE/deps.map")
 			fi
-			# Strip each slice's expected Homebrew prefix. What remains should
-			# be the same path under both - "Cellar/webp/1.6.0/lib/libwebp.7.dylib"
-			# and so on. If the tails differ, these are different libraries that
-			# happen to share a name.
-			x86_tail=${x86_src#/usr/local/}
-			arm_tail=${arm_src#/opt/homebrew/}
-			if [ -n "$x86_src" ] && [ -n "$arm_src" ] && [ "$x86_tail" != "$arm_tail" ]; then
-				echo "   ! $base is a different library in each slice:"
-				echo "       x86_64: $x86_src"
-				echo "       arm64:  $arm_src"
-				echo "     refusing to fuse them into one Contents/Frameworks/$base"
-				exit 1
+			if [ -n "$x86_src" ] && [ -n "$arm_src" ]; then
+				case "$(staged_library_agreement "$x86_src" "$arm_src")" in
+				same)
+					;;
+				version)
+					# Same formula, different version on each runner. Said out
+					# loud because it explains any behaviour that differs
+					# between the two halves of the bundle, but not fatal: see
+					# staged_library_agreement() for why fusing them is sound.
+					echo "   ! $base is a different VERSION in each slice:"
+					echo "       x86_64: $x86_src"
+					echo "       arm64:  $arm_src"
+					echo "     fusing anyway; each architecture loads its own half"
+					;;
+				*)
+					echo "   ! $base is a different library in each slice:"
+					echo "       x86_64: $x86_src"
+					echo "       arm64:  $arm_src"
+					echo "     refusing to fuse them into one Contents/Frameworks/$base"
+					exit 1
+					;;
+				esac
 			fi
 			"$LIPO" -create "$X86_STAGE/libs/$base" "$ARM_STAGE/libs/$base" \
 				-output "$FRAMEWORKSD/$base"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,14 @@ macro(rpcemu_add_python_test name script)
     list(APPEND RPCEMU_REGISTERED_TESTS ${name})
 endmacro()
 
+# And for a shell script, which the macOS build script's own logic is tested
+# with. Same reasoning as above: it lands on the same list and is counted.
+macro(rpcemu_add_shell_test name script)
+    add_test(NAME ${name}
+             COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/${script} ${ARGN})
+    list(APPEND RPCEMU_REGISTERED_TESTS ${name})
+endmacro()
+
 # The JIT differential testers use the recompiler's test hooks
 # (compiled into rpcemu_core when RPCEMU_JIT_TEST is set, see src/CMakeLists.txt).
 # They compare each recompiled instruction class against the interpreter and are
@@ -171,6 +179,19 @@ rpcemu_add_test(test_debugger_gate)
 # hand, and so are the seven legal modes: this is a new arm on a switch that
 # every mode change in the emulator passes through, and the way to get it wrong
 # is to catch a mode that used to work.
+# Which libraries build-macos.sh may fuse into one universal bundle. macOS
+# only, because that is the only platform the script runs on.
+#
+# Every build on main and 1.x failed on 2 September 2026 with nothing in the
+# tree changed: the two macOS runners are separate images with separate
+# Homebrew installations and had drifted to pcre2 10.48 against 10.47_1, which
+# the fuse check read as two different libraries. Too strict stops every
+# release and too lax ships two unrelated libraries in one file, so the
+# judgement is tested rather than eyeballed - the case that broke CI included.
+if(APPLE)
+    rpcemu_add_shell_test(test_fuse_libs test_fuse_libs.sh)
+endif()
+
 add_executable(test_bad_mode test_bad_mode.c test_stubs.c)
 target_link_libraries(test_bad_mode PRIVATE rpcemu_core m)
 rpcemu_add_test(test_bad_mode)
@@ -718,6 +739,9 @@ if(RPCEMU_JIT_TESTS)
 endif()
 if(RPCEMU_PYTHON_TESTS)
     math(EXPR RPCEMU_EXPECTED_TESTS "${RPCEMU_EXPECTED_TESTS} + 1")	# abort watcher
+endif()
+if(APPLE)
+    math(EXPR RPCEMU_EXPECTED_TESTS "${RPCEMU_EXPECTED_TESTS} + 1")	# build-macos.sh library fusing
 endif()
 
 list(LENGTH RPCEMU_REGISTERED_TESTS RPCEMU_ACTUAL_TESTS)

--- a/tests/test_fuse_libs.sh
+++ b/tests/test_fuse_libs.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# staged_library_agreement() in build-macos.sh, which decides whether the two
+# slices of a universal build may be fused.
+#
+# WHY THIS EXISTS. On 2 September 2026 every build on main and 1.x failed, and
+# nothing in the tree had changed: the two macOS runners are separate images with
+# separate Homebrew installations, and they had drifted to pcre2 10.48 on x86_64
+# and 10.47_1 on arm64. The check compared the whole path below each slice's
+# Homebrew prefix - version directory included - so the same formula at two
+# versions read as "a different library in each slice" and the fuse step refused.
+#
+# The judgement is four lines of string handling with no dependencies, and it can
+# fail in two directions that both matter: too strict stops every release, too
+# lax puts two unrelated libraries into one file and ships it. So it is tested
+# rather than eyeballed, and the case that broke CI is one of the cases.
+#
+# Run: tests/test_fuse_libs.sh
+
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/.." && pwd)"
+
+# Pull the function out of the build script and define it here. Sourcing the
+# whole script would run it; this takes the one function under test, which also
+# means the test fails loudly if it is renamed or removed.
+fn=$(awk '/^staged_library_agreement\(\) \{/,/^\}/' "$root/build-macos.sh")
+if [ -z "$fn" ]; then
+	echo "error: staged_library_agreement() not found in build-macos.sh" >&2
+	exit 2
+fi
+eval "$fn"
+
+failures=0
+
+check() {
+	local what="$1" x86="$2" arm="$3" want="$4" got
+
+	got=$(staged_library_agreement "$x86" "$arm")
+	if [ "$got" = "$want" ]; then
+		printf '  %-58s ok\n' "$what"
+	else
+		printf '  %-58s FAIL (got %s, want %s)\n' "$what" "$got" "$want"
+		failures=$((failures + 1))
+	fi
+}
+
+echo "The same library under each prefix"
+check "identical tails" \
+	/usr/local/Cellar/webp/1.6.0/lib/libwebp.7.dylib \
+	/opt/homebrew/Cellar/webp/1.6.0/lib/libwebp.7.dylib \
+	same
+
+echo "The runners drifting apart, which is what broke CI"
+check "pcre2 10.48 against 10.47_1" \
+	/usr/local/Cellar/pcre2/10.48/lib/libpcre2-32.0.dylib \
+	/opt/homebrew/Cellar/pcre2/10.47_1/lib/libpcre2-32.0.dylib \
+	version
+check "a plain version bump" \
+	/usr/local/Cellar/webp/1.6.1/lib/libwebp.7.dylib \
+	/opt/homebrew/Cellar/webp/1.6.0/lib/libwebp.7.dylib \
+	version
+check "a revision suffix on one side only" \
+	/usr/local/Cellar/glib/2.84.0/lib/libglib-2.0.0.dylib \
+	/opt/homebrew/Cellar/glib/2.84.0_1/lib/libglib-2.0.0.dylib \
+	version
+
+# Not every Homebrew library sits under a Cellar directory, and one at the
+# prefix root with the same relative path in both slices is the same library by
+# the only definition available here. Kept as a case because it is the one place
+# the version-forgiving path must NOT be reached: there is no version to forgive,
+# and answering "version" would mean skipping the comparison that matters.
+echo "At the prefix root rather than under a Cellar"
+check "the same relative path under each prefix" \
+	/usr/local/lib/libfoo.dylib \
+	/opt/homebrew/lib/libfoo.dylib \
+	same
+check "different relative paths, neither a Cellar" \
+	/usr/local/lib/libfoo.dylib \
+	/opt/homebrew/lib/other/libfoo.dylib \
+	differ
+
+echo "What must still be refused"
+check "different formulae with one basename" \
+	/usr/local/Cellar/pcre2/10.48/lib/libpcre2-32.0.dylib \
+	/opt/homebrew/Cellar/pcre/8.45/lib/libpcre2-32.0.dylib \
+	differ
+check "same formula, different file below the version" \
+	/usr/local/Cellar/webp/1.6.0/lib/libwebp.7.dylib \
+	/opt/homebrew/Cellar/webp/1.6.0/lib32/libwebp.7.dylib \
+	differ
+check "a non-Homebrew prefix on one side" \
+	/opt/local/lib/libpcre2-32.0.dylib \
+	/opt/homebrew/Cellar/pcre2/10.47_1/lib/libpcre2-32.0.dylib \
+	differ
+# An opt/ symlink is not a Cellar path and its version cannot be read from it,
+# so it is refused rather than guessed at.
+check "an opt symlink rather than a Cellar path" \
+	/usr/local/opt/pcre2/lib/libpcre2-32.0.dylib \
+	/opt/homebrew/Cellar/pcre2/10.47_1/lib/libpcre2-32.0.dylib \
+	differ
+
+echo
+if [ "$failures" -eq 0 ]; then
+	echo "all ok"
+	exit 0
+fi
+echo "$failures FAILED"
+exit 1


### PR DESCRIPTION
Backport of #232. **This is what is breaking every build on `1.x`**, and nothing in the tree caused it. Worth merging ahead of #231, which is red for this reason and no other.
tree caused it.** Worth merging ahead of #230 and #231, which are red for this
reason and no other.

```
! libpcre2-32.0.dylib is a different library in each slice:
    x86_64: /usr/local/Cellar/pcre2/10.48/lib/libpcre2-32.0.dylib
    arm64:  /opt/homebrew/Cellar/pcre2/10.47_1/lib/libpcre2-32.0.dylib
  refusing to fuse them into one Contents/Frameworks/libpcre2-32.0.dylib
```

The two macOS jobs run on separate runner images with separate Homebrew
installations, and those drift. `macos-universal` compared the whole path below
each slice's Homebrew prefix - version directory included - so one formula at
two versions read as two different libraries.

### Why fusing them is sound

A fat dylib is two independent binaries in one file. The x86_64 half was built
against 10.48, the arm64 half against 10.47_1, and a process maps only the half
matching its own architecture; neither half ever sees the other's code. Each was
linked against the headers it was built with.

What must still fail is a genuinely different library sharing a basename - an
`/opt/local` libfoo staged against a Homebrew one - because that says the two
halves of the bundle are not the same software. The comparison now takes the
formula name and the path below the version and forgives only the version, and
says so in the log rather than passing over it silently.

### Tested

The judgement moved out of the middle of a loop into
`staged_library_agreement()`, which answers `same`, `version` or `differ`.
`tests/test_fuse_libs.sh` pulls that function out of the script and runs eleven
cases through it, the pcre2 pair that broke CI included, plus the cases that
must still be refused. It can fail in two directions that both matter - too
strict stops every release, too lax puts two unrelated libraries in one file and
ships it.

Registered through a new `rpcemu_add_shell_test()` and counted like every other
test, macOS only. 79/79 locally.

### What this does not do

It does not pin the runners' Homebrew versions. They will drift again; after
this that is a line in the log rather than a failed release. A real universal
fuse cannot be exercised on this machine - there are no x86_64 Homebrew
libraries here - so the proof that the fixed path works end to end is this PR's
own `macos-universal` job.
