### PR TITLE
Machine Inspector: stepping follows the machine, not a half-second clock

### DIFF
--- a/src/gui/machine_inspector_window.cpp
+++ b/src/gui/machine_inspector_window.cpp
@@ -600,6 +600,14 @@ void MachineInspectorWindow::OnAutoRefresh(wxCommandEvent &event)
 	}
 }
 
+void MachineInspectorWindow::RefreshFromStateChange()
+{
+	/* Only worth the round trip while the window is up. */
+	if (IsShown()) {
+		RefreshSnapshot();
+	}
+}
+
 void MachineInspectorWindow::RefreshSnapshot()
 {
 	const MachineSnapshot snapshot = emulator_.TakeSnapshot();

--- a/src/gui/machine_inspector_window.h
+++ b/src/gui/machine_inspector_window.h
@@ -52,6 +52,19 @@ public:
 	 */
 	bool LogTraceControlsAgainstMachine(const char *when);
 
+	/**
+	 * The debugger has started or stopped; read the machine again now.
+	 *
+	 * This window's own refresh is a half-second timer, which is fine for
+	 * watching a running machine and far too slow for stepping: the snapshot
+	 * taken immediately after a step still says "running", because the step has
+	 * not finished yet, so every button that needs a stopped machine greys out
+	 * and nothing re-reads until the tick. Jon Abbott measured that in
+	 * discussion #223 as a consistent half second per step with Step unclickable
+	 * in between.
+	 */
+	void RefreshFromStateChange();
+
 private:
 	enum {
 		ID_AUTO_REFRESH = wxID_HIGHEST + 1,

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -3600,6 +3600,24 @@ void MainFrame::PostDebuggerStateChanged()
 	CallAfter([this]() {
 		UpdateDebuggerActionStates();
 		ReportMenuState();
+
+		/*
+		 * ★ And tell the inspector, which used to hear nothing from here.
+		 *
+		 * Its own refresh is a half-second timer. That is fine for watching a
+		 * running machine and hopeless for stepping: the snapshot it takes
+		 * straight after a step still says "running", because the step has not
+		 * finished, so Step and Run grey out and nothing re-reads until the
+		 * next tick. Measured by the reporter of discussion #223 as a
+		 * consistent half second per step with Step unclickable in between,
+		 * which is exactly this and not the cost of drawing the window.
+		 *
+		 * The emulator thread raises this when the debugger actually starts or
+		 * stops, so the window now follows the machine rather than the clock.
+		 */
+		if (machine_inspector_window_ != nullptr) {
+			machine_inspector_window_->RefreshFromStateChange();
+		}
 	});
 }
 

--- a/tests/test_debugger_gate.c
+++ b/tests/test_debugger_gate.c
@@ -253,6 +253,54 @@ test_combinations(void)
 	check_gate("all clear", 0);
 }
 
+
+/*
+ * A step leaves the machine RUNNING until the step finishes, and any front end
+ * that samples the debugger at that moment sees "not stopped".
+ *
+ * WHY THIS EXISTS. This is not a fault - it is what stepping means, and the
+ * pause arrives a moment later through the instruction hook. It is here because
+ * the Machine Inspector used to read the machine on a half-second timer and
+ * refresh itself immediately after asking for a step, so it caught exactly this
+ * transient and greyed out every button that needs a stopped machine. Nothing
+ * re-read until the next tick, which capped stepping at about two instructions
+ * a second and was reported that way in discussion #223.
+ *
+ * The window now refreshes when the debugger's state actually changes rather
+ * than on a clock. This locks down the fact that made the old arrangement
+ * wrong, so nobody reintroduces "ask for a step, then sample" and wonders why
+ * the buttons flicker.
+ */
+static void
+test_step_is_not_immediately_paused(void)
+{
+	DebuggerStatus status;
+
+	printf("A step is not a pause\n");
+
+	reset_debugger();
+	debugger_request_pause(DebugPauseReason_User);
+	debugger_instruction_hook(0x8000, 0xe1a00000);
+
+	debugger_get_status(&status);
+	check("stopped to begin with", status.paused != 0);
+
+	debugger_single_step(1);
+	debugger_get_status(&status);
+	check("asking for a step leaves the machine running", status.paused == 0);
+	check("and says a step is in progress", status.step_active != 0);
+	check_gate("mid-step", 1);
+
+	/* The instruction runs, and the pause lands on the far side of it. */
+	debugger_instruction_hook(0x8000, 0xe1a00000);
+	debugger_after_instruction(0x8000, 0xe1a00000);
+	debugger_instruction_hook(0x8004, 0xe1a00000);
+
+	debugger_get_status(&status);
+	check("stopped again once the step has been taken", status.paused != 0);
+	check("and the step is over", status.step_active == 0);
+}
+
 int
 main(void)
 {
@@ -264,6 +312,7 @@ main(void)
 	test_pause_and_step();
 	test_traps();
 	test_combinations();
+	test_step_is_not_immediately_paused();
 
 	printf("\n%s\n", failures ? "FAILED" : "All tests passed");
 


### PR DESCRIPTION
Jon Abbott came back on discussion #223 with the measurement that settles the
slow step, and he was right where I was wrong. I first guessed the refresh
timer, then talked myself out of it and said the cost was probably the snapshot
rebuilding both hidden tabs. His reply: the delay is consistent, it is close to
the timer, and **the Step button greys out in between**.

### The chain

`OnStep()` asks for a step and refreshes immediately — but
`debugger_single_step()` leaves the machine **running**. The pause arrives a
moment later through the instruction hook, once the instruction has actually
been taken. So:

1. the snapshot taken right after the click reports not-paused;
2. `UpdateDebuggerUi()` does `step_button_->Enable(paused)` and the button goes
   grey;
3. nothing re-reads the machine until the window's own timer fires, 500 ms
   later;
4. clicks in between land on a disabled button, so stepping is capped at about
   two instructions a second.

### The fix

`MainFrame::PostDebuggerStateChanged()` already existed, and the emulator thread
already raises it when the debugger actually starts or stops. It updated the
machine window's menus and **told the inspector nothing**. It now tells the
inspector too, so the window follows the machine instead of the clock. That fixes
Run and Pause the same way, and the keys added in #234, which read the same
possibly-stale snapshot to decide whether a step is allowed.

### Tested

`tests/test_debugger_gate.c` gains the fact that made the old arrangement wrong:
after `debugger_single_step(1)` the machine is running with `step_active` set,
and it is paused again only once the instruction has been taken. That is not a
bug — it is what stepping means — but it is the transient the window used to
sample, so pinning it stops anyone reintroducing "ask for a step, then read".

79/79 on `main`, 54/54 on `1.x`.

### What I did not do

**I could not reproduce the click cadence here.** The Run, Pause and Step buttons
sit on a notebook page and macOS accessibility will not hand them over, and
space-bar events posted to the process go to the machine window rather than the
inspector. So the timing figure is Jon's, not mine. What is verified here is the
causal chain — the inspector had no refresh but the timer, the button is gated on
`paused`, and a step leaves `paused` clear until it completes — and the new test
pins the last of those.

Backported to `1.x` in the paired PR, which is the line he is using.
