### PR TITLE
Full screen: log the bars before each transition, not only after

### DIFF
--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -1490,6 +1490,21 @@ void MainFrame::EnterFullScreen()
 	 * The status bar below is the genuine exception and stays.
 	 */
 
+	/*
+	 * ★ Read the bars BEFORE touching anything.
+	 *
+	 * Without this the log has only the state after each transition, and the
+	 * two readings cannot answer the question that matters: was the menu bar
+	 * detached BY going full screen, or was it never attached on this machine
+	 * at all? "native menu GONE" afterwards means nothing without a "native
+	 * menu attached" beforehand to compare it with.
+	 *
+	 * That gap is why the CI run on a Windows runner - the first time a window
+	 * has ever come up in CI - could not settle issue #219 on its own. See
+	 * docs/testing.md.
+	 */
+	LogBarState("before entering");
+
 	/* Removed rather than hidden. Hiding it leaves the space it occupied
 	   reserved - measurably so: the frame's client height does not change -
 	   and on macOS that shows as an empty strip along the bottom of the
@@ -1575,6 +1590,11 @@ void MainFrame::ExitFullScreen()
 	if (!full_screen_) {
 		return;
 	}
+
+	/* The other half of the pair; see the note in EnterFullScreen(). Taken
+	   while still full screen, so the four readings across a round trip are
+	   before/after entering and before/after leaving. */
+	LogBarState("before leaving");
 
 	/* Cleared first: SizeWindowToGuest() below does nothing while it is set, and
 	   it is the thing that puts the window back. */


### PR DESCRIPTION
Issue #219, and the reason the first real Windows evidence could not settle it.

`LogBarState()` shipped in 1.1.18 as the diagnostic for the menu bar not coming
back, and it was called in exactly two places: **after** entering full screen and
**after** leaving. Two readings after the fact cannot answer the question they
exist to answer.

On a Windows CI runner — the first time a wx frame has come up in CI at all —
both said:

```
menu bar shown (native menu GONE)
```

which is unreadable on its own. A menu that full screen detached and a menu that
was never attached on that machine look identical from there.

There are four readings across a round trip now: before and after entering,
before and after leaving. Measured on macOS, where the answer is healthy and so
shows the shape:

```
before entering - menu bar shown, tool bar shown, status bar present
entered         - menu bar shown, tool bar shown, status bar absent
before leaving  - menu bar shown, tool bar shown, status bar absent
left            - menu bar shown, tool bar shown, status bar present
```

The status bar going and coming back is this code's own doing and is correct;
what matters is that the pair either side of each transition can now be
compared. On Windows the same four lines carry the native-menu answer, which is
`::GetMenu()` asked directly rather than what wx believes.

**This is the log the reporter has been asked for**, so it wants to be in his
hands before he replies rather than after. Four lines per round trip and nothing
otherwise.

Paired with the `1.x` backport, which is the line he is on.
