### PR TITLE
Debugger: SPSR in the inspector, and a breakpoint SWI a guest can execute

### DIFF
--- a/docs/debugcmd.md
+++ b/docs/debugcmd.md
@@ -68,6 +68,11 @@ response has an `"ok"` boolean; failures carry `"error"`.
 | `ping` | `{ok, paused, model, dynarec}` |
 | `regs` | `{ok, paused, pc, cpsr, mode, flags, regs:[16 hex]}` |
 | `reg set <0-15\|pc\|cpsr> <hex>` | `{ok, reg, value}` — refused unless paused |
+`regs` also returns `spsr`: the saved PSR of the current mode as a hex string,
+or `null` in User and System mode, which bank none. Reporting the array's
+contents there would be whatever the last exception left behind. Knowing the
+mode an exception return is about to restore is not answerable from the CPSR.
+
 | `status` | `{ok, paused, pause_requested, reason, halt_pc, halt_opcode, last_pc, hit_address, hit_value, hit_size, hit_is_write, step_active, trace_pending, pc_symbol, pc_offset, symbols_loaded, breakpoints:[…], watchpoints:[…]}` — see below |
 | `mem <addr> <len> [phys]` | `{ok, addr, physical, len, data:"<hex>"}` — `len` capped 4096; virtual unless `phys` |
 | `mem write <addr> <hexbytes> [phys]` | `{ok, addr, written, requested}` — reports how many landed rather than failing the whole request |
@@ -195,7 +200,9 @@ way the first one after a boot is; send a throwaway command before trusting an
 empty result.
 
 `status.reason` / pause reasons: `0`=none `1`=user `2`=breakpoint `3`=watchpoint
-`4`=step `5`=exception `6`=SWI `7`=reserved CPU mode. Trace `type`: `0`=exception
+`4`=step `5`=exception `6`=SWI `7`=reserved CPU mode `8`=breakpoint SWI
+(`SWI &FFFFFF` in the guest's own code; see
+[debugger-tracing.md](debugger-tracing.md)). Trace `type`: `0`=exception
 `1`=SWI `2`=watchpoint; for an exception, `arg0` is `0`=undefined instruction
 `1`=prefetch abort `2`=data abort `3`=reserved CPU mode.
 

--- a/docs/debugger-tracing.md
+++ b/docs/debugger-tracing.md
@@ -24,6 +24,27 @@ interrupts and are not trappable here; a SWI is caught by SWI tracing below.)
 Exceptions can also be **logged** to the Trace tab without halting — useful for
 seeing, for example, the harmless app-space probes RISC OS performs during boot.
 
+## A breakpoint in your own source
+
+`SWI &FFFFFF` — the instruction word `&EFFFFFFF` — halts the machine in the
+debugger. The emulator swallows it, so RISC OS never sees a SWI it does not
+know, no error is raised, and execution resumes at the instruction after it.
+With the debugger disabled (`debug_enabled=0`) it is still swallowed and nothing
+else happens, so code carrying one runs unchanged.
+
+The pause reason reads *breakpoint SWI* and the halt PC is the SWI's own
+address. It needs nothing switched on first: putting the instruction in the
+source is the request.
+
+It exists because an address breakpoint is awkward for module code, where the
+address moves every time the module is rebuilt and reloaded. Suggested in
+discussion #223 by somebody who had been getting the same effect by trapping a
+SWI in his own module's handler.
+
+The number is in the unallocated range and is matched on the whole 24-bit
+comment field, not on the masked SWI number `opSWI()` works with — several
+ordinary SWIs share that masked value and must not be caught by it.
+
 ## A reserved CPU mode
 
 The mode field of the CPSR has sixteen possible values and the architecture

--- a/src/arm_common.c
+++ b/src/arm_common.c
@@ -584,6 +584,25 @@ opSWI(uint32_t opcode)
 		swinum = arm.reg[12] & 0xdffff;
 	}
 
