### PR TITLE
Full screen: leave it before telling ourselves we have left

### DIFF
--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -1515,6 +1515,10 @@ void MainFrame::EnterFullScreen()
 		SetStatusBar(nullptr);
 		bar->Destroy();
 	}
+	/* ★ ShowFullScreen FIRST, then the flag - see the long note in
+	   ExitFullScreen(). IsFullScreen() is overridden to answer with
+	   full_screen_, and wx's own ShowFullScreen() returns immediately if it
+	   already agrees with the state being asked for. */
 	ShowFullScreen(true, wxFULLSCREEN_ALL);
 	full_screen_ = true;
 	LogBarState("entered");
@@ -1596,16 +1600,49 @@ void MainFrame::ExitFullScreen()
 	   before/after entering and before/after leaving. */
 	LogBarState("before leaving");
 
-	/* Cleared first: SizeWindowToGuest() below does nothing while it is set, and
-	   it is the thing that puts the window back. */
-	full_screen_ = false;
 
 	if (panel_ != nullptr) {
 		panel_->SetFullScreen(false);
 	}
 	/* Both bars come back with it: see the note in EnterFullScreen() for why
 	   nothing here shows them by hand any more. */
+	/*
+	 * ★ full_screen_ IS STILL SET HERE, AND MUST BE.
+	 *
+	 * IsFullScreen() is overridden in this class to answer with full_screen_,
+	 * and it is virtual, so wx's own code asks us. wxFrame::ShowFullScreen()
+	 * begins:
+	 *
+	 *     if ( IsFullScreen() == show )
+	 *         return false;
+	 *
+	 * Clearing the flag before this call therefore told wx we were already out
+	 * of full screen, and the whole exit path was skipped: the tool bar never
+	 * got its Show(true), the menu was never re-attached with
+	 * ::SetMenu(hwnd, m_hMenu), and wxTopLevelWindowMSW never restored
+	 * m_fsOldWindowStyle - which is the title bar. On Windows the window came
+	 * back with no title bar, no menu bar and no tool bar, and stayed that way
+	 * for the rest of the session, because nothing else ever puts them back.
+	 *
+	 * That is issue #219, and #206 before it. The reporter's log named it: the
+	 * native menu was "attached" before entering and "GONE" on all three later
+	 * readings, while wx still believed the menu bar was shown. The status bar
+	 * was the one thing that came back, and only because ExitFullScreen()
+	 * rebuilds that itself a few lines below.
+	 *
+	 * It also explains the earlier report against 1.1.14 that leaving full
+	 * screen "appeared to do nothing at all" - it did nothing at all - which
+	 * was worked around by calling SizeWindowToGuest() below rather than by
+	 * finding this.
+	 *
+	 * EnterFullScreen() has the mirror of this: it sets full_screen_ AFTER its
+	 * ShowFullScreen(true), for the same reason. Neither order is tidiness.
+	 */
 	ShowFullScreen(false);
+
+	/* Now it can be cleared: wx has finished, and SizeWindowToGuest() below
+	   does nothing while it is set. */
+	full_screen_ = false;
 	/*
 	 * Minimal UI is ours to enforce, and only in the one direction. The ports do
 	 * not agree about a bar that was already hidden when full screen started:


### PR DESCRIPTION
Backport of the `1.x` fix; `main` had the identical fault.

Fixes #219, and explains #206 and the 1.1.14 report before it. **One ordering
mistake, ours, behind all three** — and this time it is verified on Windows
rather than reasoned from the wx source.

### The bug

`MainFrame` overrides `IsFullScreen()` to answer with its own `full_screen_`
flag. The override is **virtual, so wxWidgets asks us**, and
`wxFrame::ShowFullScreen()` begins:

```cpp
if ( IsFullScreen() == show )
    return false;
```

`ExitFullScreen()` cleared `full_screen_` **before** calling
`ShowFullScreen(false)`. wx asked whether we were full screen, we said no, it
was being asked to leave full screen — so it returned immediately having done
nothing. Everything the exit path does was skipped:

- the tool bar never got its `Show(true)`
- the menu was never re-attached with `::SetMenu(hwnd, m_hMenu)`
- `wxTopLevelWindowMSW` never restored `m_fsOldWindowStyle`, **which is the
  title bar**

The status bar was the one thing that came back, and only because
`ExitFullScreen()` rebuilds that itself a few lines later. That asymmetry is
what turned the reporter's log from a symptom into a diagnosis.

It also explains why it survived a machine restart: on this branch the same
frame is reused via the machine selector, and nothing else ever puts those bars
back.

### Verified on Windows

The reporter's log on 1.1.18, against the same four readings from a
`windows-latest` CI runner carrying this change:

| | last reading |
| --- | --- |
| his 1.1.18 | `menu bar shown (native menu GONE), tool bar hidden, status bar present` |
| **this change** | **`menu bar shown (native menu attached), tool bar shown, status bar present`** |

The three earlier readings are identical in both, `native menu GONE` while full
screen included — that is wx correctly hiding it on the way in.

macOS re-tested and unchanged: all three bars healthy across a round trip. It
never showed this, because its menu bar is not attached to the window and the
status bar is the one we rebuild ourselves.

79/79 tests on this line.

### On the evidence

The CI probe used to get it is **not** in this PR — it was a temporary step on
the branch driven by `RPCEMU_TEST_FULLSCREEN_AFTER`, removed before review. The
four-reading logging that made the diagnosis possible is #242, already merged;
without the "before entering" sample the Windows log could not distinguish a
menu detached by full screen from one never attached.
