### PR TITLE
CI: give the dependency install room, and let apt retry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,18 +130,26 @@ jobs:
   # It also fetches the ROM the boot below needs, which seeds the cache every
   # other job reads: this job finishes before build-gate lets any build start, so
   # by then the entry exists and the five platform jobs cannot race to write it.
+  # A note on the timeouts in this file, because they caused two red runs on
+  # 2 September 2026 with nothing in the tree changed. They are tripwires
+  # against a hung step, not budgets: raising one costs nothing on a normal run
+  # and only changes when the job gives up. "Install dependencies" had four
+  # minutes where apt normally takes three, so one slow Azure mirror failed the
+  # step - and this job gates every other one, so a single slow apt reddened the
+  # whole matrix. Eight minutes is about twice the normal cost, which is the
+  # right shape for a tripwire.
   sanitisers:
     needs: release-preflight
     if: always() && needs.release-preflight.result != 'failure'
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-tags: true
 
       - name: Install dependencies
-        timeout-minutes: 4
+        timeout-minutes: 8
         run: bash setup-build-env.sh
 
       # The interpreter, not the recompiler: ASan instruments compiled code, and
@@ -396,7 +404,7 @@ jobs:
     needs: build-gate
     if: always() && needs.build-gate.result == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 16
+    timeout-minutes: 21
     steps:
       - uses: actions/checkout@v7
         with:
@@ -409,7 +417,7 @@ jobs:
       #
       # amd64 alone; the check below says why.
       - name: Install dependencies
-        timeout-minutes: 3
+        timeout-minutes: 8
         run: bash setup-build-env.sh --podules
 
       # The assembled guest modules are committed, so a user needs no
@@ -532,14 +540,14 @@ jobs:
     needs: build-gate
     if: always() && needs.build-gate.result == 'success'
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 16
+    timeout-minutes: 21
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-tags: true
 
       - name: Install dependencies
-        timeout-minutes: 3
+        timeout-minutes: 8
         run: bash setup-build-env.sh
 
       - name: Build and package (arm64, both binaries)
@@ -1031,14 +1039,14 @@ jobs:
     # it. The eight JIT differential tests build here now, checking the arm64
     # backend against the interpreter on the architecture it emits code for.
     runs-on: macos-14
-    timeout-minutes: 14
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-tags: true
 
       - name: Install dependencies
-        timeout-minutes: 3
+        timeout-minutes: 8
         run: |
           # Both slices need the SAME version of every dependency: lipo fuses
           # them, and a library from two upstream releases is not one library.

--- a/setup-build-env.sh
+++ b/setup-build-env.sh
@@ -38,12 +38,18 @@ fi
 echo "Detected $(uname -s) $(uname -m)"
 echo ""
 
+# Retries, because the failure this guards against is a mirror that stalls
+# rather than one that refuses: apt gives up on the first timeout otherwise, and
+# in CI that fails the step and with it the whole matrix. Costs nothing when the
+# mirror is healthy.
+APT_RETRY="-o Acquire::Retries=3"
+
 echo "Updating package lists..."
-sudo apt update
+sudo apt $APT_RETRY update
 
 echo ""
 echo "Installing build tools, CMake, wxWidgets, SDL2, ALSA, VNC, and libusb..."
-sudo apt install -y \
+sudo apt $APT_RETRY install -y \
 	build-essential \
 	cmake \
 	pkg-config \
@@ -66,7 +72,7 @@ echo ""
 
 if [ "$INSTALL_CROSS_ARM64" = true ]; then
 	echo "Installing Linux arm64 cross-compilation tools..."
-	sudo apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+	sudo apt $APT_RETRY install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 	echo ""
 	echo "For cross-compiled wxWidgets builds you may also need arm64 dev libraries:"
 	echo "  sudo dpkg --add-architecture arm64"
@@ -77,7 +83,7 @@ fi
 if [ "$INSTALL_PODULES" = true ]; then
 	echo ""
 	echo "Installing ARM binutils for podule ROM builds..."
-	sudo apt install -y binutils-arm-linux-gnueabi || {
+	sudo apt $APT_RETRY install -y binutils-arm-linux-gnueabi || {
 		echo "Warning: binutils-arm-linux-gnueabi not available"
 	}
 fi


### PR DESCRIPTION
**Two red runs today with nothing in the tree changed**, both the same step:

```
##[error]The action 'Install dependencies' has timed out after 4 minutes.
```

The step had a four-minute cap and apt normally takes about three, so one slow
Azure mirror was enough to fail it. Both times it was the `sanitisers` job — and
that job **gates every other one**, so a single slow apt reddened the whole
matrix. Neither failure had anything to do with the commit under test; #238 is
red for this reason and nothing else.

### These numbers are tripwires, not budgets

Raising one costs nothing on a normal run; it only changes when the job gives
up. Every `Install dependencies` step now has eight minutes, roughly twice its
normal cost. There is a note at the top of the `sanitisers` job saying so,
because the next person to read a `4` will otherwise assume it was measured.

### The job caps had to move with them, and one was a real trap

Raising the macOS install from three minutes to eight put that job's capped
steps at **16 minutes against a job cap of 14** — so the *job* would have died
before the step's own tripwire fired and the raise would have achieved nothing.
Caught by totting up the step caps per job and comparing against the job cap,
which is worth doing after any change in this file:

| job | was | now |
| --- | --- | --- |
| `sanitisers` | 12 | 20 |
| `linux-amd64` | 16 | 21 |
| `linux-arm64` | 16 | 21 |
| `macos-arm64` | 14 | 20 |

### And retries, for a different failure mode

`setup-build-env.sh` now passes `-o Acquire::Retries=3`. That does nothing for a
mirror that is merely slow, which is what happened today, but it covers one that
stalls and drops — where apt otherwise gives up on the first timeout. Costs
nothing when the mirror is healthy.

### What this does not do

It does not make the install faster. Caching apt packages would, and that is a
bigger change than a tripwire deserves. If these keep firing at eight minutes
then the install itself is the thing to look at, not the number.