+	/*
+	 * The debugger's breakpoint SWI, which a guest puts in its own source to
+	 * stop the machine where it stands. Checked before anything else and on
+	 * the whole comment field, not the masked swinum above, and swallowed
+	 * either way so RISC OS never sees a SWI it does not know. See
+	 * RPCEMU_SWI_BREAKPOINT.
+	 *
+	 * Ungated: the point of it is that it works without anything being
+	 * switched on first. One comparison against a constant per SWI.
+	 */
+	if ((opcode & 0x00ffffffu) == RPCEMU_SWI_BREAKPOINT) {
+		/* PC, not arm.reg[15]: R15 leads the instruction by eight, and the
+		   address wanted is the SWI's own so the halt names the line the
+		   programmer wrote. */
+		debugger_break_swi(PC);
+		arm.reg[cpsr] &= ~VFLAG;
+		return 0;
+	}
+
 	/* Debugger: trace/halt on SWI (gated to stay free when tracing is off) */
 	if (debugger_swi_trace_active) {
 		debugger_swi_hook(swinum, opcode);

--- a/src/debugcmd.c
+++ b/src/debugcmd.c
@@ -414,11 +414,34 @@ dc_cmd_regs(char *r)
 	size_t n;
 	int i;
 
+	/* The SPSR, for the five modes that bank one. User and System do not, and
+	   reporting whatever the last exception left in the array would be worse
+	   than reporting nothing - so it comes back null for those. Asked for in
+	   discussion #223: walking an exception return means knowing the mode it is
+	   about to restore, and the CPSR does not say. */
+	{
+		char spsr[24];
+
+		switch (arm.mode & 0xf) {
+		case FIQ:
+		case IRQ:
+		case SUPERVISOR:
+		case ABORT:
+		case UNDEFINED:
+			snprintf(spsr, sizeof(spsr), "\"%08x\"",
+			    (unsigned) arm.spsr[arm.mode & 0xf]);
+			break;
+		default:
+			snprintf(spsr, sizeof(spsr), "null");
+			break;
+		}
+
 	n = (size_t) snprintf(r, DC_RESP_SZ,
 	    "{\"ok\":true,\"paused\":%s,\"pc\":\"%08x\",\"cpsr\":\"%08x\","
+	    "\"spsr\":%s,"
 	    "\"mode\":%u,\"flags\":\"%c%c%c%c\",\"regs\":[",
 	    debugger_is_paused() ? "true" : "false",
-	    (unsigned) PC, (unsigned) arm.reg[cpsr], (unsigned) arm.mode,
+	    (unsigned) PC, (unsigned) arm.reg[cpsr], spsr, (unsigned) arm.mode,
 	    (arm.reg[cpsr] & NFLAG) ? 'N' : '-',
 	    (arm.reg[cpsr] & ZFLAG) ? 'Z' : '-',
 	    (arm.reg[cpsr] & CFLAG) ? 'C' : '-',
@@ -428,6 +451,7 @@ dc_cmd_regs(char *r)
 		    i ? "," : "", (unsigned) arm.reg[i]);
 	}
 	snprintf(r + n, DC_RESP_SZ - n, "]}");
+	}
 }
 
 static void

--- a/src/gui/emulator_snapshot.cpp
+++ b/src/gui/emulator_snapshot.cpp
@@ -81,6 +81,24 @@ emulator_fill_snapshot(MachineSnapshot *snapshot)
 	}
 
 	snapshot->cpsr = arm.reg[cpsr];
+
+	/* Only the five exception modes bank an SPSR. Reading arm.spsr in User or
+	   System mode would report whatever the last exception left there, which is
+	   worse than reporting nothing. */
+	switch (arm.mode & 0xf) {
+	case FIQ:
+	case IRQ:
+	case SUPERVISOR:
+	case ABORT:
+	case UNDEFINED:
+		snapshot->spsr = arm.spsr[arm.mode & 0xf];
+		snapshot->spsr_valid = 1;
+		break;
+	default:
+		snapshot->spsr = 0;
+		snapshot->spsr_valid = 0;
+		break;
+	}
 	snapshot->mode = arm.mode;
 
 	const uint32_t pc = PC;

--- a/src/gui/machine_inspector_window.cpp
+++ b/src/gui/machine_inspector_window.cpp
@@ -236,7 +236,14 @@ wxWindow *MachineInspectorWindow::BuildStatePanel(wxWindow *parent)
 	mode_label_ = new wxStaticText(panel, wxID_ANY, "Mode");
 	mmu_label_ = new wxStaticText(panel, wxID_ANY, "MMU");
 	core_label_ = new wxStaticText(panel, wxID_ANY, "Core");
+	spsr_label_ = new wxStaticText(panel, wxID_ANY, "SPSR --------");
+	ApplyMonoFont(spsr_label_);
+	spsr_label_->SetToolTip(
+	    "The saved PSR of the current mode, and the mode a return through it "
+	    "would enter. User and System have none.");
+
 	psr_box->Add(cpsr_label_, 0, wxLEFT | wxBOTTOM, 4);
