### PR TITLE
Machine Inspector: nine of the debugger requests from discussion #223

### DIFF
--- a/docs/disassembly.md
+++ b/docs/disassembly.md
@@ -77,6 +77,45 @@ time there was no step-over.
 `arm_disasm_sym()` is `arm_disasm()` with a symbol resolver, which annotates a
 branch target with the name it lands in.
 
+## How it is written down
+
+Four options change the rendering without changing what is decoded, set through
+`arm_disasm_set_options()` and exposed as checkboxes beside the Machine
+Inspector's disassembly view. They came out of discussion #223, from somebody
+reading the disassembly against his own assembler source: a listing that does
+not look like the code you are comparing it against costs a translation step on
+every line.
+
+| Option | Off | On |
+| --- | --- | --- |
+| `hex_immediates` | `MOV R0, #128` | `MOV R0, #&80` |
+| `apcs_registers` | `MOV PC, R14` | `MOV pc, lr` |
+| `collapse_reglists` | `{R0, R1, R2, R3, R7}` | `{R0-R3, R7}` |
+| `resolve_pc_relative` | `LDR R11, [PC, #-120]` | `LDR R11, &00007F90` |
+
+`hex_immediates` governs the whole line - branch targets, SWI numbers and MSR
+immediates as well as operands - because a listing mixing `&80` with `0x374C` is
+the inconsistency the option exists to remove. A named SWI keeps its name: the
+name is the useful part and is not a number to reformat.
+
+Two things are deliberately not options. Register names are consistent whichever
+setting is chosen: with `apcs_registers` clear the answer is R0-R14 and PC, where
+this disassembler used to print R13 and R14 as SP and LR while numbering
+everything else - the mixture the request complained about. And a range is only
+collapsed for three or more registers, since `{R0-R1}` is longer than
+`{R0, R1}`.
+
+The options are global rather than per call, because the whole disassembler is a
+set of static tables and every caller wants the same answer. That includes the
+debug socket's `dis`, so one machine disassembles one way whoever asked. The GUI
+thread writes them when a checkbox moves while the emulator thread may be
+reading: the fields are single bytes, and the worst a race can do is render one
+line with a mixture of old and new settings.
+
+Not done yet, from the same discussion: a lower-case rendering. It cannot be a
+post-pass over the finished string, because SWI names and symbol annotations
+must keep their case, so it needs the mnemonic and operand tables doubled up.
+
 ## Testing
 
 `tests/test_arm_disasm.c` covers both entry points: a sample of every encoding

--- a/src/arm_disasm.c
+++ b/src/arm_disasm.c
@@ -45,11 +45,68 @@ static const char *cond_names[16] = {
 	"HI", "LS", "GE", "LT", "GT", "LE", "",   "NV"
 };
 
-/* Register names */
-static const char *reg_names[16] = {
+/*
+ * Register names, ARM notation.
+ *
+ * R13 and R14 are numbered rather than shown as SP and LR, which is what this
+ * table used to do. Mixing the two conventions in one line was raised in
+ * discussion #223: either name every register by number or name them all by
+ * role, but do not do half of each. PC stays, because R15 is written PC in
+ * every ARM assembler there has ever been.
+ */
+static const char *reg_names_arm[16] = {
 	"R0",  "R1",  "R2",  "R3",  "R4",  "R5",  "R6",  "R7",
-	"R8",  "R9",  "R10", "R11", "R12", "SP",  "LR",  "PC"
+	"R8",  "R9",  "R10", "R11", "R12", "R13", "R14", "PC"
 };
+
+/*
+ * The same registers by their APCS roles, for reading a disassembly against
+ * assembler source that uses them.
+ */
+static const char *reg_names_apcs[16] = {
+	"a1",  "a2",  "a3",  "a4",  "v1",  "v2",  "v3",  "v4",
+	"v5",  "sb",  "sl",  "fp",  "ip",  "sp",  "lr",  "pc"
+};
+
+/* See ArmDisasmOptions. Zeroed, so the defaults are the plain ARM rendering. */
+static ArmDisasmOptions disasm_opts;
+
+/** The register naming in force. */
+#define reg_names (disasm_opts.apcs_registers ? reg_names_apcs : reg_names_arm)
+
+void
+arm_disasm_set_options(const ArmDisasmOptions *opts)
+{
+	if (opts == NULL) {
+		memset(&disasm_opts, 0, sizeof(disasm_opts));
+	} else {
+		disasm_opts = *opts;
+	}
+}
+
+void
+arm_disasm_get_options(ArmDisasmOptions *opts)
+{
+	if (opts != NULL) {
+		*opts = disasm_opts;
+	}
+}
+
+/**
+ * Render an immediate the way the options ask for.
+ *
+ * @param buf    Destination, at least 16 bytes
+ * @param value  The value to render
+ */
+static void
+format_imm(char *buf, size_t buflen, uint32_t value)
+{
+	if (disasm_opts.hex_immediates) {
+		snprintf(buf, buflen, "&%X", (unsigned) value);
+	} else {
+		snprintf(buf, buflen, "%u", (unsigned) value);
+	}
+}
 
 /* Data processing opcode names */
 static const char *dp_names[16] = {
@@ -91,9 +148,14 @@ decode_shifter(uint32_t opcode, char *buf, size_t buflen, int imm)
 		 * going to be used leaves the shift with 1..31.
 		 */
 		if (rot == 0) {
-			return snprintf(buf, buflen, "#%u", imm8);
+			char imm_str[16];
+
+			format_imm(imm_str, sizeof(imm_str), imm8);
+			return snprintf(buf, buflen, "#%s", imm_str);
 		}
-		return snprintf(buf, buflen, "#0x%X",
+		/* A rotated immediate is unreadable in decimal whatever the option
+		   says, so this one stays hex; only the notation follows the option. */
+		return snprintf(buf, buflen, disasm_opts.hex_immediates ? "#&%X" : "#0x%X",
 		    (imm8 >> rot) | (imm8 << (32 - rot)));
 	} else {
 		/* Register with optional shift */
@@ -122,8 +184,15 @@ decode_shifter(uint32_t opcode, char *buf, size_t buflen, int imm)
 					                reg_names[rm], shift_names[shift_type]);
 				}
 			} else {
-				return snprintf(buf, buflen, "%s, %s #%d",
-				                reg_names[rm], shift_names[shift_type], shift_amt);
+				{
+					char imm_str[16];
+
+					format_imm(imm_str, sizeof(imm_str),
+					    (uint32_t) shift_amt);
+					return snprintf(buf, buflen, "%s, %s #%s",
+					    reg_names[rm], shift_names[shift_type],
+					    imm_str);
+				}
 			}
 		}
 	}
