### PR TITLE
CI: the Homebrew install needs room too, and a failed brew update need not stop the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -971,7 +971,7 @@ jobs:
     # need x86_64 libraries (from a Rosetta x86_64 Homebrew - the arm64 Homebrew
     # in /opt/homebrew can't provide them) and Rosetta 2 to run the JIT test.
     runs-on: macos-14
-    timeout-minutes: 34
+    timeout-minutes: 48
     steps:
       - uses: actions/checkout@v7
         with:
@@ -981,7 +981,13 @@ jobs:
         run: softwareupdate --install-rosetta --agree-to-license
 
       - name: Install x86_64 Homebrew + dependencies
-        timeout-minutes: 10
+        # Twenty, not ten. This provisions a whole second Homebrew under
+        # Rosetta, updates it with three retries and backoff, and then installs
+        # seven formulae; ten minutes left no room for a slow github.com and
+        # timed out on 2 September 2026 with nothing in the tree changed. As
+        # with the other install steps, this is a tripwire against a hung step
+        # rather than a budget.
+        timeout-minutes: 20
         run: |
           # A separate Intel Homebrew installs into /usr/local (the arm64
           # Homebrew lives in /opt/homebrew); both coexist. The install script
@@ -996,10 +1002,29 @@ jobs:
           # The Intel and Apple Silicon Homebrews update independently, so
           # "brew update" is what holds them to one formula revision.
           # Retried because it fetches from github.com.
+          #
+          # ★ A failed update is no longer fatal.
+          #
+          # It used to exit 1, because two slices built against different
+          # upstream revisions could not be fused: build-macos.sh refused the
+          # pair. That is no longer true - the fuse step now compares the
+          # formula rather than the version, says so in the log when the two
+          # runners have drifted, and fuses them, because a fat dylib is two
+          # independent binaries and each architecture loads its own half.
+          #
+          # So the worst a failed update can now do is leave the two slices on
+          # different revisions of the same formula, which is reported rather
+          # than silent. Failing the whole matrix for it costs more than it
+          # saves.
           for attempt in 1 2 3; do
             arch -x86_64 /usr/local/bin/brew update && break
             echo "brew update failed (attempt $attempt of 3)"
-            [ "$attempt" = 3 ] && exit 1
+            if [ "$attempt" = 3 ]; then
+              echo "::warning::brew update failed three times; the x86_64 and" \
+                   "arm64 slices may be built against different revisions." \
+                   "The fuse step reports it if so."
+              break
+            fi
             sleep $((attempt * 15))
           done
           arch -x86_64 /usr/local/bin/brew install cmake ninja pkg-config wxwidgets sdl2 libvncserver libusb


### PR DESCRIPTION
**PR #243 is red for this and nothing else**, and this is the third
dependency-install timeout today:

```
##[error]The action 'Install x86_64 Homebrew + dependencies' has timed out after 10 minutes
```

### My omission

This morning (#240) I raised every step named exactly `Install dependencies` and
did not look for the ones named anything else. This one is `Install x86_64
Homebrew + dependencies`, so it kept its ten minutes. Found by listing every
step whose name mentions installing and printing its cap beside its job's, which
is what I should have done the first time:

| job | step | step cap | job cap |
| --- | --- | --- | --- |
| sanitisers | Install dependencies | 8 | 20 |
| linux-amd64 | Install dependencies | 8 | 21 |
| linux-arm64 | Install dependencies | 8 | 21 |
| macos-arm64 | Install dependencies | 8 | 20 |
| **macos-x86_64** | **Install x86_64 Homebrew + dependencies** | **10** | 34 |

Ten minutes was tight for what that step does: provision a second Homebrew under
Rosetta, update it with three retries and 15s then 30s of backoff, and install
seven formulae. Twenty now, with the job cap 34 → 48 so the step cap is
reachable — a step cap above its job cap achieves nothing, the job dies first.

### And a failed `brew update` no longer fails the build

It used to `exit 1`, and that was right at the time: two slices built against
different upstream revisions could not be fused, because `build-macos.sh`
refused the pair.

**That stopped being true this morning.** The fuse step now compares the formula
rather than the version, reports a drift in the log, and fuses them — a fat
dylib is two independent binaries and each architecture loads its own half. So
the worst a failed update can do now is leave the slices on different revisions
of one formula, which is *reported* rather than silent. It emits a `::warning::`
and carries on.

That is a consequence of #232 I did not notice when making it: the `exit 1` here
existed to protect an invariant that no longer holds.

### What this does not do

It does not make the install faster. If these fire again at twenty minutes then
the install is the thing to look at, not the number.