+	psr_box->Add(spsr_label_, 0, wxLEFT | wxBOTTOM, 4);
 	psr_box->Add(mode_label_, 0, wxLEFT | wxBOTTOM, 4);
 	psr_box->Add(mmu_label_, 0, wxLEFT | wxBOTTOM, 4);
 	psr_box->Add(core_label_, 0, wxLEFT | wxBOTTOM, 4);
@@ -687,6 +694,18 @@ void MachineInspectorWindow::ApplyProcessorState(const MachineSnapshot &snapshot
 	}
 
 	cpsr_label_->SetLabel(wxString::Format("CPSR %08X", snapshot.cpsr));
+
+	/*
+	 * The SPSR, and - the useful part - the mode a return through it would
+	 * enter. Tracing a fault back through an exception return means knowing
+	 * where it is about to go, and the number alone does not say.
+	 */
+	if (snapshot.spsr_valid) {
+		spsr_label_->SetLabel(wxString::Format("SPSR %08X -> %s",
+		    snapshot.spsr, ModeToString(snapshot.spsr)));
+	} else {
+		spsr_label_->SetLabel("SPSR -------- (none in this mode)");
+	}
 	mode_label_->SetLabel(wxString::Format("%s %s (%s)",
 	    ModeToString(snapshot.mode),
 	    ARM_MODE_32(snapshot.mode) ? "32-bit" : "26-bit",

--- a/src/gui/machine_inspector_window.h
+++ b/src/gui/machine_inspector_window.h
@@ -166,6 +166,7 @@ private:
 	wxStaticText *flag_label_[7] = {};
 	wxStaticText *mode_label_ = nullptr;
 	wxStaticText *cpsr_label_ = nullptr;
+	wxStaticText *spsr_label_ = nullptr;
 	wxStaticText *mmu_label_ = nullptr;
 	wxStaticText *core_label_ = nullptr;
 	uint32_t previous_regs_[16] = {};

--- a/src/gui/machine_snapshot.h
+++ b/src/gui/machine_snapshot.h
@@ -38,6 +38,14 @@ typedef struct MachineSnapshot {
 
 	uint32_t regs[16];
 	uint32_t cpsr;
+
+	/* The saved PSR of the mode the machine is in, and whether that mode has
+	   one. User and System do not; the five exception modes each have their
+	   own. Asked for in discussion #223 by somebody tracing an ADFFS fault
+	   through 36 places that write SPSR and 14 that return through it - the
+	   mode a return is about to restore is not visible any other way. */
+	uint32_t spsr;
+	int spsr_valid;
 	uint32_t mode;
 	uint32_t pc;
 

--- a/src/rpcemu.c
+++ b/src/rpcemu.c
@@ -1477,6 +1477,41 @@ debugger_bad_mode(uint32_t mode, uint32_t pc)
 }
 
 /**
+ * Called from opSWI() when the guest executes the debugger's breakpoint SWI.
+ *
+ * The SWI is swallowed by the caller whatever this returns, so a machine with
+ * no debugger runs straight past one rather than taking an error for a SWI
+ * RISC OS has never heard of.
+ *
+ * Halts immediately, like debugger_bad_mode() and unlike the exception and SWI
+ * traps: there is no handler to reach and the instruction that asked to stop is
+ * the interesting one, so debugger_halt_pc names it. The SWI has already been
+ * consumed by the time the machine stops, so resuming or stepping continues at
+ * the instruction after it - which is what "step over it when resumed" asks
+ * for.
+ *
+ * @param pc Address of the SWI itself
+ * @return 1 if the machine was halted, 0 if there was nothing to halt into
+ */
+int
+debugger_break_swi(uint32_t pc)
+{
+	debugger_trace_push(TraceEvent_Swi, pc, 0, RPCEMU_SWI_BREAKPOINT,
+	    arm.reg[0], arm.reg[cpsr]);
+
+	if (!config.debug_enabled) {
+		return 0;
+	}
+	if (debugger_paused) {
+		return 1;
+	}
+
+	rpclog("Debugger: breakpoint SWI at %08x\n", (unsigned) pc);
+	debugger_enter_pause(DebugPauseReason_BreakSwi, pc, 0xefffffffu);
+	return 1;
+}
+
+/**
  * Write a message to the RPCEmu log file rpclog.txt
  *
  * @param format printf style format of message

--- a/src/rpcemu.h
+++ b/src/rpcemu.h
@@ -119,8 +119,32 @@ typedef enum {
 	/* A guest write asked for one of the nine mode values the architecture
 	   reserves. Not a trap the user turns on: it is always wrong, and the
 	   emulator used to answer it by ending the process. */
-	DebugPauseReason_BadMode = 7
+	DebugPauseReason_BadMode = 7,
+	/* The guest executed the debugger's breakpoint SWI. Not a trap the user
+	   switches on: the instruction is in their own code and putting it there
+	   is the request. */
+	DebugPauseReason_BreakSwi = 8
 } DebugPauseReason;
+
+/**
+ * The SWI a guest can execute to stop the machine in the debugger.
+ *
+ * `SWI &FFFFFF`, the instruction word `0xEFFFFFFF`, chosen because it is in the
+ * unallocated range and so cannot collide with anything RISC OS or a module
+ * offers. Suggested in discussion #223 by somebody who had been getting the
+ * same effect by trapping a SWI in his own module's handler - a breakpoint you
+ * can put in the source is worth a great deal when the address moves every time
+ * the code is rebuilt.
+ *
+ * The emulator swallows it: it never reaches RISC OS, so no "SWI not known"
+ * error, and execution resumes at the instruction after it. With the debugger
+ * disabled it is swallowed and nothing else happens, so code carrying one still
+ * runs.
+ *
+ * Matched on the whole 24-bit comment field rather than on opSWI()'s masked
+ * `swinum`, which folds bits out and would let other SWIs alias onto it.
+ */
+#define RPCEMU_SWI_BREAKPOINT	0x00ffffffu
 
 typedef struct {
 	uint32_t address;
@@ -663,6 +687,14 @@ extern uint32_t debugger_drain_trace_events(DebugTraceEvent *out, uint32_t max, 
 extern void debugger_exception_hook(uint32_t mmode, uint32_t address, uint32_t pc);
 extern int debugger_swi_hook(uint32_t swinum, uint32_t opcode);
 extern int debugger_bad_mode(uint32_t mode, uint32_t pc);
+
+/**
+ * The guest executed RPCEMU_SWI_BREAKPOINT.
+ *
+ * @param pc Address of the SWI itself
+ * @return 1 if the machine was halted, 0 if there was no debugger to halt into
+ */
+extern int debugger_break_swi(uint32_t pc);
 
 /* host GUI bridge */
 extern void rpcemu_video_update(const uint32_t *buffer, int xsize, int ysize, int yl, int yh, int double_size, int host_xsize, int host_ysize);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -192,6 +192,15 @@ if(APPLE)
     rpcemu_add_shell_test(test_fuse_libs test_fuse_libs.sh)
 endif()
 
+# The breakpoint SWI a guest can put in its own source. It must halt, must be
+# swallowed so RISC OS never takes an error for an unknown SWI, and must name
+# the SWI's own address rather than R15 which leads it by eight - the first
+# version reported the address plus eight. Links rpcemu_core for the real
+# opSWI().
+add_executable(test_break_swi test_break_swi.c test_stubs.c)
+target_link_libraries(test_break_swi PRIVATE rpcemu_core m)
+rpcemu_add_test(test_break_swi)
+
 add_executable(test_bad_mode test_bad_mode.c test_stubs.c)
 target_link_libraries(test_bad_mode PRIVATE rpcemu_core m)
 rpcemu_add_test(test_bad_mode)
@@ -733,7 +742,7 @@ rpcemu_add_test(test_unzip)
 #
 # Raise RPCEMU_EXPECTED_TESTS when adding a test. If that feels like a chore, it
 # is the only line in the file that cannot go stale without being noticed.
-set(RPCEMU_EXPECTED_TESTS 44)	# tests that build on every platform
+set(RPCEMU_EXPECTED_TESTS 45)	# tests that build on every platform
 if(RPCEMU_JIT_TESTS)
     math(EXPR RPCEMU_EXPECTED_TESTS "${RPCEMU_EXPECTED_TESTS} + 8")	# JIT differential
 endif()

--- a/tests/test_break_swi.c
+++ b/tests/test_break_swi.c
@@ -1,0 +1,209 @@
+/*
+  RPCEmu - An Acorn system emulator
+
+  Copyright (C) 2026 Andy Timmins
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+/*
+ * The breakpoint SWI: a guest stopping the machine from its own source.
+ *
+ * WHY THIS EXISTS. `SWI &FFFFFF` halts the machine in the debugger and is
+ * swallowed on the way through, so RISC OS never sees a SWI it does not know.
+ * Asked for in discussion #223 by somebody debugging a module, where an address
+ * breakpoint has to be re-found every time the code is rebuilt and moves.
+ *
+ * Three things have to hold together and each fails differently:
+ *
+ *  - it must HALT, or the breakpoint does nothing;
+ *  - it must be SWALLOWED, or the guest takes an error for an unknown SWI -
+ *    which would be worse than no feature at all, because the breakpoint would
+ *    then change the behaviour of the program being debugged;
+ *  - the halt must name the SWI's own address, not R15, which leads it by
+ *    eight. The first version of this reported the address plus eight and
+ *    would have had the reporter looking at the wrong line.
+ *
+ * It also must not fire for anything else: the number is matched on the whole
+ * 24-bit comment field, because opSWI()'s own `swinum` is masked to 0xdffff and
+ * other SWIs would alias onto it.
+ *
+ * Links rpcemu_core for the real opSWI() and the real debugger state.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "rpcemu.h"
+#include "arm.h"
+#include "arm_common.h"
+#include "mem.h"
+
+#define AT_PC		0x00108000u
+#define AT_R15		(AT_PC + 8u)
+
+static int failures;
+
+static void
+check(const char *what, int ok)
+{
+	printf("  %-64s %s\n", what, ok ? "ok" : "FAIL");
+	if (!ok) {
+		failures++;
+	}
+}
+
+static void
+check_hex(const char *what, uint32_t got, uint32_t want)
+{
+	const int ok = (got == want);
+
+	printf("  %-64s %s", what, ok ? "ok" : "FAIL");
+	if (!ok) {
+		printf("  (got %08x, want %08x)", got, want);
+		failures++;
+	}
+	printf("\n");
+}
+
+/** A 32-bit Supervisor machine at a known PC, with an idle enabled debugger. */
+static void
+reset_machine(void)
+{
+	DebugTraceEvent drain[8];
+	uint32_t dropped;
+
+	arm_reset(CPUModel_SA110);
+	prog32 = 1;
+	updatemode(0x10 | SUPERVISOR);
+	arm.reg[15] = AT_R15;
+	arm.reg[16] = 0x10 | SUPERVISOR;
+
+	config.debug_enabled = 1;
+	debugger_resume();
+	debugger_clear_breakpoints();
+	debugger_clear_watchpoints();
+	while (debugger_drain_trace_events(drain, 8, &dropped) > 0) {
+		/* discard */
+	}
+}
+
+static void
+test_halts_and_is_swallowed(void)
+{
+	DebuggerStatus status;
+	int rc;
+
+	printf("SWI &FFFFFF stops the machine\n");
+
+	reset_machine();
+	rc = opSWI(0xefffffffu);
+
+	check("opSWI reports it handled, so the SWI is not passed on", rc == 0);
+	check("and clears V, as a SWI the emulator answers itself does",
+	      (arm.reg[cpsr] & VFLAG) == 0);
+
+	debugger_get_status(&status);
+	check("the machine is halted", status.paused != 0);
+	check("and says why", status.reason == DebugPauseReason_BreakSwi);
+	check_hex("the halt names the SWI, not R15 which leads it by eight",
+	          status.halt_pc, AT_PC);
+}
+
+static void
+test_leaves_a_trace_entry(void)
+{
+	DebugTraceEvent events[4];
+	uint32_t dropped = 0;
+	uint32_t count;
+
+	printf("and leaves a record of where it stopped\n");
+
+	reset_machine();
+	arm.reg[0] = 0x12345678u;
+	opSWI(0xefffffffu);
+
+	count = debugger_drain_trace_events(events, 4, &dropped);
+	check("one trace event, no drops", count == 1 && dropped == 0);
+	if (count == 1) {
+		check("recorded as a SWI", events[0].type == TraceEvent_Swi);
+		check_hex("carrying the SWI number", events[0].arg0,
+		          RPCEMU_SWI_BREAKPOINT);
+		check_hex("and the PC", events[0].pc, AT_PC);
+		check_hex("and R0, as SWI tracing does", events[0].arg1, 0x12345678u);
+	}
+}
+
+static void
+test_only_this_number(void)
+{
+	DebuggerStatus status;
+
+	printf("and nothing else is caught by it\n");
+
+	/*
+	 * opSWI() masks its own swinum to 0xdffff, so a number differing only in
+	 * the bits that mask away must NOT be taken for the breakpoint. &DFFFFF is
+	 * exactly that: it has the same masked value as &FFFFFF.
+	 */
+	reset_machine();
+	opSWI(0xefdfffffu);
+	debugger_get_status(&status);
+	check("SWI &DFFFFF, which masks to the same swinum, does not halt",
+	      status.paused == 0);
+
+	reset_machine();
+	opSWI(0xef000011u);		/* OS_Exit */
+	debugger_get_status(&status);
+	check("an ordinary SWI does not halt", status.paused == 0);
+}
+
+static void
+test_without_a_debugger(void)
+{
+	DebuggerStatus status;
+	int rc;
+
+	printf("with the debugger switched off\n");
+
+	reset_machine();
+	config.debug_enabled = 0;
+
+	rc = opSWI(0xefffffffu);
+	debugger_get_status(&status);
+
+	check("it is still swallowed, so the guest takes no error", rc == 0);
+	check("but nothing is halted, because there is nothing to halt into",
+	      status.paused == 0);
+
+	config.debug_enabled = 1;
+}
+
+int
+main(void)
+{
+	arm_init();
+	mem_init();
+	machine.model = Model_RPCSA110;
+	mem_reset(16, 2);
+
+	test_halts_and_is_swallowed();
+	test_leaves_a_trace_entry();
+	test_only_this_number();
+	test_without_a_debugger();
+
+	printf("\n%s\n", failures == 0 ? "all ok" : "FAILURES");
+	return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Backport to `1.x`, which is the line Jon is using.

Two things Jon Abbott asked for while debugging ADFFS 3.0. Both are holding up
work he is doing **now**, rather than being nice to have.

### SPSR in the inspector — discussion #225

> *"that's why I suggested showing SPSR in the MI as I couldn't see what CPU mode
> SPSR was going to return to"*

He is chasing a reserved-mode fault he believes is stack corruption, and counted
**36 places where ADFFS writes SPSR against 14 that return through it**. Which
mode a return is about to restore is not answerable from the CPSR, and the
inspector did not show the SPSR at all.

It now sits beside the CPSR and names the mode it would return to, which is the
part actually wanted:

```
SPSR 60000013 -> Supervisor
```

Only the five modes that bank one report it — User and System read "none in this
mode", because printing `arm.spsr[]` there would report whatever the last
exception left behind. The debug socket's `regs` gains the same field (hex
string, or `null`), since a corrupted stack is quicker to walk from a script.

### A breakpoint SWI — discussion #223

> *"you've already partly implemented it with the SWI trap, so you could just use
> something like &EFFFFFFF as it's in the user SWI range. It would obviously
> need to not execute the instruction and step over it when resumed/stepped."*

He had been getting the effect by trapping a SWI in ADFFS's own handler.

`SWI &FFFFFF` now halts the machine wherever it is executed. The emulator
**swallows** it, so RISC OS never sees a SWI it does not know and no error is
raised; the halt names the SWI's **own** address; and because the instruction has
already been consumed, resuming or stepping continues at the instruction after
it — the "step over it" half of the request. With `debug_enabled=0` it is
swallowed and nothing else happens, so code carrying one still runs.

Ungated deliberately: a breakpoint you write into your source should work
without anything being switched on first. One comparison against a constant per
SWI.

Matched on the whole 24-bit comment field, **not** on `opSWI()`'s own `swinum`,
which is masked to `0xdffff` — `&DFFFFF` has the same masked value and must not
be caught by it. There is a test for exactly that.

### Measured

On a booted RISC OS 5.31, planting the instruction over the debug socket and
running into it:

```
paused=True  reason=8  halt_pc=fa200000    the SWI itself
pc afterwards          fa200004            already past it
machine still alive, RISC OS none the wiser
```

**The first version reported `halt_pc` as `fa200008`**, because it passed
`arm.reg[15]`, which leads the instruction by eight. That would have had him
looking at the wrong line. The test now pins it.

### Tests

`tests/test_break_swi.c` covers the halt, the swallow, the address, the trace
entry, the near-miss number and the debugger-disabled case. 80/80 on `main`,
55/55 on `1.x`.

Paired with the `1.x` backport, which is the line he is using.