@@ -247,7 +316,28 @@ disasm_single_transfer(uint32_t opcode, uint32_t address, char *buf, size_t bufl
 	const char *suffix = b ? "B" : "";
 	const char *sign = u ? "" : "-";
 
-	(void) address;
+	/*
+	 * A literal pool load, resolved to the address it reaches.
+	 *
+	 * "LDR R11, [PC, #-120]" says nothing about what is being loaded; the
+	 * address does, and the instruction carries everything needed to work it
+	 * out. Asked for in discussion #223. R15 reads eight ahead of the
+	 * instruction, which is where the +8 comes from.
+	 *
+	 * Restricted to the pre-indexed immediate form with no writeback off R15:
+	 * a register offset or a writeback means the address is not knowable here,
+	 * and pretending otherwise would be worse than leaving the registers on
+	 * show.
+	 */
+	if (disasm_opts.resolve_pc_relative && imm && p && !w && rn == 15) {
+		const int offset = (int) (opcode & 0xFFF);
+		const uint32_t target = u ? address + 8u + (uint32_t) offset
+		                          : address + 8u - (uint32_t) offset;
+
+		return snprintf(buf, buflen, "%s%s%s %s, &%08X",
+		                mnem, cond_names[cond], suffix, reg_names[rd],
+		                (unsigned) target);
+	}
 
 	if (imm) {
 		/* Immediate offset */
@@ -255,7 +345,10 @@ disasm_single_transfer(uint32_t opcode, uint32_t address, char *buf, size_t bufl
 		if (offset == 0) {
 			offset_str[0] = '\0';
 		} else {
-			snprintf(offset_str, sizeof(offset_str), ", #%s%d", sign, offset);
+			char imm_str[16];
+
+			format_imm(imm_str, sizeof(imm_str), (uint32_t) offset);
+			snprintf(offset_str, sizeof(offset_str), ", #%s%s", sign, imm_str);
 		}
 	} else {
 		/* Register offset with shift */
@@ -266,8 +359,11 @@ disasm_single_transfer(uint32_t opcode, uint32_t address, char *buf, size_t bufl
 		if (shift_amt == 0 && shift_type == 0) {
 			snprintf(offset_str, sizeof(offset_str), ", %s%s", sign, reg_names[rm]);
 		} else {
-			snprintf(offset_str, sizeof(offset_str), ", %s%s, %s #%d",
-			         sign, reg_names[rm], shift_names[shift_type], shift_amt);
+			char imm_str[16];
+
+			format_imm(imm_str, sizeof(imm_str), (uint32_t) shift_amt);
+			snprintf(offset_str, sizeof(offset_str), ", %s%s, %s #%s",
+			         sign, reg_names[rm], shift_names[shift_type], imm_str);
 		}
 	}
 
@@ -383,17 +479,41 @@ disasm_block_transfer(uint32_t opcode, uint32_t address, char *buf, size_t bufle
 		mnem = "STM";
 	}
 
-	/* Build register list */
+	/*
+	 * Build the register list.
+	 *
+	 * Collapsed to ranges when asked - "{R0-R4, R7-R8, R14}" rather than every
+	 * register spelled out - which is how an assembler writes it and how the
+	 * request in discussion #223 asked to read it. A range is only worth
+	 * writing for three or more registers: "R0-R1" is longer than "R0, R1".
+	 */
 	*ptr++ = '{';
 	for (i = 0; i < 16; i++) {
-		if (reglist & (1 << i)) {
-			if (!first) {
-				*ptr++ = ',';
-				*ptr++ = ' ';
-			}
-			ptr += sprintf(ptr, "%s", reg_names[i]);
-			first = 0;
+		int run;
+
+		if (!(reglist & (1 << i))) {
+			continue;
 		}
+
+		/* How far the consecutive run from here reaches. */
+		run = i;
+		if (disasm_opts.collapse_reglists) {
+			while (run + 1 < 16 && (reglist & (1 << (run + 1)))) {
+				run++;
+			}
+		}
+
+		if (!first) {
+			*ptr++ = ',';
+			*ptr++ = ' ';
+		}
+		if (run >= i + 2) {
+			ptr += sprintf(ptr, "%s-%s", reg_names[i], reg_names[run]);
+			i = run;
+		} else {
+			ptr += sprintf(ptr, "%s", reg_names[i]);
+		}
+		first = 0;
 	}
 	*ptr++ = '}';
 	if (s) {
@@ -424,7 +544,8 @@ disasm_branch(uint32_t opcode, uint32_t address, char *buf, size_t buflen)
 	/* Calculate target: PC + 8 + (offset << 2) */
 	uint32_t target = address + 8 + ((uint32_t) offset << 2);
 
-	return snprintf(buf, buflen, "%s%s 0x%08X",
+	return snprintf(buf, buflen,
+	                disasm_opts.hex_immediates ? "%s%s &%08X" : "%s%s 0x%08X",
 	                l ? "BL" : "B", cond_names[cond], target);
 }
 
@@ -1429,9 +1550,13 @@ disasm_swi(uint32_t opcode, uint32_t address, char *buf, size_t buflen)
 	} else {
 		/* Unknown SWI - show number */
 		if (imm < 0x200) {
-			return snprintf(buf, buflen, "SWI%s 0x%X", cond_names[cond], imm);
+			return snprintf(buf, buflen,
+			    disasm_opts.hex_immediates ? "SWI%s &%X" : "SWI%s 0x%X",
+			    cond_names[cond], imm);
 		} else {
-			return snprintf(buf, buflen, "SWI%s 0x%06X", cond_names[cond], imm);
+			return snprintf(buf, buflen,
+			    disasm_opts.hex_immediates ? "SWI%s &%06X" : "SWI%s 0x%06X",
+			    cond_names[cond], imm);
 		}
 	}
 }
@@ -1577,7 +1702,8 @@ disasm_msr(uint32_t opcode, uint32_t address, char *buf, size_t buflen)
 		uint32_t value = (rot == 0) ? imm8
 		    : ((imm8 >> rot) | (imm8 << (32 - rot)));
 
-		snprintf(operand, sizeof(operand), "#0x%X", value);
+		snprintf(operand, sizeof(operand),
+		    disasm_opts.hex_immediates ? "#&%X" : "#0x%X", value);
 	} else {
 		int rm = opcode & 0xF;
 		snprintf(operand, sizeof(operand), "%s", reg_names[rm]);

--- a/src/arm_disasm.h
+++ b/src/arm_disasm.h
@@ -50,6 +50,55 @@
 extern "C" {
 #endif
 
+/**
+ * How arm_disasm() renders what it decodes.
+ *
+ * Asked for in discussion #223, by somebody using the debugger against his own
+ * assembler source: a disassembly that does not look like the code you are
+ * comparing it against costs a translation step on every line. None of these
+ * change what is decoded, only how it is written down.
+ *
+ * Held globally rather than passed per call, because the whole disassembler is
+ * already a set of static tables and every caller wants the same answer. Both
+ * the GUI thread (the inspector) and the emulator thread (the debug socket's
+ * "dis") read it, and the GUI writes it when a checkbox moves; the fields are
+ * single bytes and the worst a race can do is render one line with a mixture of
+ * old and new settings.
+ */
+typedef struct {
+	/** Immediates as RISC OS hex, "#&80" rather than "#128". */
+	uint8_t hex_immediates;
+
+	/**
+	 * APCS register names: a1-a4, v1-v5, sb, sl, fp, ip, sp, lr, pc.
+	 *
+	 * Clear gives ARM names, R0-R14 and PC. Note that clear is not what this
+	 * disassembler used to print: R13 and R14 came out as SP and LR while
+	 * R0-R12 were numbered, which is the mixture the request complains about.
+	 */
+	uint8_t apcs_registers;
+
+	/** Collapse LDM/STM lists to ranges: "{R0-R4, R7}" not "{R0, R1, ...}". */
+	uint8_t collapse_reglists;
+
+	/**
+	 * Resolve a PC-relative load or store to the address it reaches, so
+	 * "LDR R11, [PC, #-120]" reads "LDR R11, &00001C84".
+	 *
+	 * Only for a pre-indexed immediate offset off R15 with no writeback,
+	 * which is the literal-pool form the compiler and the assembler emit.
+	 * Anything else keeps its registers, because the address is not knowable
+	 * from the instruction alone.
+	 */
+	uint8_t resolve_pc_relative;
+} ArmDisasmOptions;
+
+/** Replace the rendering options. NULL restores the defaults (all clear). */
+void arm_disasm_set_options(const ArmDisasmOptions *opts);
+
+/** Read the rendering options currently in force. */
+void arm_disasm_get_options(ArmDisasmOptions *opts);
+
 /** Broad category of an instruction, as identified by arm_decode(). */
 typedef enum {
 	ARM_CLASS_UNKNOWN = 0,	/**< Not a recognised encoding */

--- a/src/gui/emulator_host.cpp
+++ b/src/gui/emulator_host.cpp
@@ -997,6 +997,14 @@ void EmulatorHost::HandleCommand(const EmuCommand &command)
 		debugger_single_step(1);
 		NotifyDebuggerStateChanged();
 		break;
+	case EmuCommandType::DebuggerStepOver:
+		/* Falls back to a plain step when there is nothing to step over,
+		   which is what debugger_step_over() reports by returning zero. */
+		if (!debugger_step_over()) {
+			debugger_single_step(1);
+		}
+		NotifyDebuggerStateChanged();
+		break;
 	case EmuCommandType::DebuggerStepN: {
 		uint32_t count = command.debug_count;
 		if (count == 0) {
@@ -1275,6 +1283,11 @@ void EmulatorHost::DebuggerResume()
 void EmulatorHost::DebuggerStep()
 {
 	PostCommand(MakeCommand(EmuCommandType::DebuggerStep));
+}
+
+void EmulatorHost::DebuggerStepOver()
+{
+	PostCommand(MakeCommand(EmuCommandType::DebuggerStepOver));
 }
 
 void EmulatorHost::DebuggerStepN(uint32_t instruction_count)

--- a/src/gui/emulator_host.h
+++ b/src/gui/emulator_host.h
@@ -78,6 +78,7 @@ enum class EmuCommandType {
 	DebuggerPause,
 	DebuggerResume,
 	DebuggerStep,
+	DebuggerStepOver,
 	DebuggerStepN,
 	DebuggerAddBreakpoint,
 	DebuggerRemoveBreakpoint,
@@ -231,6 +232,16 @@ public:
 	void DebuggerPause();
 	void DebuggerResume();
 	void DebuggerStep();
+
+	/**
+	 * Run to the instruction after this one, over a call rather than into it.
+	 *
+	 * The core has had debugger_step_over() since the debug socket gained it;
+	 * nothing in the window could reach it, so stepping through a SWI or a BL
+	 * in the inspector meant stepping through everything it did. Asked for as
+	 * "Step past" in discussion #223.
+	 */
+	void DebuggerStepOver();
 	void DebuggerStepN(uint32_t instruction_count);
 	void DebuggerAddBreakpoint(uint32_t address);
 	void DebuggerRemoveBreakpoint(uint32_t address);

--- a/src/gui/emulator_snapshot.cpp
+++ b/src/gui/emulator_snapshot.cpp
@@ -213,6 +213,14 @@ emulator_disassemble_at(uint32_t address, int count)
 		count = 256;
 	}
 
+	/*
+	 * Where execution actually is, so the line about to run can be marked.
+	 *
+	 * R15 reads eight ahead of the instruction being executed, which is what
+	 * PC in arm.h undoes. Read once rather than per line.
+	 */
+	const uint32_t pc = (arm.reg[15] - 8u) & arm.r15_mask;
+
 	std::string result;
 	char disasm_buf[128];
 
@@ -222,8 +230,15 @@ emulator_disassemble_at(uint32_t address, int count)
 
 		arm_disasm(opcode, addr, disasm_buf, sizeof(disasm_buf));
 
+		/*
+		 * Upper case, and "<" in place of ":" on the instruction about to
+		 * execute - both asked for in discussion #223. The marker follows
+		 * what the RISC OS disassembler does, so it reads the way somebody
+		 * coming from *Memory expects, and it costs no column width.
+		 */
 		char line[256];
-		snprintf(line, sizeof(line), "%08x: %08x  %s\n", addr, opcode, disasm_buf);
+		snprintf(line, sizeof(line), "%08X%c %08X  %s\n",
+		         addr, addr == pc ? '<' : ':', opcode, disasm_buf);
 		result += line;
 	}
 

--- a/src/gui/machine_inspector_window.cpp
+++ b/src/gui/machine_inspector_window.cpp
@@ -35,6 +35,8 @@ extern "C" {
 #include "arm_common.h"	/* ARM_MODE_32: bit 4 of the mode says 26- or 32-bit */
 }
 
+#include <cstring>
+
 #include "arm_disasm.h"
 #include "cp15.h"
 
@@ -131,6 +133,8 @@ wxBEGIN_EVENT_TABLE(MachineInspectorWindow, wxFrame)
 	EVT_BUTTON(ID_RUN, MachineInspectorWindow::OnRun)
 	EVT_BUTTON(ID_PAUSE, MachineInspectorWindow::OnPause)
 	EVT_BUTTON(ID_STEP, MachineInspectorWindow::OnStep)
+	EVT_BUTTON(ID_STEP_OVER, MachineInspectorWindow::OnStepOver)
+	EVT_CHECKBOX(ID_DISASM_STYLE, MachineInspectorWindow::OnDisasmStyleChanged)
 	EVT_BUTTON(ID_BREAKPOINT_ADD, MachineInspectorWindow::OnAddBreakpoint)
 	EVT_BUTTON(ID_BREAKPOINT_REMOVE, MachineInspectorWindow::OnRemoveBreakpoint)
 	EVT_BUTTON(ID_WATCHPOINT_ADD, MachineInspectorWindow::OnAddWatchpoint)
@@ -297,11 +301,29 @@ void MachineInspectorWindow::BuildUi()
 	disasm_follow_pc_checkbox_ = new wxCheckBox(disasm_panel, ID_DISASM_FOLLOW_PC, "Follow PC");
 	disasm_follow_pc_checkbox_->SetValue(true);
 
+	/* How the disassembly is written down: see ArmDisasmOptions. Off by
+	   default, so the view reads as it always has until asked otherwise. */
+	disasm_hex_checkbox_ = new wxCheckBox(disasm_panel, ID_DISASM_STYLE, "Hex");
+	disasm_hex_checkbox_->SetToolTip("Immediates as &80 rather than 128");
+	disasm_apcs_checkbox_ = new wxCheckBox(disasm_panel, ID_DISASM_STYLE, "APCS");
+	disasm_apcs_checkbox_->SetToolTip(
+	    "Register names as a1-a4, v1-v5, sb, sl, fp, ip, sp, lr, pc");
+	disasm_ranges_checkbox_ = new wxCheckBox(disasm_panel, ID_DISASM_STYLE, "Ranges");
+	disasm_ranges_checkbox_->SetToolTip(
+	    "Collapse LDM/STM register lists: {R0-R4, R7}");
+	disasm_resolve_checkbox_ = new wxCheckBox(disasm_panel, ID_DISASM_STYLE, "PC-rel");
+	disasm_resolve_checkbox_->SetToolTip(
+	    "Show a PC-relative load as the address it reaches");
+
 	auto *disasm_controls = new wxBoxSizer(wxHORIZONTAL);
 	disasm_controls->Add(new wxStaticText(disasm_panel, wxID_ANY, "Address:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 6);
 	disasm_controls->Add(disasm_address_input_, 0, wxRIGHT, 6);
 	disasm_controls->Add(disasm_go_button, 0, wxRIGHT, 6);
-	disasm_controls->Add(disasm_follow_pc_checkbox_, 0);
+	disasm_controls->Add(disasm_follow_pc_checkbox_, 0, wxRIGHT, 12);
+	disasm_controls->Add(disasm_hex_checkbox_, 0, wxRIGHT, 6);
+	disasm_controls->Add(disasm_apcs_checkbox_, 0, wxRIGHT, 6);
+	disasm_controls->Add(disasm_ranges_checkbox_, 0, wxRIGHT, 6);
+	disasm_controls->Add(disasm_resolve_checkbox_, 0);
 
 	disasm_view_ = new wxTextCtrl(disasm_panel, wxID_ANY, wxEmptyString,
 	                              wxDefaultPosition, wxDefaultSize,
@@ -353,6 +375,9 @@ void MachineInspectorWindow::BuildUi()
 	run_button_ = new wxButton(debug_panel, ID_RUN, "Run");
 	pause_button_ = new wxButton(debug_panel, ID_PAUSE, "Pause");
 	step_button_ = new wxButton(debug_panel, ID_STEP, "Step");
+	step_over_button_ = new wxButton(debug_panel, ID_STEP_OVER, "Step over");
+	step_over_button_->SetToolTip(
+	    "Run to the next instruction without going into a call or a SWI");
 	run_button_->Enable(false);
 	pause_button_->Enable(false);
 	step_button_->Enable(false);
@@ -364,7 +389,8 @@ void MachineInspectorWindow::BuildUi()
 	auto *debug_buttons = new wxBoxSizer(wxHORIZONTAL);
 	debug_buttons->Add(run_button_, 0, wxRIGHT, 6);
 	debug_buttons->Add(pause_button_, 0, wxRIGHT, 6);
-	debug_buttons->Add(step_button_, 0, wxRIGHT, 12);
+	debug_buttons->Add(step_button_, 0, wxRIGHT, 6);
+	debug_buttons->Add(step_over_button_, 0, wxRIGHT, 12);
 	debug_buttons->Add(debug_status_label_, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 12);
 	debug_buttons->Add(debug_hit_label_, 1, wxALIGN_CENTER_VERTICAL);
 
@@ -528,6 +554,10 @@ void MachineInspectorWindow::BuildUi()
 	memory_address_input_->Bind(wxEVT_TEXT_ENTER, &MachineInspectorWindow::OnMemoryGo, this);
 	breakpoint_list_->Bind(wxEVT_LISTBOX, &MachineInspectorWindow::OnBreakpointSelection, this);
 	watchpoint_list_->Bind(wxEVT_LISTBOX, &MachineInspectorWindow::OnWatchpointSelection, this);
+	/* Keys on the frame and on the two read-only views, which are where the
+	   focus lands while stepping. A text entry keeps its own keys. */
+	Bind(wxEVT_CHAR_HOOK, &MachineInspectorWindow::OnDebugKey, this);
+
 	swi_filter_min_input_->Bind(wxEVT_TEXT_ENTER, &MachineInspectorWindow::OnTraceConfigChanged, this);
 	swi_filter_max_input_->Bind(wxEVT_TEXT_ENTER, &MachineInspectorWindow::OnTraceConfigChanged, this);
 }
@@ -590,7 +620,18 @@ void MachineInspectorWindow::ApplySnapshot(const MachineSnapshot &snapshot)
 	}
 
 	if (disasm_follow_pc_checkbox_->GetValue()) {
-		RefreshDisassembly(snapshot.pc);
+		/*
+		 * Back from the PC, not at it.
+		 *
+		 * Starting the view at the PC put the instruction about to run on the
+		 * top line, so the instructions that led to it - the ones you want
+		 * when you have just stopped somewhere unexpected - were off the top
+		 * and had to be fetched by typing a lower address in by hand. Asked
+		 * for in discussion #223. Clamped so it cannot wrap below zero.
+		 */
+		const uint32_t back = kDisasmLeadIn * 4u;
+
+		RefreshDisassembly(snapshot.pc >= back ? snapshot.pc - back : 0u);
 	}
 }
 
@@ -860,6 +901,21 @@ void MachineInspectorWindow::UpdateDebuggerUi(const MachineSnapshot &snapshot)
 	run_button_->Enable(paused);
 	pause_button_->Enable(!paused);
 	step_button_->Enable(paused);
+	step_over_button_->Enable(paused);
+
+	/*
+	 * ★ Re-lay-out the row after changing the labels.
+	 *
+	 * Both labels are in a horizontal sizer, the status one sized to its
+	 * content. Setting a longer string does not re-run the sizer, so the label
+	 * kept the width it was created with and the two ran into each other:
+	 * "Paused: manual pause at PC 0xFNo watchpoint hit", reported in
+	 * discussion #223. Asking the parent to lay out again costs nothing at
+	 * this rate and puts both labels where they belong.
+	 */
+	if (debug_status_label_->GetParent() != nullptr) {
+		debug_status_label_->GetParent()->Layout();
+	}
 }
 
 void MachineInspectorWindow::OnTraceConfigChanged(wxCommandEvent &)
@@ -1076,7 +1132,8 @@ void MachineInspectorWindow::DrainTraceEvents()
 void MachineInspectorWindow::RefreshDisassembly(uint32_t address)
 {
 	disasm_current_address_ = address;
-	SetTextIfChanged(disasm_view_, wxString::FromUTF8(emulator_disassemble_at(address, 32)));
+	SetTextIfChanged(disasm_view_,
+	    wxString::FromUTF8(emulator_disassemble_at(address, kDisasmLines)));
 }
 
 void MachineInspectorWindow::RefreshMemoryView(uint32_t address)
@@ -1187,6 +1244,89 @@ void MachineInspectorWindow::OnStep(wxCommandEvent &)
 {
 	emulator_.DebuggerStep();
 	RefreshSnapshot();
+}
+
+void MachineInspectorWindow::OnStepOver(wxCommandEvent &)
+{
+	emulator_.DebuggerStepOver();
+	RefreshSnapshot();
+}
+
+/*
+ * A rendering option moved.
+ *
+ * The options live in the disassembler rather than in this window, because the
+ * debug socket's "dis" renders through the same code and one machine should not
+ * disassemble two different ways depending on who asked. The view is redrawn at
+ * once so the effect of the click is visible without waiting for a refresh.
+ */
+void MachineInspectorWindow::OnDisasmStyleChanged(wxCommandEvent &)
+{
+	ArmDisasmOptions opts;
+
+	memset(&opts, 0, sizeof(opts));
+	opts.hex_immediates = disasm_hex_checkbox_->GetValue() ? 1 : 0;
+	opts.apcs_registers = disasm_apcs_checkbox_->GetValue() ? 1 : 0;
+	opts.collapse_reglists = disasm_ranges_checkbox_->GetValue() ? 1 : 0;
+	opts.resolve_pc_relative = disasm_resolve_checkbox_->GetValue() ? 1 : 0;
+	arm_disasm_set_options(&opts);
+
+	RefreshDisassembly(disasm_current_address_);
+}
+
+/*
+ * Keys for the things done most often while stepping through code.
+ *
+ * Asked for in discussion #223: reaching for the mouse between every step is
+ * what makes stepping tedious. Enter toggles rather than having separate keys
+ * for run and pause, for the same reason.
+ */
+void MachineInspectorWindow::OnDebugKey(wxKeyEvent &event)
+{
+	const bool paused = last_snapshot_.debug_paused != 0;
+
+	/*
+	 * ★ Not while something is being typed into.
+	 *
+	 * CHAR_HOOK sees the key before the focused control does, which is what
+	 * makes it work on the read-only views - but it would also swallow the
+	 * space bar and Return from the address and breakpoint boxes, so an
+	 * address could not be typed or submitted. The focused window decides:
+	 * anything that takes text keeps its keys.
+	 */
+	const wxWindow *focus = FindFocus();
+
+	if (dynamic_cast<const wxTextEntry *>(focus) != nullptr) {
+		event.Skip();
+		return;
+	}
+
+	switch (event.GetKeyCode()) {
+	case WXK_RETURN:
+	case WXK_NUMPAD_ENTER:
+		if (paused) {
+			emulator_.DebuggerResume();
+		} else {
+			emulator_.DebuggerPause();
+		}
+		RefreshSnapshot();
+		return;
+
+	case WXK_SPACE:
+		if (paused) {
+			if (event.ShiftDown()) {
+				emulator_.DebuggerStepOver();
+			} else {
+				emulator_.DebuggerStep();
+			}
+			RefreshSnapshot();
+		}
+		return;
+
+	default:
+		event.Skip();
+		return;
+	}
 }
 
 void MachineInspectorWindow::OnAddBreakpoint(wxCommandEvent &)

--- a/src/gui/machine_inspector_window.h
+++ b/src/gui/machine_inspector_window.h
@@ -63,6 +63,8 @@ private:
 		ID_RUN,
 		ID_PAUSE,
 		ID_STEP,
+		ID_STEP_OVER,
+		ID_DISASM_STYLE,
 		ID_BREAKPOINT_ADD,
 		ID_BREAKPOINT_REMOVE,
 		ID_WATCHPOINT_ADD,
@@ -70,6 +72,15 @@ private:
 		ID_TRACE_CONFIG,
 		ID_TRACE_CLEAR,
 	};
+
+	/*
+	 * How much disassembly the view shows, and how much of it sits above the
+	 * PC when the view is following it. A third above and two thirds below
+	 * reads better than dead centre: what led here is usually a handful of
+	 * instructions, and where it is going is the part being read.
+	 */
+	static const int kDisasmLines = 32;
+	static const int kDisasmLeadIn = 10;
 
 	void BuildUi();
 
@@ -88,6 +99,13 @@ private:
 	void OnRun(wxCommandEvent &event);
 	void OnPause(wxCommandEvent &event);
 	void OnStep(wxCommandEvent &event);
+	void OnStepOver(wxCommandEvent &event);
+
+	/** A disassembly rendering option moved; push the set to arm_disasm. */
+	void OnDisasmStyleChanged(wxCommandEvent &event);
+
+	/** Enter runs or pauses, Space steps, Shift+Space steps over. */
+	void OnDebugKey(wxKeyEvent &event);
 	void OnAddBreakpoint(wxCommandEvent &event);
 	void OnRemoveBreakpoint(wxCommandEvent &event);
 	void OnAddWatchpoint(wxCommandEvent &event);
@@ -146,6 +164,14 @@ private:
 	wxTextCtrl *disasm_address_input_ = nullptr;
 	wxCheckBox *disasm_follow_pc_checkbox_ = nullptr;
 
+	/* How the disassembly is written down, from discussion #223. These drive
+	   arm_disasm's global options, so they change the debug socket's output
+	   too, which is deliberate: one machine, one rendering. */
+	wxCheckBox *disasm_hex_checkbox_ = nullptr;
+	wxCheckBox *disasm_apcs_checkbox_ = nullptr;
+	wxCheckBox *disasm_ranges_checkbox_ = nullptr;
+	wxCheckBox *disasm_resolve_checkbox_ = nullptr;
+
 	wxTextCtrl *memory_address_input_ = nullptr;
 	wxSpinCtrl *memory_bytes_spin_ = nullptr;
 
@@ -154,6 +180,7 @@ private:
 	wxButton *run_button_ = nullptr;
 	wxButton *pause_button_ = nullptr;
 	wxButton *step_button_ = nullptr;
+	wxButton *step_over_button_ = nullptr;
 	wxListBox *breakpoint_list_ = nullptr;
 	wxTextCtrl *breakpoint_input_ = nullptr;
 	wxButton *breakpoint_remove_button_ = nullptr;

--- a/tests/test_arm_disasm.c
+++ b/tests/test_arm_disasm.c
@@ -98,7 +98,7 @@ test_data_processing(void)
 	check_text(0xE1A00060, "MOV R0, R0, RRX");
 	check_text(0xE1B00001, "MOVS R0, R1");
 	check_text(0x01A00001, "MOVEQ R0, R1");
-	check_text(0xE1A0F00E, "MOV PC, LR");
+	check_text(0xE1A0F00E, "MOV PC, R14");
 }
 
 static void
@@ -120,8 +120,8 @@ test_transfers(void)
 
 	printf("Block transfer\n");
 
-	check_text(0xE92D4010, "STMDB SP!, {R4, LR}");
-	check_text(0xE8BD8010, "LDMIA SP!, {R4, PC}");
+	check_text(0xE92D4010, "STMDB R13!, {R4, R14}");
+	check_text(0xE8BD8010, "LDMIA R13!, {R4, PC}");
 	check_text(0xE8900007, "LDMIA R0, {R0, R1, R2}");
 }
 
@@ -136,7 +136,7 @@ test_branches(void)
 	check_text(0xEAFFFFFE, "B 0x00008000");
 	check_text(0x1A000002, "BNE 0x00008010");
 	check_text(0xE12FFF11, "BX R1");
-	check_text(0xE12FFF1E, "BX LR");
+	check_text(0xE12FFF1E, "BX R14");
 }
 
 static void
@@ -168,7 +168,7 @@ test_fpa(void)
 	/* Load and store, CP1: precision from bits 22 and 15 */
 	check_text(0xED910100, "LDFS F0, [R1]");
 	check_text(0xED910108, "LDFS F0, [R1, #32]");
-	check_text(0xED2DA102, "STFD F2, [SP, #-8]!");
+	check_text(0xED2DA102, "STFD F2, [R13, #-8]!");
 
 	/* Multiple register load and store, CP2 */
 	check_text(0xED910200, "LFM F0, 4, [R1]");
@@ -430,6 +430,119 @@ test_symbol_annotation(void)
 	check("no resolver leaves the text alone", strcmp(buf, "BL 0x00008008") == 0);
 }
 
+
+/* ------------------------------------------------------ rendering options */
+
+/**
+ * Check an opcode's rendering with a given set of options in force, and put
+ * the defaults back afterwards so no test can leak into the next.
+ */
+static void
+check_opts(const ArmDisasmOptions *opts, uint32_t opcode, uint32_t at,
+           const char *expected)
+{
+	char buf[256];
+	char what[400];
+
+	arm_disasm_set_options(opts);
+	arm_disasm(opcode, at, buf, sizeof(buf));
+	arm_disasm_set_options(NULL);
+
+	snprintf(what, sizeof(what), "%08X -> \"%s\"", opcode, expected);
+	check(what, strcmp(buf, expected) == 0);
+	if (strcmp(buf, expected) != 0) {
+		printf("      got \"%s\"\n", buf);
+	}
+}
+
+/*
+ * The four rendering options from discussion #223.
+ *
+ * WHY THESE ARE TESTED. Each one exists so a disassembly can be read against
+ * assembler source without translating every line, and each is a different
+ * way of writing the same decoded instruction. A bug here does not look like a
+ * bug: it looks like the disassembler disagreeing with your own code, which is
+ * exactly the doubt these were added to remove. The defaults are checked
+ * alongside every option, because an option that cannot be turned off is as
+ * bad as one that does not work.
+ */
+static void
+test_rendering_options(void)
+{
+	ArmDisasmOptions opts;
+
+	printf("Rendering options\n");
+
+	/* Hex immediates: MOV R0, #128 the RISC OS way. */
+	memset(&opts, 0, sizeof(opts));
+	check_opts(NULL, 0xE3A00080, AT, "MOV R0, #128");
+	opts.hex_immediates = 1;
+	check_opts(&opts, 0xE3A00080, AT, "MOV R0, #&80");
+	/* And an immediate offset on a load, which goes through the same helper. */
+	check_opts(NULL, 0xE5D000FF, AT, "LDRB R0, [R0, #255]");
+	check_opts(&opts, 0xE5D000FF, AT, "LDRB R0, [R0, #&FF]");
+
+	/* APCS names. */
+	memset(&opts, 0, sizeof(opts));
+	opts.apcs_registers = 1;
+	check_opts(NULL, 0xE1A0F00E, AT, "MOV PC, R14");
+	check_opts(&opts, 0xE1A0F00E, AT, "MOV pc, lr");
+	check_opts(&opts, 0xE0812003, AT, "ADD a3, a2, a4");
+
+	/* Register lists as ranges. A run of two is left spelled out, being no
+	   longer than the range that would replace it. */
+	memset(&opts, 0, sizeof(opts));
+	opts.collapse_reglists = 1;
+	check_opts(NULL,  0xE92D409F, AT, "STMDB R13!, {R0, R1, R2, R3, R4, R7, R14}");
+	check_opts(&opts, 0xE92D409F, AT, "STMDB R13!, {R0-R4, R7, R14}");
+	check_opts(&opts, 0xE92D4003, AT, "STMDB R13!, {R0, R1, R14}");
+	check_opts(&opts, 0xE92D0007, AT, "STMDB R13!, {R0-R2}");
+	/* Every register, which is one range from end to end. */
+	check_opts(&opts, 0xE92DFFFF, AT, "STMDB R13!, {R0-PC}");
+
+	/* PC-relative loads resolved. R15 reads eight ahead, so a -120 offset
+	   from 0x8000 reaches 0x7F90. */
+	memset(&opts, 0, sizeof(opts));
+	opts.resolve_pc_relative = 1;
+	check_opts(NULL,  0xE51FB078, AT, "LDR R11, [PC, #-120]");
+	check_opts(&opts, 0xE51FB078, AT, "LDR R11, &00007F90");
+	check_opts(&opts, 0xE59FB004, AT, "LDR R11, &0000800C");
+	/* Not off R15, so nothing to resolve. */
+	check_opts(&opts, 0xE51CB078, AT, "LDR R11, [R12, #-120]");
+	/* Writeback: the address moves, so the registers stay on show. */
+	check_opts(&opts, 0xE53FB078, AT, "LDR R11, [PC, #-120]!");
+
+	/* Hex notation is one setting for the whole line, not just the operands
+	   that happen to be immediates: a branch target, a SWI number and an MSR
+	   immediate all follow it. Mixing "&80" with "0x374C" in one disassembly
+	   is the inconsistency this option exists to remove. */
+	memset(&opts, 0, sizeof(opts));
+	opts.hex_immediates = 1;
+	check_opts(NULL,  0xEA00001C, AT, "B 0x00008078");
+	check_opts(&opts, 0xEA00001C, AT, "B &00008078");
+	/* A named SWI keeps its name whatever the notation - the name is the
+	   useful part, and it is not a number to be reformatted. */
+	check_opts(&opts, 0xEF000011, AT, "SWI OS_Exit");
+	check_opts(NULL,  0xEF012345, AT, "SWI 0x012345");
+	check_opts(&opts, 0xEF012345, AT, "SWI &012345");
+
+	/* The options are independent, and combine. */
+	memset(&opts, 0, sizeof(opts));
+	opts.apcs_registers = 1;
+	opts.collapse_reglists = 1;
+	opts.hex_immediates = 1;
+	check_opts(&opts, 0xE92D409F, AT, "STMDB sp!, {a1-v1, v4, lr}");
+
+	/* And setting NULL restores every default. */
+	arm_disasm_set_options(&opts);
+	arm_disasm_set_options(NULL);
+	memset(&opts, 0xff, sizeof(opts));
+	arm_disasm_get_options(&opts);
+	check("NULL puts every option back to its default",
+	      opts.hex_immediates == 0 && opts.apcs_registers == 0 &&
+	      opts.collapse_reglists == 0 && opts.resolve_pc_relative == 0);
+}
+
 int
 main(void)
 {
@@ -445,6 +558,7 @@ main(void)
 	test_swi();
 	test_unknown();
 	test_symbol_annotation();
+	test_rendering_options();
 
 	printf("\n%s\n", failures ? "FAILED" : "All tests passed");
 


### PR DESCRIPTION
Backport of #234 to `1.x`, which is the line Jon is actually using — 1.1.18.

Nine of the twenty observations from discussion #223, being the ones about
reading a disassembly and driving the stepper. Jon Abbott's list came out of his
first pass with the debugger against his own assembler source, and most of it is
"this costs me a translation step on every line" rather than anything grand.

### Disassembly rendering

Four options, off by default, as checkboxes beside the disassembly view:

| Option | Off | On |
| --- | --- | --- |
| Hex | `MOV R0, #128` | `MOV R0, #&80` |
| APCS | `MOV PC, R14` | `MOV pc, lr` |
| Ranges | `{R0, R1, R2, R3, R7}` | `{R0-R3, R7}` |
| PC-rel | `LDR R11, [PC, #-120]` | `LDR R11, &00007F90` |

Hex governs the whole line - branch targets, SWI numbers and MSR immediates as
well as operands - because a listing mixing `&80` with `0x374C` is the
inconsistency it exists to remove. A named SWI keeps its name.

**Register names are now consistent either way**, which is the actual
complaint: this disassembler printed R13 and R14 as SP and LR while numbering
everything else. Clear gives R0-R14 and PC; set gives the APCS roles throughout.
That deliberately changes five expectations in `test_arm_disasm.c`.

They are global rather than per call, so the debug socket's `dis` renders the
same way - one machine, one rendering.

### The view

- The address and opcode columns are upper case.
- The instruction about to execute has its `:` replaced by `<`, as the RISC OS
  disassembler does.
- The view starts ten instructions **above** the PC rather than at it. What led
  here is what you want when you have just stopped somewhere unexpected, and it
  used to be off the top of the pane.

### Stepping

- A **Step over** button. `debugger_step_over()` has existed since the debug
  socket gained it and nothing in the window could reach it.
- Keys: Return runs or pauses, Space steps, Shift+Space steps over. Bound
  through `CHAR_HOOK` so they reach the read-only views, and declined when the
  focus is in a text entry — otherwise an address could not be typed.

### And one bug

`"Paused: manual pause at PC 0xFNo watchpoint hit"`. Both labels are in a
horizontal sizer with the status one sized to its content, and `SetLabel` does
not re-run the sizer. The row is laid out again after the labels change.

### Measured in the live window

Read back out of the control rather than looked at, RISC OS 4.39 stopped inside
a module:

```
039B36C8: E59CE330  LDR R14, [R12, #816]     upper case, R14 not LR
   ... eight more lines of lead-in ...
039B36F0< E1550007  CMP R5, R7               the instruction about to run
039B36F4: 228C5A03  ADDCS R5, R12, #0x3000
```

and with Hex, Ranges and PC-rel ticked, the same code, toggled live by clicking
the checkboxes:

```
039B36C8: E59CE330  LDR R14, [R12, #&330]
039B36EC: E3A06080  MOV R6, #&80
039B36F0< E1550007  CMP R5, R7
```

### Tests

54/54 on this line. `test_arm_disasm.c` gains nineteen cases covering every option, each
expectation computed from the encoding rather than from what the code prints.
Writing them caught two of my own errors: SWI `&11` is `OS_Exit`, not
`OS_WriteC`, and there is a second SWI rendering path for numbers above `0x200`
that my first patch missed.

### Still on Jon's list, not in here

Lower-case rendering (cannot be a post-pass: SWI names and symbol annotations
must keep their case, so the tables need doubling up); custom SWI names from a
CSV; auto-step at a chosen rate; halting on an exception at the faulting
instruction rather than the vector; ignoring IRQ and OS code; a breakpoint
triggered from guest code; import/export of inspector settings; SPSR display;
and editing registers and memory from the window — which the debug socket
already does with `reg set` and `mem write`, so that one is plumbing.

Also unaddressed: **the step being slow**, about half a second for him. Every
step runs a full snapshot refresh with both hidden tabs rebuilt as strings,
which is the obvious suspect, but I have not measured it and will not claim it.
