### PR TITLE
Debugger: the rest of what discussion #223 asked for

### DIFF
--- a/docs/debugcmd.md
+++ b/docs/debugcmd.md
@@ -94,10 +94,11 @@ mode an exception return is about to restore is not answerable from the CPSR.
 | `runto <addr>` | `{ok}` — runs until the address is reached; poll `status` |
 | `bt [depth]` (alias `backtrace`) | `{ok, truncated, frames:[{level,pc,lr,sp,fp,symbol,offset}]}` — see *Backtraces* below |
 | `sym load <path>` / `sym clear` | `{ok, count}` — host path, not a guest one |
+| `swi load <path>` / `swi clear` | `{ok, count}` — SWI names for the disassembler, host path. See [disassembly.md](disassembly.md) |
 | `sym lookup <addr>` | `{ok, address, symbol, offset}` — `symbol` is `null` if nothing covers the address |
 | `sym find <name>` | `{ok, symbol, address}` |
 | `trace [max]` | `{ok, dropped, events:[{seq,type,pc,opcode,arg0,arg1,arg2}]}` — `max` capped 128 |
-| `trace config [key=value …]` | `{ok, …}` — keys `data_abort`, `prefetch_abort`, `undefined`, `log_exceptions`, `swi_log`, `swi_halt`, `swi_min`, `swi_max`. No arguments reports the current setting |
+| `trace config [key=value …]` | `{ok, …}` — keys `data_abort`, `prefetch_abort`, `undefined`, `log_exceptions`, `swi_log`, `swi_halt`, `swi_min`, `swi_max`, `step_skip_irq`, `step_skip_os`. No arguments reports the current setting |
 | `state save <path>` | `{ok, saved}` — snapshot the whole machine to a host file |
 | `state load <path>` | `{ok, loaded}` — restore one; a snapshot that does not match the machine is refused with `{ok:false, error}` and the machine carries on untouched |
 | `reset` | `{ok, reset}` — reset the machine, as the reset button would |
@@ -193,6 +194,13 @@ in the kernel reads as an answer and is not one.
 There is no way to read symbols out of the running guest. That would mean
 depending on RISC OS kernel workspace layout, which differs between versions,
 and a name that cannot be trusted is worth less than a bare address.
+
+`swi load` is the same idea for SWI numbers, and is deliberately the same shape.
+It differs in one respect: a line that is not a number-and-name pair is skipped
+rather than failing the file, because a SWI list is usually a handful of lines
+maintained by hand next to the module, not a generated table of thousands where
+a silent partial load would mis-attribute everything. The format is in
+[disassembly.md](disassembly.md).
 
 `state` and `reset` are here rather than anywhere else because a snapshot has to
 be taken between instructions on the emulator thread, which is the thread this

--- a/docs/debugger-tracing.md
+++ b/docs/debugger-tracing.md
@@ -21,6 +21,16 @@ the exception handler, exactly as it would at a breakpoint, so you can inspect
 registers and memory at the point of the fault. (IRQ and FIQ are ordinary
 interrupts and are not trappable here; a SWI is caught by SWI tracing below.)
 
+**The address reported is the instruction that faulted, not the handler.** The
+halt has to be deferred - `exception()` needs to finish building the handler's
+state before the machine can usefully stop - so the machine really is sitting at
+the vector, and the registers and the mode are the handler's. But the vector
+address is the same for every data abort in the session and tells you nothing,
+whereas the aborting instruction is the whole question, so that is what the
+pause reports and what the disassembly view follows. Asked for in discussion
+#223, where the previous behaviour was described as landing "in the OS somewhere
+rather than at my instruction".
+
 Exceptions can also be **logged** to the Trace tab without halting — useful for
 seeing, for example, the harmless app-space probes RISC OS performs during boot.
 
@@ -74,7 +84,86 @@ SWI tracing records every operating-system call the guest makes. Options:
 - **Halt on SWI** — pause when a matching SWI is executed.
 - **Filter** — restrict tracing/halting to an inclusive SWI-number range (the
   full range means all SWIs). SWI names are decoded from the built-in
-  disassembler table.
+  disassembler table, plus any loaded from a file - see
+  [disassembly.md](disassembly.md).
+
+## Stepping: passing through interrupts and the OS
+
+Two settings on the Trace tab, under **While stepping, pass through**:
+
+- **IRQ and FIQ** — a step that lands in interrupt or fast-interrupt mode keeps
+  going until the machine is back out.
+- **the OS (ROM)** — the same for anything at or above `&F0000000`, where the
+  ROM lives, and for the hardware vector page below `&40`.
+
+Both are off unless asked for. They exist because stepping through your own code
+on a running RISC OS means landing in the timer interrupt every few
+instructions, and the way out - step, step, step until the PC comes back - is
+exactly the tedium the setting removes. Measured on a RISC OS 5.31 desktop: one
+step from inside the ROM, with both settings on, arrived at `&000086D4` in
+application space.
+
+The vector page is in the list because the vectors are as much the OS as the ROM
+is, and they are in low RAM rather than above `&F0000000`. A filter written on
+the ROM address alone let every step stop on a vector, which is no more use than
+the ROM was.
+
+**Only steps are filtered.** A breakpoint or a watchpoint is an explicit request
+for a particular address and fires wherever it is, ROM and interrupt handlers
+included; a trapped exception is the thing being hunted. Filtering those would
+hide what was asked for.
+
+One consequence worth knowing: if the machine never reaches unfiltered code, the
+step never completes and the machine runs on. **Pause** still gets control back.
+
+## Auto-step
+
+**Auto** beside the step buttons keeps stepping at the rate in the box next to
+it, from 1 to 200 steps a second, so code can be watched running slowly without
+holding down Step. The rate is a ceiling: if the machine has not finished the
+previous step the tick is dropped rather than queued.
+
+It switches itself off if the machine is resumed from anywhere else - the Run
+button, the debug socket, a breakpoint being cleared - rather than
+single-stepping it from under whoever resumed it.
+
+Measured on a RISC OS 5.31 desktop on Apple Silicon: 25 steps in 173ms, about
+**6ms a step**. Discussion #223 reported roughly half a second a step before the
+inspector stopped polling on a timer and started refreshing when the debugger's
+state actually changes.
+
+## Saving a session
+
+**Save session...** and **Load session...** on the Trace tab write the whole
+debugging setup to a file: the breakpoints and watchpoints, the exception traps,
+the SWI tracing and its filter, the two stepping filters, how the disassembly is
+rendered, the auto-step rate, and the path of any SWI name file that is loaded.
+
+It is plain text, one setting per line, because it is the sort of file that
+wants editing by hand and keeping in a repository beside the code being
+debugged:
+
+```
+# RPCEmu debugging session
+trap_data_abort 1
+step_skip_irq 1
+disasm_lower 1
+swi_names /home/me/MyModule/swis.csv
+breakpoint 000086D4
+watchpoint 0000A100 4 0 1 0
+```
+
+Loading **replaces** rather than merges: a session file describes a whole setup,
+and leaving yesterday's breakpoints in place beside it would be a third thing
+that is neither. Unknown keys are ignored, so a file written by a later version
+loads what it can, and a named SWI file that has since moved is logged rather
+than turned into a dialog - everything else in the session is still worth
+having.
+
+The two halves of that file - the writer and the reader - spell each key out as
+a string literal a hundred lines apart, which no compiler can pair up. A reader
+that was never written would lose the setting in silence, with the file still
+looking right, so `tests/check-session-keys.sh` compares the two lists.
 
 ## Logging watchpoints
 

--- a/docs/disassembly.md
+++ b/docs/disassembly.md
@@ -79,7 +79,7 @@ branch target with the name it lands in.
 
 ## How it is written down
 
-Four options change the rendering without changing what is decoded, set through
+Five options change the rendering without changing what is decoded, set through
 `arm_disasm_set_options()` and exposed as checkboxes beside the Machine
 Inspector's disassembly view. They came out of discussion #223, from somebody
 reading the disassembly against his own assembler source: a listing that does
@@ -92,6 +92,7 @@ every line.
 | `apcs_registers` | `MOV PC, R14` | `MOV pc, lr` |
 | `collapse_reglists` | `{R0, R1, R2, R3, R7}` | `{R0-R3, R7}` |
 | `resolve_pc_relative` | `LDR R11, [PC, #-120]` | `LDR R11, &00007F90` |
+| `lowercase` | `LDMIA R13!, {R0-R3, PC}` | `ldmia r13!, {r0-r3, pc}` |
 
 `hex_immediates` governs the whole line - branch targets, SWI numbers and MSR
 immediates as well as operands - because a listing mixing `&80` with `0x374C` is
@@ -112,9 +113,49 @@ thread writes them when a checkbox moves while the emulator thread may be
 reading: the fields are single bytes, and the worst a race can do is render one
 line with a mixture of old and new settings.
 
-Not done yet, from the same discussion: a lower-case rendering. It cannot be a
-post-pass over the finished string, because SWI names and symbol annotations
-must keep their case, so it needs the mnemonic and operand tables doubled up.
+`lowercase` **is** a post-pass over the finished string, but not a blind one.
+Lower-casing the whole line would turn `SWI OS_WriteC` into `swi os_writec`,
+and `os_writec` is not a lower-case style of `OS_WriteC` - it is wrong, because
+that is somebody's identifier and not a mnemonic. So as the line is built, the
+spans holding a SWI name and a symbol annotation are recorded, and `apply_case()`
+lowers everything outside them. Doubling the mnemonic and operand tables was the
+alternative and would have to be kept in step for ever; four recorded spans do
+not.
+
+The `X` of an X-form SWI belongs to the name for this purpose. `XOS_Exit` is one
+identifier, so the protected span starts one character to the left of the name
+proper - the first version of this ate the `X` and printed `xOS_Exit`.
+
+## SWI names for your own modules
+
+The built-in table is the OS's. A call into a module of your own disassembles as
+`SWI &42C40`, which has to be looked up by hand every time, so names can be
+loaded from a file:
+
+```
+# a module's own SWIs
+&42C40,MyModule_Doit
+&42C41,MyModule_Undo
+```
+
+One SWI per line, the number and the name separated by a comma. Numbers may be
+written `&hex` as RISC OS writes them, `0xhex`, or plain decimal. Blank lines and
+lines beginning with `#` are ignored, and so is any line that is not a
+number-and-name pair - a file that is half wrong loads the half that is right
+rather than failing altogether.
+
+Give the **chunk base**, as the module header declares it. The X bit is ignored
+when matching, so `&42C40` in the file also names `&62C40` in the code, and the
+`X` is still printed from the opcode: the line reads `SWI XMyModule_Doit`. Listing
+both forms would double the file for no information.
+
+Names from a file are searched before the built-in table, so an OS SWI can be
+renamed as well as a new one added.
+
+Load them with the **SWI names...** button beside the disassembly view, or with
+`swi load <path>` on the [debug socket](debugcmd.md); `swi clear` forgets them.
+A saved inspector session records the path and reloads it - see
+[debugger-tracing.md](debugger-tracing.md).
 
 ## Testing
 

--- a/src/arm_disasm.c
+++ b/src/arm_disasm.c
@@ -34,6 +34,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
 
@@ -70,6 +71,198 @@ static const char *reg_names_apcs[16] = {
 
 /* See ArmDisasmOptions. Zeroed, so the defaults are the plain ARM rendering. */
 static ArmDisasmOptions disasm_opts;
+
+/*
+ * SWI names loaded from a file, searched before the built-in table so a chunk
+ * can be renamed as well as added. Grown as needed and freed by
+ * arm_disasm_clear_swi_names().
+ */
+typedef struct {
+	uint32_t number;
+	char *name;
+} UserSwiName;
+
+/* Bit 17 of a SWI number: the error-returning "X" form. */
+#define SWI_X_BIT 0x20000u
+
+static UserSwiName *user_swis;
+static size_t user_swi_count;
+static size_t user_swi_alloc;
+
+/*
+ * Spans of the rendered line that lower case must not touch: a SWI's name and a
+ * symbol annotation. They are identifiers belonging to somebody else, and
+ * "os_writec" is not a different style of "OS_WriteC", it is wrong.
+ *
+ * Recorded as the line is built and consumed by apply_case() at the end. File
+ * static, like the options, and reset at the start of every render.
+ */
+#define DISASM_MAX_KEEP 4
+static struct {
+	size_t start;
+	size_t len;
+} keep_case[DISASM_MAX_KEEP];
+static unsigned keep_case_count;
+
+static void
+keep_case_reset(void)
+{
+	keep_case_count = 0;
+}
+
+static void
+keep_case_add(size_t start, size_t len)
+{
+	if (keep_case_count < DISASM_MAX_KEEP && len > 0) {
+		keep_case[keep_case_count].start = start;
+		keep_case[keep_case_count].len = len;
+		keep_case_count++;
+	}
+}
+
+/** Lower case the rendered line, leaving the protected spans alone. */
+static void
+apply_case(char *buf)
+{
+	size_t i;
+
+	if (!disasm_opts.lowercase || buf == NULL) {
+		return;
+	}
+
+	for (i = 0; buf[i] != '\0'; i++) {
+		unsigned k;
+		int protected_here = 0;
+
+		for (k = 0; k < keep_case_count; k++) {
+			if (i >= keep_case[k].start &&
+			    i < keep_case[k].start + keep_case[k].len) {
+				protected_here = 1;
+				break;
+			}
+		}
+		if (!protected_here && buf[i] >= 'A' && buf[i] <= 'Z') {
+			buf[i] = (char) (buf[i] - 'A' + 'a');
+		}
+	}
+}
+
+const char *
+arm_disasm_load_swi_names(const char *path, unsigned *count)
+{
+	FILE *f;
+	char line[256];
+	unsigned loaded = 0;
+
+	if (count != NULL) {
+		*count = 0;
+	}
+	if (path == NULL) {
+		return "no file named";
+	}
+
+	f = fopen(path, "r");
+	if (f == NULL) {
+		return "could not be opened";
+	}
+
+	while (fgets(line, sizeof(line), f) != NULL) {
+		char *comma;
+		char *name;
+		char *end;
+		unsigned long number;
+		size_t len;
+
+		char *number_text = line;
+
+		/* Comments and blank lines, indented or not. */
+		while (*number_text == ' ' || *number_text == '\t') {
+			number_text++;
+		}
+		if (*number_text == '#' || *number_text == '\n' ||
+		    *number_text == '\r' || *number_text == '\0') {
+			continue;
+		}
+
+		comma = strchr(number_text, ',');
+		if (comma == NULL) {
+			continue;	/* not a pair; skipped rather than fatal */
+		}
+		*comma = '\0';
+
+		/*
+		 * "&62C40" as well as "0x62C40" and plain decimal. The ampersand is how
+		 * every RISC OS document, module header and assembler listing writes a
+		 * hex number, so it is the form somebody will type first; strtoul() has
+		 * never heard of it and would silently skip the line.
+		 */
+		if (*number_text == '&') {
+			number = strtoul(number_text + 1, &end, 16);
+			if (end == number_text + 1) {
+				continue;
+			}
+		} else {
+			number = strtoul(number_text, &end, 0);
+			if (end == number_text) {
+				continue;	/* no number where one was wanted */
+			}
+		}
+
+		name = comma + 1;
+		while (*name == ' ' || *name == '\t') {
+			name++;
+		}
+		len = strlen(name);
+		while (len > 0 && (name[len - 1] == '\n' || name[len - 1] == '\r' ||
+		                   name[len - 1] == ' ' || name[len - 1] == '\t')) {
+			name[--len] = '\0';
+		}
+		if (len == 0) {
+			continue;
+		}
+
+		if (user_swi_count == user_swi_alloc) {
+			const size_t want = user_swi_alloc ? user_swi_alloc * 2 : 32;
+			UserSwiName *bigger = realloc(user_swis, want * sizeof(*bigger));
+
+			if (bigger == NULL) {
+				fclose(f);
+				return "ran out of memory";
+			}
+			user_swis = bigger;
+			user_swi_alloc = want;
+		}
+
+		user_swis[user_swi_count].name = strdup(name);
+		if (user_swis[user_swi_count].name == NULL) {
+			fclose(f);
+			return "ran out of memory";
+		}
+		user_swis[user_swi_count].number = (uint32_t) number;
+		user_swi_count++;
+		loaded++;
+	}
+
+	fclose(f);
+	if (count != NULL) {
+		*count = loaded;
+	}
+	return NULL;
+}
+
+void
+arm_disasm_clear_swi_names(void)
+{
+	size_t i;
+
+	for (i = 0; i < user_swi_count; i++) {
+		free(user_swis[i].name);
+	}
+	free(user_swis);
+	user_swis = NULL;
+	user_swi_count = 0;
+	user_swi_alloc = 0;
+}
 
 /** The register naming in force. */
 #define reg_names (disasm_opts.apcs_registers ? reg_names_apcs : reg_names_arm)
@@ -1510,7 +1703,27 @@ lookup_swi_name(uint32_t swi_num)
 {
 	/* Strip the X bit for lookup */
 	uint32_t base_swi = swi_num & 0x1FFFF;
+	/* The X bit on its own, for the file's benefit: see below. */
+	uint32_t no_x = swi_num & ~SWI_X_BIT;
 	size_t i;
+
+	/*
+	 * Names from a file first, so a chunk can be renamed as well as added.
+	 *
+	 * Matched with the X bit ignored on BOTH sides, because a module header
+	 * declares its chunk base - the number without the X - while the code being
+	 * read almost always calls the X form. Requiring the file to list both
+	 * would double every line of it for no information. The X prefix is still
+	 * printed from the opcode, so an X call renders "XMyModule_Doit" against a
+	 * file that said "MyModule_Doit".
+	 */
+	for (i = 0; i < user_swi_count; i++) {
+		if (user_swis[i].number == swi_num ||
+		    (user_swis[i].number & ~SWI_X_BIT) == no_x ||
+		    user_swis[i].number == base_swi) {
+			return user_swis[i].name;
+		}
+	}
 
 	for (i = 0; i < SWI_TABLE_SIZE; i++) {
 		if (swi_table[i].number == base_swi) {
@@ -1535,18 +1748,28 @@ disasm_swi(uint32_t opcode, uint32_t address, char *buf, size_t buflen)
 	(void) address;
 
 	/* Check for X form (error-returning) */
-	is_x = (imm & 0x20000) != 0;
+	is_x = (imm & SWI_X_BIT) != 0;
 	name = lookup_swi_name(imm);
 
 	if (name) {
-		/* Known SWI - show name */
+		/* Known SWI - show name. The name's span is recorded so lower case
+		   leaves it alone: it is an identifier, not styling. */
+		int n;
+
 		if (is_x) {
-			return snprintf(buf, buflen, "SWI%s X%s",
-			                cond_names[cond], name);
+			n = snprintf(buf, buflen, "SWI%s X%s",
+			             cond_names[cond], name);
+			/* The X belongs to the name: XOS_WriteC is what the SWI is
+			   called, and "xOS_WriteC" is not a lower-case rendering of
+			   it. Protect one character further left. */
+			keep_case_add((size_t) (n - (int) strlen(name) - 1),
+			              strlen(name) + 1);
 		} else {
-			return snprintf(buf, buflen, "SWI%s %s",
-			                cond_names[cond], name);
+			n = snprintf(buf, buflen, "SWI%s %s",
+			             cond_names[cond], name);
+			keep_case_add((size_t) (n - (int) strlen(name)), strlen(name));
 		}
+		return n;
 	} else {
 		/* Unknown SWI - show number */
 		if (imm < 0x200) {
@@ -2351,6 +2574,7 @@ arm_disasm_sym(uint32_t opcode, uint32_t address, char *buffer, size_t buflen,
 		return NULL;
 	}
 
+	keep_case_reset();
 	cls = arm_classify(opcode);
 
 	switch (cls) {
@@ -2432,9 +2656,15 @@ arm_disasm_sym(uint32_t opcode, uint32_t address, char *buffer, size_t buflen,
 					snprintf(buffer + len, buflen - len,
 					         "  ; %s", name);
 				}
+				/* Everything from the comment marker on is the
+				   symbol's, and its case is not ours to change. */
+				keep_case_add(len, strlen(buffer) - len);
 			}
 		}
 	}
+
+	/* Last, so it sees the finished line and every protected span. */
+	apply_case(buffer);
 
 	return buffer;
 }

--- a/src/arm_disasm.h
+++ b/src/arm_disasm.h
@@ -91,7 +91,38 @@ typedef struct {
 	 * from the instruction alone.
 	 */
 	uint8_t resolve_pc_relative;
+
+	/**
+	 * Render in lower case: `mov r0, #&80`.
+	 *
+	 * Mnemonics, registers, conditions and hex digits follow it. What does NOT
+	 * is a SWI's name or a symbol annotation - those are somebody else's
+	 * identifiers and changing their case makes them wrong, not just
+	 * differently styled.
+	 */
+	uint8_t lowercase;
 } ArmDisasmOptions;
+
+/**
+ * Add SWI names from a file, consulted before the built-in table.
+ *
+ * A debugger that says "SWI 0x62c40" where your own module's SWI should be is
+ * of limited use, and the built-in table can only ever know about RISC OS's
+ * own. Asked for in discussion #223 for exactly that: debugging third-party
+ * code whose SWI chunk means nothing here.
+ *
+ * The format is one `number,name` per line, the number in C notation so both
+ * `0x62c40` and `404032` work, `#` and blank lines ignored. A name given here
+ * wins over the built-in table, so a chunk can be renamed as well as added.
+ *
+ * @param path  File to read
+ * @param count Filled in with the number of names loaded, if not NULL
+ * @return NULL on success, or a static string saying what was wrong
+ */
+const char *arm_disasm_load_swi_names(const char *path, unsigned *count);
+
+/** Forget every name loaded by arm_disasm_load_swi_names(). */
+void arm_disasm_clear_swi_names(void);
 
 /** Replace the rendering options. NULL restores the defaults (all clear). */
 void arm_disasm_set_options(const ArmDisasmOptions *opts);

--- a/src/debugcmd.c
+++ b/src/debugcmd.c
@@ -245,7 +245,8 @@ dc_cmd_trace_config(char *r, char *args)
 		if (eq == NULL) {
 			dc_error("usage: trace config [data_abort=0|1] [prefetch_abort=0|1] "
 			         "[undefined=0|1] [log_exceptions=0|1] [swi_log=0|1] "
-			         "[swi_halt=0|1] [swi_min=<hex>] [swi_max=<hex>]");
+			         "[swi_halt=0|1] [swi_min=<hex>] [swi_max=<hex>] "
+			         "[step_skip_irq=0|1] [step_skip_os=0|1]");
 			return;
 		}
 		*eq = '\0';
@@ -259,6 +260,8 @@ dc_cmd_trace_config(char *r, char *args)
 		else if (strcmp(tok, "swi_halt") == 0)       { cfg.swi_trace_halt = v ? 1 : 0; }
 		else if (strcmp(tok, "swi_min") == 0)        { cfg.swi_filter_min = (uint32_t) strtoul(eq + 1, NULL, 16); }
 		else if (strcmp(tok, "swi_max") == 0)        { cfg.swi_filter_max = (uint32_t) strtoul(eq + 1, NULL, 16); }
+		else if (strcmp(tok, "step_skip_irq") == 0)  { cfg.step_skip_irq = v ? 1 : 0; }
+		else if (strcmp(tok, "step_skip_os") == 0)   { cfg.step_skip_os = v ? 1 : 0; }
 		else {
 			dc_error("unknown trace config key");
 			return;
@@ -270,10 +273,65 @@ dc_cmd_trace_config(char *r, char *args)
 	snprintf(r, DC_RESP_SZ,
 	    "{\"ok\":true,\"data_abort\":%u,\"prefetch_abort\":%u,\"undefined\":%u,"
 	    "\"log_exceptions\":%u,\"swi_log\":%u,\"swi_halt\":%u,"
-	    "\"swi_min\":\"%08x\",\"swi_max\":\"%08x\"}",
+	    "\"swi_min\":\"%08x\",\"swi_max\":\"%08x\","
+	    "\"step_skip_irq\":%u,\"step_skip_os\":%u}",
 	    cfg.trap_data_abort, cfg.trap_prefetch_abort, cfg.trap_undefined,
 	    cfg.log_exceptions, cfg.swi_trace_enabled, cfg.swi_trace_halt,
-	    (unsigned) cfg.swi_filter_min, (unsigned) cfg.swi_filter_max);
+	    (unsigned) cfg.swi_filter_min, (unsigned) cfg.swi_filter_max,
+	    cfg.step_skip_irq, cfg.step_skip_os);
+}
+
+/**
+ * swi load <path> | swi clear
+ *
+ * The names a module's own SWIs disassemble under. The built-in table is the
+ * OS's; anything else is site knowledge, so it comes from a file. Same shape as
+ * "sym", deliberately, because it is the same idea applied to SWI numbers.
+ */
+static void
+dc_cmd_swi(char *r, char *args)
+{
+	char *sub = strtok(args, " \t");
+
+	if (!sub) {
+		dc_error("usage: swi load <path> | swi clear");
+		return;
+	}
+
+	if (strcmp(sub, "clear") == 0) {
+		arm_disasm_clear_swi_names();
+		snprintf(r, DC_RESP_SZ, "{\"ok\":true,\"count\":0}");
+		return;
+	}
+
+	if (strcmp(sub, "load") == 0) {
+		char *path = strtok(NULL, "");	/* rest of the line: paths have spaces */
+		unsigned count = 0;
+		const char *error;
+
+		if (path != NULL) {
+			while (*path == ' ' || *path == '\t') {
+				path++;
+			}
+		}
+		if (path == NULL || *path == '\0') {
+			dc_error("usage: swi load <path>");
+			return;
+		}
+
+		error = arm_disasm_load_swi_names(path, &count);
+		if (error != NULL) {
+			char buf[DC_ERROR_MAX_MSG];
+
+			snprintf(buf, sizeof(buf), "cannot load SWI names: %s", error);
+			dc_error(buf);
+			return;
+		}
+		snprintf(r, DC_RESP_SZ, "{\"ok\":true,\"count\":%u}", count);
+		return;
+	}
+
+	dc_error("usage: swi load <path> | swi clear");
 }
 
 /**
@@ -303,6 +361,7 @@ dc_cmd_help(char *r)
 	    "\"step [count] | step into [count] | step over | step out\","
 	    "\"runto <hexaddr>\",\"bt [depth]\","
 	    "\"sym load <path> | sym clear | sym lookup <hexaddr> | sym find <name>\","
+	    "\"swi load <path> | swi clear\","
 	    "\"state save|load <path>\","
 	    "\"clipboard get|set [text]\""
 	    "]}");
@@ -1253,6 +1312,8 @@ dc_dispatch(char *line)
 			return;
 		}
 		snprintf(resp, DC_RESP_SZ, "{\"ok\":true}");
+	} else if (strcmp(verb, "swi") == 0) {
+		dc_cmd_swi(resp, args ? args : (char *) "");
 	} else if (strcmp(verb, "sym") == 0) {
 		dc_cmd_sym(resp, args ? args : (char *) "");
 	} else if (strcmp(verb, "bt") == 0 || strcmp(verb, "backtrace") == 0) {

--- a/src/gui/machine_inspector_window.cpp
+++ b/src/gui/machine_inspector_window.cpp
@@ -29,6 +29,8 @@
 #include <vector>
 
 #include <wx/spinctrl.h>
+#include <wx/filedlg.h>
+#include <wx/textfile.h>
 
 #include "emulator_snapshot.h"
 
@@ -137,6 +139,11 @@ wxBEGIN_EVENT_TABLE(MachineInspectorWindow, wxFrame)
 	EVT_BUTTON(ID_STEP, MachineInspectorWindow::OnStep)
 	EVT_BUTTON(ID_STEP_OVER, MachineInspectorWindow::OnStepOver)
 	EVT_CHECKBOX(ID_DISASM_STYLE, MachineInspectorWindow::OnDisasmStyleChanged)
+	EVT_CHECKBOX(ID_AUTOSTEP, MachineInspectorWindow::OnAutoStep)
+	EVT_TIMER(ID_AUTOSTEP_TIMER, MachineInspectorWindow::OnAutoStepTimer)
+	EVT_BUTTON(ID_SETTINGS_SAVE, MachineInspectorWindow::OnSaveSettings)
+	EVT_BUTTON(ID_SETTINGS_LOAD, MachineInspectorWindow::OnLoadSettings)
+	EVT_BUTTON(ID_SWI_NAMES, MachineInspectorWindow::OnLoadSwiNames)
 	EVT_BUTTON(ID_BREAKPOINT_ADD, MachineInspectorWindow::OnAddBreakpoint)
 	EVT_BUTTON(ID_BREAKPOINT_REMOVE, MachineInspectorWindow::OnRemoveBreakpoint)
 	EVT_BUTTON(ID_WATCHPOINT_ADD, MachineInspectorWindow::OnAddWatchpoint)
@@ -313,6 +320,10 @@ void MachineInspectorWindow::BuildUi()
 
 	/* How the disassembly is written down: see ArmDisasmOptions. Off by
 	   default, so the view reads as it always has until asked otherwise. */
+	disasm_lower_checkbox_ = new wxCheckBox(disasm_panel, ID_DISASM_STYLE, "lower");
+	disasm_lower_checkbox_->SetToolTip(
+	    "Lower case, to match assembler source. SWI names and symbols keep "
+	    "their own case.");
 	disasm_hex_checkbox_ = new wxCheckBox(disasm_panel, ID_DISASM_STYLE, "Hex");
 	disasm_hex_checkbox_->SetToolTip("Immediates as &80 rather than 128");
 	disasm_apcs_checkbox_ = new wxCheckBox(disasm_panel, ID_DISASM_STYLE, "APCS");
@@ -330,10 +341,18 @@ void MachineInspectorWindow::BuildUi()
 	disasm_controls->Add(disasm_address_input_, 0, wxRIGHT, 6);
 	disasm_controls->Add(disasm_go_button, 0, wxRIGHT, 6);
 	disasm_controls->Add(disasm_follow_pc_checkbox_, 0, wxRIGHT, 12);
+	disasm_controls->Add(disasm_lower_checkbox_, 0, wxRIGHT, 6);
 	disasm_controls->Add(disasm_hex_checkbox_, 0, wxRIGHT, 6);
 	disasm_controls->Add(disasm_apcs_checkbox_, 0, wxRIGHT, 6);
 	disasm_controls->Add(disasm_ranges_checkbox_, 0, wxRIGHT, 6);
-	disasm_controls->Add(disasm_resolve_checkbox_, 0);
+	disasm_controls->Add(disasm_resolve_checkbox_, 0, wxRIGHT, 12);
+
+	auto *swi_names_button = new wxButton(disasm_panel, ID_SWI_NAMES,
+	    "SWI names...", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
+	swi_names_button->SetToolTip(
+	    "Load a CSV of SWI numbers and names, so a module's own SWIs "
+	    "disassemble by name instead of by number");
+	disasm_controls->Add(swi_names_button, 0);
 
 	disasm_view_ = new wxTextCtrl(disasm_panel, wxID_ANY, wxEmptyString,
 	                              wxDefaultPosition, wxDefaultSize,
@@ -401,6 +420,19 @@ void MachineInspectorWindow::BuildUi()
 	debug_buttons->Add(pause_button_, 0, wxRIGHT, 6);
 	debug_buttons->Add(step_button_, 0, wxRIGHT, 6);
 	debug_buttons->Add(step_over_button_, 0, wxRIGHT, 12);
+
+	autostep_checkbox_ = new wxCheckBox(debug_panel, ID_AUTOSTEP, "Auto");
+	autostep_checkbox_->SetToolTip(
+	    "Keep stepping at the rate beside this, so code can be watched running "
+	    "slowly without holding down Step");
+	autostep_rate_spin_ = new wxSpinCtrl(debug_panel, wxID_ANY, "4",
+	                                     wxDefaultPosition, wxSize(70, -1),
+	                                     wxSP_ARROW_KEYS, 1, 200, 4);
+	autostep_rate_spin_->SetToolTip("Steps per second");
+	debug_buttons->Add(autostep_checkbox_, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 4);
+	debug_buttons->Add(autostep_rate_spin_, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 2);
+	debug_buttons->Add(new wxStaticText(debug_panel, wxID_ANY, "/sec"), 0,
+	    wxALIGN_CENTER_VERTICAL | wxRIGHT, 12);
 	debug_buttons->Add(debug_status_label_, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 12);
 	debug_buttons->Add(debug_hit_label_, 1, wxALIGN_CENTER_VERTICAL);
 
@@ -498,6 +530,25 @@ void MachineInspectorWindow::BuildUi()
 	swi_box->Add(new wxStaticText(trace_panel, wxID_ANY, ".."), 0, wxALIGN_CENTER_VERTICAL | wxLEFT, 2);
 	swi_box->Add(swi_filter_max_input_, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, 2);
 
+	auto *step_box = new wxStaticBoxSizer(wxHORIZONTAL, trace_panel,
+	    "While stepping, pass through");
+	step_skip_irq_checkbox_ = new wxCheckBox(trace_panel, ID_TRACE_CONFIG,
+	    "IRQ and FIQ");
+	step_skip_irq_checkbox_->SetToolTip(
+	    "A step that lands in an interrupt keeps going until it is back out. "
+	    "Breakpoints still fire there.");
+	step_skip_os_checkbox_ = new wxCheckBox(trace_panel, ID_TRACE_CONFIG,
+	    "the OS (ROM)");
+	step_skip_os_checkbox_->SetToolTip(
+	    "The same for anything at or above &F0000000, which is the ROM.");
+	step_box->Add(step_skip_irq_checkbox_, 0, wxALL, 4);
+	step_box->Add(step_skip_os_checkbox_, 0, wxALL, 4);
+	step_box->AddStretchSpacer();
+	step_box->Add(new wxButton(trace_panel, ID_SETTINGS_SAVE, "Save session..."),
+	    0, wxALL, 2);
+	step_box->Add(new wxButton(trace_panel, ID_SETTINGS_LOAD, "Load session..."),
+	    0, wxALL, 2);
+
 	/* A floor on the log, so the tab opens showing a useful number of lines
 	   rather than three; the sash below the code views takes it further. */
 	trace_view_ = new wxTextCtrl(trace_panel, wxID_ANY, wxEmptyString,
@@ -519,6 +570,7 @@ void MachineInspectorWindow::BuildUi()
 	auto *trace_sizer = new wxBoxSizer(wxVERTICAL);
 	trace_sizer->Add(exception_box, 0, wxEXPAND | wxALL, 8);
 	trace_sizer->Add(swi_box, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 8);
+	trace_sizer->Add(step_box, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 8);
 	trace_sizer->Add(trace_view_, 1, wxEXPAND | wxLEFT | wxRIGHT, 8);
 	trace_sizer->Add(trace_footer, 0, wxEXPAND | wxALL, 8);
 	trace_panel->SetSizer(trace_sizer);
@@ -1229,6 +1281,8 @@ void MachineInspectorWindow::SeedTraceConfig(const MachineSnapshot &snapshot)
 	log_exceptions_checkbox_->SetValue(cfg.log_exceptions != 0);
 	swi_trace_checkbox_->SetValue(cfg.swi_trace_enabled != 0);
 	swi_halt_checkbox_->SetValue(cfg.swi_trace_halt != 0);
+	step_skip_irq_checkbox_->SetValue(cfg.step_skip_irq != 0);
+	step_skip_os_checkbox_->SetValue(cfg.step_skip_os != 0);
 
 	/* The full range is "no filter", which is what an empty box means, so it
 	   is left showing its hint rather than 0 and FFFFFFFF. */
@@ -1281,6 +1335,8 @@ void MachineInspectorWindow::ApplyTraceConfig()
 	cfg.log_exceptions = log_exceptions_checkbox_->GetValue() ? 1 : 0;
 	cfg.swi_trace_enabled = swi_trace_checkbox_->GetValue() ? 1 : 0;
 	cfg.swi_trace_halt = swi_halt_checkbox_->GetValue() ? 1 : 0;
+	cfg.step_skip_irq = step_skip_irq_checkbox_->GetValue() ? 1 : 0;
+	cfg.step_skip_os = step_skip_os_checkbox_->GetValue() ? 1 : 0;
 
 	bool ok = false;
 	const uint32_t min = ParseAddress(swi_filter_min_input_->GetValue(), &ok);
@@ -1530,6 +1586,11 @@ void MachineInspectorWindow::OnStepOver(wxCommandEvent &)
  */
 void MachineInspectorWindow::OnDisasmStyleChanged(wxCommandEvent &)
 {
+	ApplyDisasmOptions();
+}
+
+void MachineInspectorWindow::ApplyDisasmOptions()
+{
 	ArmDisasmOptions opts;
 
 	memset(&opts, 0, sizeof(opts));
@@ -1537,6 +1598,7 @@ void MachineInspectorWindow::OnDisasmStyleChanged(wxCommandEvent &)
 	opts.apcs_registers = disasm_apcs_checkbox_->GetValue() ? 1 : 0;
 	opts.collapse_reglists = disasm_ranges_checkbox_->GetValue() ? 1 : 0;
 	opts.resolve_pc_relative = disasm_resolve_checkbox_->GetValue() ? 1 : 0;
+	opts.lowercase = disasm_lower_checkbox_->GetValue() ? 1 : 0;
 	arm_disasm_set_options(&opts);
 
 	RefreshDisassembly(disasm_current_address_);
@@ -1595,6 +1657,466 @@ void MachineInspectorWindow::OnDebugKey(wxKeyEvent &event)
 		event.Skip();
 		return;
 	}
+}
+
+/*
+ * Auto-step. Driven by a timer rather than a loop, so the window stays alive and
+ * the machine can be stopped mid-run by unticking the box.
+ */
+void MachineInspectorWindow::OnAutoStep(wxCommandEvent &)
+{
+	if (autostep_checkbox_->GetValue()) {
+		const int rate = autostep_rate_spin_->GetValue();
+
+		autostep_timer_.Start(1000 / (rate > 0 ? rate : 1));
+	} else {
+		autostep_timer_.Stop();
+	}
+}
+
+void MachineInspectorWindow::OnAutoStepTimer(wxTimerEvent &)
+{
+	AutoStepTick();
+}
+
+void MachineInspectorWindow::AutoStepTick()
+{
+	RefreshSnapshot();
+
+	/*
+	 * A step already in flight. Asking for another now would queue steps faster
+	 * than the machine retires them, so this tick is simply dropped and the
+	 * rate becomes "as fast as the machine manages, up to the rate asked for".
+	 *
+	 * This case has to be tested BEFORE the resumed-elsewhere case below,
+	 * because a machine mid-step reads as not paused. Getting that order wrong
+	 * is not a small bug: the first tick steps, the second sees "not paused",
+	 * concludes somebody hit Run and switches itself off - so auto-step took
+	 * exactly one step and then stopped. Measured that way before this was
+	 * split in two. See test_step_is_not_immediately_paused() in
+	 * tests/test_debugger_gate.c, which is about the same transient.
+	 */
+	if (last_snapshot_.debug_step_active != 0) {
+		return;
+	}
+
+	/*
+	 * Only while stopped. A machine that has been resumed from elsewhere - the
+	 * Run button, the debug socket, a breakpoint being cleared - should not be
+	 * quietly single-stepped from under whoever did it, so the box turns itself
+	 * off rather than fighting.
+	 */
+	if (last_snapshot_.debug_paused == 0) {
+		autostep_timer_.Stop();
+		autostep_checkbox_->SetValue(false);
+		return;
+	}
+
+	emulator_.DebuggerStep();
+}
+
+/*
+ * A debugging session written to a file: the breakpoints, the watchpoints, the
+ * trapping and tracing settings, and how the disassembly is rendered.
+ *
+ * Plain text, one setting per line, because it is the sort of file somebody
+ * will want to edit and put in a repository beside the code being debugged.
+ * Unknown keys are ignored, so a file from a later version loads what it can.
+ */
+void MachineInspectorWindow::OnSaveSettings(wxCommandEvent &)
+{
+	wxFileDialog dlg(this, "Save debugging session", wxEmptyString,
+	                 "session.rpcdbg",
+	                 "RPCEmu debugging session (*.rpcdbg)|*.rpcdbg|All files (*)|*",
+	                 wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+
+	if (dlg.ShowModal() != wxID_OK) {
+		return;
+	}
+
+	if (!SaveSessionTo(dlg.GetPath())) {
+		wxMessageBox("That file could not be written.", "Save failed",
+		    wxOK | wxICON_ERROR, this);
+	}
+}
+
+bool MachineInspectorWindow::SaveSessionTo(const wxString &path)
+{
+	wxTextFile file(path);
+
+	if (file.Exists()) {
+		if (!file.Open()) {
+			return false;
+		}
+		file.Clear();
+	} else if (!file.Create()) {
+		return false;
+	}
+
+	file.AddLine("# RPCEmu debugging session");
+	file.AddLine(wxString::Format("trap_undefined %d",
+	    trap_undefined_checkbox_->GetValue() ? 1 : 0));
+	file.AddLine(wxString::Format("trap_prefetch %d",
+	    trap_prefetch_checkbox_->GetValue() ? 1 : 0));
+	file.AddLine(wxString::Format("trap_data_abort %d",
+	    trap_data_abort_checkbox_->GetValue() ? 1 : 0));
+	file.AddLine(wxString::Format("log_exceptions %d",
+	    log_exceptions_checkbox_->GetValue() ? 1 : 0));
+	file.AddLine(wxString::Format("swi_trace %d",
+	    swi_trace_checkbox_->GetValue() ? 1 : 0));
+	file.AddLine(wxString::Format("swi_halt %d",
+	    swi_halt_checkbox_->GetValue() ? 1 : 0));
+	file.AddLine("swi_filter_min " + swi_filter_min_input_->GetValue());
+	file.AddLine("swi_filter_max " + swi_filter_max_input_->GetValue());
+	file.AddLine(wxString::Format("step_skip_irq %d",
+	    step_skip_irq_checkbox_->GetValue() ? 1 : 0));
+	file.AddLine(wxString::Format("step_skip_os %d",
+	    step_skip_os_checkbox_->GetValue() ? 1 : 0));
+	file.AddLine(wxString::Format("disasm_lower %d",
+	    disasm_lower_checkbox_->GetValue() ? 1 : 0));
+	file.AddLine(wxString::Format("disasm_hex %d",
+	    disasm_hex_checkbox_->GetValue() ? 1 : 0));
+	file.AddLine(wxString::Format("disasm_apcs %d",
+	    disasm_apcs_checkbox_->GetValue() ? 1 : 0));
+	file.AddLine(wxString::Format("disasm_ranges %d",
+	    disasm_ranges_checkbox_->GetValue() ? 1 : 0));
+	file.AddLine(wxString::Format("disasm_pcrel %d",
+	    disasm_resolve_checkbox_->GetValue() ? 1 : 0));
+	file.AddLine(wxString::Format("autostep_rate %d",
+	    autostep_rate_spin_->GetValue()));
+	if (!swi_names_path_.IsEmpty()) {
+		file.AddLine("swi_names " + swi_names_path_);
+	}
+
+	/* The breakpoints and watchpoints as the machine has them, not as this
+	   window last drew them. */
+	for (uint32_t i = 0; i < last_snapshot_.debug_breakpoint_count; i++) {
+		const DebugBreakpointInfo &bp = last_snapshot_.debug_breakpoints[i];
+
+		file.AddLine(wxString::Format("breakpoint %08X", bp.address));
+	}
+	for (uint32_t i = 0; i < last_snapshot_.debug_watchpoint_count; i++) {
+		const DebugWatchpointInfo &wp = last_snapshot_.debug_watchpoints[i];
+
+		file.AddLine(wxString::Format("watchpoint %08X %u %d %d %d",
+		    wp.address, wp.size, wp.on_read ? 1 : 0, wp.on_write ? 1 : 0,
+		    wp.log_only ? 1 : 0));
+	}
+
+	return file.Write();
+}
+
+void MachineInspectorWindow::OnLoadSettings(wxCommandEvent &)
+{
+	wxFileDialog dlg(this, "Load debugging session", wxEmptyString, wxEmptyString,
+	                 "RPCEmu debugging session (*.rpcdbg)|*.rpcdbg|All files (*)|*",
+	                 wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+
+	if (dlg.ShowModal() != wxID_OK) {
+		return;
+	}
+
+	if (!LoadSessionFrom(dlg.GetPath())) {
+		wxMessageBox("That file could not be read.", "Load failed",
+		    wxOK | wxICON_ERROR, this);
+	}
+}
+
+bool MachineInspectorWindow::LoadSessionFrom(const wxString &path)
+{
+	wxTextFile file;
+
+	if (!file.Open(path)) {
+		return false;
+	}
+
+	/* Replaced rather than merged: a session file describes a whole setup, and
+	   leaving yesterday's breakpoints in place beside it would be a third thing
+	   that is neither. */
+	emulator_.DebuggerClearBreakpoints();
+	emulator_.DebuggerClearWatchpoints();
+
+	for (wxString line = file.GetFirstLine(); !file.Eof();
+	     line = file.GetNextLine()) {
+		wxString key;
+		long value = 0;
+
+		line.Trim(true).Trim(false);
+		if (line.IsEmpty() || line.StartsWith("#")) {
+			continue;
+		}
+		key = line.BeforeFirst(' ');
+		const wxString rest = line.AfterFirst(' ').Trim(false);
+
+		auto flag = [&](wxCheckBox *box) {
+			if (rest.ToLong(&value)) {
+				box->SetValue(value != 0);
+			}
+		};
+
+		if (key == "trap_undefined")   flag(trap_undefined_checkbox_);
+		else if (key == "trap_prefetch")    flag(trap_prefetch_checkbox_);
+		else if (key == "trap_data_abort")  flag(trap_data_abort_checkbox_);
+		else if (key == "log_exceptions")   flag(log_exceptions_checkbox_);
+		else if (key == "swi_trace")        flag(swi_trace_checkbox_);
+		else if (key == "swi_halt")         flag(swi_halt_checkbox_);
+		else if (key == "step_skip_irq")    flag(step_skip_irq_checkbox_);
+		else if (key == "step_skip_os")     flag(step_skip_os_checkbox_);
+		else if (key == "disasm_lower")     flag(disasm_lower_checkbox_);
+		else if (key == "disasm_hex")       flag(disasm_hex_checkbox_);
+		else if (key == "disasm_apcs")      flag(disasm_apcs_checkbox_);
+		else if (key == "disasm_ranges")    flag(disasm_ranges_checkbox_);
+		else if (key == "disasm_pcrel")     flag(disasm_resolve_checkbox_);
+		else if (key == "swi_filter_min")   swi_filter_min_input_->SetValue(rest);
+		else if (key == "swi_filter_max")   swi_filter_max_input_->SetValue(rest);
+		else if (key == "autostep_rate") {
+			if (rest.ToLong(&value) && value > 0) {
+				autostep_rate_spin_->SetValue((int) value);
+			}
+		} else if (key == "swi_names") {
+			unsigned count = 0;
+
+			/* Not an error worth a dialog: the file may simply have moved
+			   since the session was saved, and everything else in it is
+			   still worth having. */
+			if (arm_disasm_load_swi_names(rest.utf8_str(), &count) == NULL) {
+				swi_names_path_ = rest;
+			} else {
+				rpclog("Machine Inspector: session names a SWI list that "
+				    "cannot be read: %s\n", (const char *) rest.utf8_str());
+			}
+		} else if (key == "breakpoint") {
+			bool ok = false;
+			const uint32_t address = ParseAddress(rest, &ok);
+
+			if (ok) {
+				emulator_.DebuggerAddBreakpoint(address);
+			}
+		} else if (key == "watchpoint") {
+			unsigned long addr = 0, size = 0;
+			int rd = 0, wr = 0, log = 0;
+
+			if (sscanf(rest.utf8_str().data(), "%lx %lu %d %d %d",
+			           &addr, &size, &rd, &wr, &log) == 5) {
+				emulator_.DebuggerAddWatchpoint((uint32_t) addr,
+				    (uint32_t) size, rd != 0, wr != 0, log != 0);
+			}
+		}
+		/* Anything else is from a version that knows more than this one. */
+	}
+
+	/* Push both sets of settings out, then read the machine back so the window
+	   shows what actually took. */
+	ApplyTraceConfig();
+	ApplyDisasmOptions();
+	RefreshSnapshot();
+
+	return true;
+}
+
+/*
+ * SWI names for the module being debugged.
+ *
+ * Asked for in discussion #223: the built-in table covers the OS, so a call
+ * into somebody's own module disassembles as "SWI &62C40" and has to be looked
+ * up by hand every time. A CSV is the format because that is what the tools
+ * that already know these numbers - a module's own headers, an assembler
+ * listing - can be made to produce in one line of anything.
+ */
+void MachineInspectorWindow::OnLoadSwiNames(wxCommandEvent &)
+{
+	wxFileDialog dlg(this, "Load SWI names", wxEmptyString, wxEmptyString,
+	                 "SWI name list (*.csv;*.txt)|*.csv;*.txt|All files (*)|*",
+	                 wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+
+	if (dlg.ShowModal() != wxID_OK) {
+		return;
+	}
+
+	unsigned count = 0;
+	const char *error = arm_disasm_load_swi_names(dlg.GetPath().utf8_str(),
+	                                              &count);
+
+	if (error == NULL) {
+		swi_names_path_ = dlg.GetPath();
+	} else {
+		wxMessageBox(wxString::Format("%s\n\nEach line is a SWI number and a "
+		    "name, separated by a comma:\n\n  &42C40,MyModule_Doit\n"
+		    "  &42C41,MyModule_Undo\n\nNumbers may be written &hex, 0xhex or "
+		    "decimal. Give the chunk base as the module declares it - the X "
+		    "form is matched too, and rendered with its X. Blank lines and "
+		    "lines starting with # are ignored.", error),
+		    "SWI names not loaded", wxOK | wxICON_ERROR, this);
+		return;
+	}
+
+	rpclog("Machine Inspector: %u SWI names loaded from %s\n", count,
+	    (const char *) dlg.GetPath().utf8_str());
+
+	/* Redraw at once: the point of loading them is to read the code on
+	   screen. */
+	RefreshDisassembly(disasm_current_address_);
+}
+
+/*
+ * Save a session, change everything, load it back, and say whether it came
+ * back. Reports each setting rather than a single pass/fail, so a reader of the
+ * log can see WHICH one was lost.
+ */
+bool MachineInspectorWindow::TestSessionRoundTrip(const wxString &path)
+{
+	/* Something distinctive, and not the default of anything. */
+	trap_data_abort_checkbox_->SetValue(true);
+	swi_trace_checkbox_->SetValue(true);
+	step_skip_irq_checkbox_->SetValue(true);
+	step_skip_os_checkbox_->SetValue(true);
+	disasm_lower_checkbox_->SetValue(true);
+	disasm_apcs_checkbox_->SetValue(true);
+	swi_filter_min_input_->SetValue("40000");
+	autostep_rate_spin_->SetValue(17);
+	emulator_.DebuggerClearBreakpoints();
+	emulator_.DebuggerAddBreakpoint(0x00008abc);
+	RefreshSnapshot();
+
+	if (!SaveSessionTo(path)) {
+		rpclog("TEST_INSPECTOR: session could not be saved to %s\n",
+		    (const char *) path.utf8_str());
+		return false;
+	}
+
+	/* Wipe every one of them, so anything that survives is the file's doing. */
+	trap_data_abort_checkbox_->SetValue(false);
+	swi_trace_checkbox_->SetValue(false);
+	step_skip_irq_checkbox_->SetValue(false);
+	step_skip_os_checkbox_->SetValue(false);
+	disasm_lower_checkbox_->SetValue(false);
+	disasm_apcs_checkbox_->SetValue(false);
+	swi_filter_min_input_->SetValue("0");
+	autostep_rate_spin_->SetValue(1);
+	ApplyTraceConfig();
+
+	if (!LoadSessionFrom(path)) {
+		rpclog("TEST_INSPECTOR: session could not be read back\n");
+		return false;
+	}
+
+	struct {
+		const char *what;
+		int got;
+	} checks[] = {
+		{ "trap_data_abort", trap_data_abort_checkbox_->GetValue() ? 1 : 0 },
+		{ "swi_trace",       swi_trace_checkbox_->GetValue() ? 1 : 0 },
+		{ "step_skip_irq",   step_skip_irq_checkbox_->GetValue() ? 1 : 0 },
+		{ "step_skip_os",    step_skip_os_checkbox_->GetValue() ? 1 : 0 },
+		{ "disasm_lower",    disasm_lower_checkbox_->GetValue() ? 1 : 0 },
+		{ "disasm_apcs",     disasm_apcs_checkbox_->GetValue() ? 1 : 0 },
+		{ "swi_filter_min",  swi_filter_min_input_->GetValue() == "40000" },
+		{ "autostep_rate",   autostep_rate_spin_->GetValue() == 17 },
+	};
+	int ok = 1;
+
+	for (size_t i = 0; i < sizeof(checks) / sizeof(checks[0]); i++) {
+		rpclog("TEST_INSPECTOR: session %-16s %s\n", checks[i].what,
+		    checks[i].got ? "restored" : "LOST");
+		if (!checks[i].got) {
+			ok = 0;
+		}
+	}
+
+	/* The breakpoint is read back from the machine, not from the window, so
+	   this also says the load reached the emulator and not just the controls. */
+	RefreshSnapshot();
+	{
+		const int found = (last_snapshot_.debug_breakpoint_count == 1 &&
+		    last_snapshot_.debug_breakpoints[0].address == 0x00008abc);
+
+		rpclog("TEST_INSPECTOR: session breakpoint      %s\n",
+		    found ? "restored" : "LOST");
+		if (!found) {
+			ok = 0;
+		}
+	}
+
+	/* And the trace config as the MACHINE holds it, which is the whole point of
+	   loading a session rather than just filling in a form. */
+	if (!LogTraceControlsAgainstMachine("after loading a session")) {
+		ok = 0;
+	}
+
+	emulator_.DebuggerClearBreakpoints();
+
+	return ok != 0;
+}
+
+/*
+ * Tick auto-step by hand and count what the machine actually retired. The
+ * complaint in discussion #223 was about how many instructions a second the
+ * window could manage, so the measurement is instructions, not ticks.
+ */
+void MachineInspectorWindow::TestAutoStep(int rate, int ticks)
+{
+	uint32_t first;
+	int moved = 0;
+	wxLongLong started;
+
+	emulator_.DebuggerPause();
+	RefreshSnapshot();
+	first = last_snapshot_.regs[15];
+
+	autostep_rate_spin_->SetValue(rate);
+	autostep_checkbox_->SetValue(true);
+	started = wxGetLocalTimeMillis();
+
+	for (int i = 0; i < ticks; i++) {
+		const uint32_t before = last_snapshot_.regs[15];
+
+		AutoStepTick();
+
+		/* A step is asynchronous: the emulator thread has to execute the
+		   instruction. Sample until it lands rather than reading the PC back
+		   immediately, which is the mistake this whole area is about. */
+		for (int waited = 0; waited < 50; waited++) {
+			wxMilliSleep(2);
+			RefreshSnapshot();
+			if (last_snapshot_.debug_step_active == 0 &&
+			    last_snapshot_.debug_paused != 0) {
+				break;
+			}
+		}
+		if (last_snapshot_.regs[15] != before) {
+			moved++;
+		}
+	}
+
+	autostep_checkbox_->SetValue(false);
+	autostep_timer_.Stop();
+
+	{
+		/*
+		 * How long a step takes from the window, which is the question asked in
+		 * discussion #223 - "about 1/2s for each step". Reported per step, not
+		 * as a total, so it can be compared against that directly. The rate
+		 * asked for is the CEILING; this is what the machine managed.
+		 */
+		const long elapsed = (wxGetLocalTimeMillis() - started).ToLong();
+
+		rpclog("TEST_INSPECTOR: auto-step %d ticks at %d/sec moved the PC %d "
+		    "times, %08x -> %08x, %ldms total, %ldms per step\n",
+		    ticks, rate, moved, first, last_snapshot_.regs[15], elapsed,
+		    moved > 0 ? elapsed / moved : 0L);
+	}
+
+	/*
+	 * And the safety property: a machine resumed from elsewhere must switch
+	 * auto-step off rather than single-step it from under whoever resumed it.
+	 */
+	autostep_checkbox_->SetValue(true);
+	autostep_timer_.Start(1000);
+	emulator_.DebuggerResume();
+	RefreshSnapshot();
+	AutoStepTick();
+	rpclog("TEST_INSPECTOR: auto-step on a running machine turned itself %s\n",
+	    autostep_checkbox_->GetValue() ? "ON, WHICH IS WRONG" : "off");
 }
 
 void MachineInspectorWindow::OnAddBreakpoint(wxCommandEvent &)

--- a/src/gui/machine_inspector_window.h
+++ b/src/gui/machine_inspector_window.h
@@ -52,6 +52,14 @@ public:
 	 */
 	bool LogTraceControlsAgainstMachine(const char *when);
 
+	/*
+	 * Driven by RPCEMU_TEST_INSPECTOR_AFTER. Auto-step and the session file are
+	 * both window behaviour - a timer and two file dialogs - so no unit test can
+	 * reach them; these are how they get exercised against a real machine.
+	 */
+	bool TestSessionRoundTrip(const wxString &path);
+	void TestAutoStep(int rate, int ticks);
+
 	/**
 	 * The debugger has started or stopped; read the machine again now.
 	 *
@@ -84,6 +92,11 @@ private:
 		ID_WATCHPOINT_REMOVE,
 		ID_TRACE_CONFIG,
 		ID_TRACE_CLEAR,
+		ID_AUTOSTEP,
+		ID_AUTOSTEP_TIMER,
+		ID_SETTINGS_SAVE,
+		ID_SETTINGS_LOAD,
+		ID_SWI_NAMES,
 	};
 
 	/*
@@ -114,8 +127,39 @@ private:
 	void OnStep(wxCommandEvent &event);
 	void OnStepOver(wxCommandEvent &event);
 
+	/**
+	 * Auto-step: keep stepping at a chosen rate while the machine is paused.
+	 *
+	 * "so you can set it to auto step every 1/4 second and watch it execute
+	 * slowly. This would really help when you're watching code, waiting for
+	 * something to happen but don't want to keep hitting the Step button" -
+	 * discussion #223.
+	 */
+	void OnAutoStep(wxCommandEvent &event);
+	void OnAutoStepTimer(wxTimerEvent &event);
+	void AutoStepTick();
+
+	/**
+	 * Save and load everything that makes up a debugging session: the
+	 * breakpoints, the watchpoints, the trapping and tracing settings and how
+	 * the disassembly is rendered.
+	 *
+	 * Asked for as import/export in discussion #223, "so you can resume
+	 * debugging easily" - a module being debugged is reloaded at a different
+	 * address every time, but the settings around it do not change.
+	 */
+	void OnSaveSettings(wxCommandEvent &event);
+	void OnLoadSettings(wxCommandEvent &event);
+	void OnLoadSwiNames(wxCommandEvent &event);
+
+	/* The session file itself, without the dialogs, so it can be driven by a
+	   test as well as by somebody clicking. */
+	bool SaveSessionTo(const wxString &path);
+	bool LoadSessionFrom(const wxString &path);
+
 	/** A disassembly rendering option moved; push the set to arm_disasm. */
 	void OnDisasmStyleChanged(wxCommandEvent &event);
+	void ApplyDisasmOptions();
 
 	/** Enter runs or pauses, Space steps, Shift+Space steps over. */
 	void OnDebugKey(wxKeyEvent &event);
@@ -183,6 +227,9 @@ private:
 	/* How the disassembly is written down, from discussion #223. These drive
 	   arm_disasm's global options, so they change the debug socket's output
 	   too, which is deliberate: one machine, one rendering. */
+	wxCheckBox *disasm_lower_checkbox_ = nullptr;
+	/* Remembered so a saved session can name it and reload it. */
+	wxString swi_names_path_;
 	wxCheckBox *disasm_hex_checkbox_ = nullptr;
 	wxCheckBox *disasm_apcs_checkbox_ = nullptr;
 	wxCheckBox *disasm_ranges_checkbox_ = nullptr;
@@ -197,6 +244,9 @@ private:
 	wxButton *pause_button_ = nullptr;
 	wxButton *step_button_ = nullptr;
 	wxButton *step_over_button_ = nullptr;
+	wxCheckBox *autostep_checkbox_ = nullptr;
+	wxSpinCtrl *autostep_rate_spin_ = nullptr;
+	wxTimer autostep_timer_{this, ID_AUTOSTEP_TIMER};
 	wxListBox *breakpoint_list_ = nullptr;
 	wxTextCtrl *breakpoint_input_ = nullptr;
 	wxButton *breakpoint_remove_button_ = nullptr;
@@ -214,6 +264,8 @@ private:
 	wxCheckBox *log_exceptions_checkbox_ = nullptr;
 	wxCheckBox *swi_trace_checkbox_ = nullptr;
 	wxCheckBox *swi_halt_checkbox_ = nullptr;
+	wxCheckBox *step_skip_irq_checkbox_ = nullptr;
+	wxCheckBox *step_skip_os_checkbox_ = nullptr;
 	wxTextCtrl *swi_filter_min_input_ = nullptr;
 	wxTextCtrl *swi_filter_max_input_ = nullptr;
 	wxTextCtrl *trace_view_ = nullptr;

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -2375,6 +2375,26 @@ void MainFrame::OnTestInspectorTimer(wxTimerEvent &event)
 		} else {
 			rpclog("TEST_INSPECTOR: no inspector window on reopen\n");
 		}
+		test_inspector_timer_.StartOnce(2000);
+		break;
+
+	case 5:
+		/*
+		 * Auto-step and the session file. Both are window behaviour - a timer
+		 * and two file dialogs - so this is the only place they meet a real
+		 * machine. Asked for in discussion #223.
+		 */
+		if (machine_inspector_window_ != nullptr) {
+			const wxString path = wxFileName::CreateTempFileName("rpcdbg");
+
+			machine_inspector_window_->TestAutoStep(20, 25);
+			rpclog("TEST_INSPECTOR: session round trip %s\n",
+			    machine_inspector_window_->TestSessionRoundTrip(path)
+			        ? "ok" : "FAILED");
+			wxRemoveFile(path);
+		} else {
+			rpclog("TEST_INSPECTOR: no inspector window for the session test\n");
+		}
 		rpclog("TEST_INSPECTOR: done\n");
 		break;
 

--- a/src/rpcemu.c
+++ b/src/rpcemu.c
@@ -465,6 +465,21 @@ static uint32_t debugger_halt_pc = 0;
 static uint32_t debugger_halt_opcode = 0;
 static uint32_t debugger_last_pc = 0;
 static uint32_t debugger_last_opcode = 0;
+/*
+ * Where the instruction that caused a trapped exception was.
+ *
+ * The halt itself is deferred so exception() can finish setting the vector up,
+ * which means the machine stops at the handler's first instruction - and that
+ * is the address the halt used to report. "Seeing the instruction before the
+ * CPU jumps to the hardware vector would be more useful" (discussion #223), and
+ * it is: the handler is the same handful of addresses every time, while the
+ * instruction that faulted is the question. Recorded here and used as the halt
+ * PC when the pause lands.
+ */
+static uint32_t debugger_fault_pc = 0;
+static uint32_t debugger_fault_opcode = 0;
+static int debugger_fault_pc_valid = 0;
+
 static uint32_t debugger_hit_address = 0;
 static uint32_t debugger_hit_value = 0;
 static uint8_t debugger_hit_size = 0;
@@ -1183,6 +1198,41 @@ debugger_breakpoint_should_halt(DebugBreakpointInfo *bp)
 	return 1;
 }
 
+/**
+ * Is this an address a step should pass straight through?
+ *
+ * Both halves are off unless asked for. See step_skip_irq and step_skip_os.
+ */
+static int
+debugger_step_skipping(uint32_t pc)
+{
+	if (debugger_trace_config.step_skip_irq) {
+		const uint32_t m = arm.mode & 0xf;
+
+		if (m == IRQ || m == FIQ) {
+			return 1;
+		}
+	}
+	if (debugger_trace_config.step_skip_os) {
+		/*
+		 * The ROM, and the hardware vector page.
+		 *
+		 * The vectors are as much the OS as the ROM is, and they are in low
+		 * RAM rather than above 0xf0000000, so a filter written on the ROM
+		 * address alone lets every step land on one. Measured: stepping out of
+		 * the ROM idle loop with only the ROM filtered stopped at 0x00000008,
+		 * which is no more use to somebody debugging their own code than the
+		 * ROM was. Sixteen words - the eight vectors and the eight addresses
+		 * behind them - and nothing else in zero page, which is workspace and
+		 * would never be stepped through anyway.
+		 */
+		if (pc < 0x40u || pc >= 0xf0000000u) {
+			return 1;
+		}
+	}
+	return 0;
+}
+
 int
 debugger_instruction_hook(uint32_t pc, uint32_t opcode)
 {
@@ -1220,9 +1270,39 @@ debugger_instruction_hook(uint32_t pc, uint32_t opcode)
 
 	if (debugger_pause_requested) {
 		DebugPauseReason reason = debugger_pending_reason;
+
 		if (reason == DebugPauseReason_None) {
 			reason = DebugPauseReason_User;
 		}
+
+		/*
+		 * A step that has landed somewhere the user said they did not want to
+		 * see. Keep going rather than stopping: another step is armed and the
+		 * machine runs on until it is back in code they care about.
+		 *
+		 * Only for stepping. A breakpoint or a watchpoint is an explicit
+		 * request for THIS address and fires wherever it is, and a trapped
+		 * exception is the thing being hunted - filtering those would be
+		 * hiding what was asked for.
+		 */
+		if (reason == DebugPauseReason_Step && debugger_step_skipping(pc)) {
+			debugger_pause_requested = 0;
+			debugger_pending_reason = DebugPauseReason_None;
+			debugger_step_remaining = 1;
+			debugger_step_active = 1;
+			debugger_refresh_hook_active();
+			return 0;
+		}
+
+		/* An exception trap reports the instruction that faulted, not the
+		   handler this has stopped at. */
+		if (reason == DebugPauseReason_Exception && debugger_fault_pc_valid) {
+			debugger_enter_pause(reason, debugger_fault_pc,
+			    debugger_fault_opcode);
+			debugger_fault_pc_valid = 0;
+			return 1;
+		}
+
 		debugger_enter_pause(reason, pc, opcode);
 		return 1;
 	}
@@ -1406,10 +1486,19 @@ debugger_exception_hook(uint32_t mmode, uint32_t address, uint32_t pc)
 	}
 
 	/* Deferred halt: let exception() finish setting up the vector, then the
-	   core stops at the handler's first instruction via the instruction hook. */
+	   core stops at the handler's first instruction via the instruction hook.
+	   The address REPORTED, though, is the instruction that faulted - see
+	   debugger_fault_pc. */
 	if (trap && !debugger_paused && !debugger_pause_requested) {
 		debugger_pause_requested = 1;
 		debugger_pending_reason = DebugPauseReason_Exception;
+		debugger_fault_pc = pc;
+		/* The instruction hook saw this instruction a moment ago if it was
+		   running at all; if it was not, there is no honest answer and zero
+		   says so rather than showing the handler's first word as the
+		   faulting one. */
+		debugger_fault_opcode = (debugger_last_pc == pc) ? debugger_last_opcode : 0;
+		debugger_fault_pc_valid = 1;
 		debugger_refresh_hook_active();
 	}
 }

--- a/src/rpcemu.h
+++ b/src/rpcemu.h
@@ -252,8 +252,25 @@ typedef struct DebugTraceConfig {
 	uint8_t log_exceptions;		/**< Also emit exception events to the ring */
 	uint8_t swi_trace_enabled;	/**< Emit SWI events to the ring */
 	uint8_t swi_trace_halt;		/**< Halt on a matching SWI */
-	uint8_t reserved0;
-	uint8_t reserved1;
+
+	/**
+	 * While stepping, do not stop inside an interrupt.
+	 *
+	 * "When debugging main code in games, you're not interested in seeing OS or
+	 * IRQ code execute" - discussion #223. A step that lands in IRQ or FIQ mode
+	 * keeps going until it is back out. Breakpoints and watchpoints still fire
+	 * wherever they are set: an explicit request is not noise.
+	 */
+	uint8_t step_skip_irq;
+
+	/**
+	 * While stepping, do not stop in the OS.
+	 *
+	 * Anything at or above 0xf0000000, where the ROM lives, and the hardware
+	 * vector page below 0x40. Same rule as above: stepping skips it,
+	 * breakpoints do not.
+	 */
+	uint8_t step_skip_os;
 	uint32_t swi_filter_min;	/**< Inclusive SWI-number range (0..0xffffffff = all) */
 	uint32_t swi_filter_max;
 } DebugTraceConfig;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -222,6 +222,15 @@ rpcemu_add_test(test_debugger_gate)
 # hand, and so are the seven legal modes: this is a new arm on a switch that
 # every mode change in the emulator passes through, and the way to get it wrong
 # is to catch a mode that used to work.
+# Every setting the Machine Inspector writes to a session file, it must also
+# read back. The two halves are a hundred lines apart with the key name spelled
+# out as a string literal in each, so no compiler can pair them up; a reader
+# that was never written loses the setting silently, and the file still looks
+# right. Source-level rather than behavioural because both halves live inside a
+# wxWidgets window, which a unit test cannot construct.
+rpcemu_add_shell_test(check_session_keys check-session-keys.sh
+                      ${CMAKE_CURRENT_SOURCE_DIR}/../src/gui/machine_inspector_window.cpp)
+
 # Which libraries build-macos.sh may fuse into one universal bundle. macOS
 # only, because that is the only platform the script runs on.
 #
@@ -1084,7 +1093,7 @@ rpcemu_add_test(test_unzip)
 #
 # Raise RPCEMU_EXPECTED_TESTS when adding a test. If that feels like a chore, it
 # is the only line in the file that cannot go stale without being noticed.
-set(RPCEMU_EXPECTED_TESTS 67)	# tests that build on every platform
+set(RPCEMU_EXPECTED_TESTS 68)	# tests that build on every platform
 if(RPCEMU_JIT_TESTS)
     math(EXPR RPCEMU_EXPECTED_TESTS "${RPCEMU_EXPECTED_TESTS} + 10")	# JIT differential
 endif()

--- a/tests/check-session-keys.sh
+++ b/tests/check-session-keys.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Every setting the Machine Inspector saves, it must also load.
+#
+# WHY THIS EXISTS. The session file (Save session... / Load session... on the
+# Trace tab) is written by one function and read by another, a hundred lines
+# apart, with the key name spelled out as a literal in both. Adding a setting
+# means touching both, and forgetting the reader fails silently in the worst
+# way: the file looks right, it contains the setting, and loading it quietly
+# does nothing. Whoever saved a session and reloaded it would conclude the
+# setting does not stick and go looking in the wrong place entirely.
+#
+# So this compares the two lists of literals. No compiler can: they are strings.
+
+set -u
+
+src="${1:-src/gui/machine_inspector_window.cpp}"
+
+if [ ! -f "$src" ]; then
+	echo "check-session-keys: $src not found" >&2
+	exit 1
+fi
+
+# Written: file.AddLine("<key> ...") and file.AddLine(wxString::Format("<key> ...
+written=$(sed -n 's/.*file\.AddLine(\(wxString::Format(\)\{0,1\}"\([a-z_][a-z_0-9]*\) .*/\2/p' \
+	"$src" | sort -u)
+
+# Read: key == "<key>"
+read_keys=$(sed -n 's/.*key == "\([a-z_][a-z_0-9]*\)".*/\1/p' "$src" | sort -u)
+
+if [ -z "$written" ] || [ -z "$read_keys" ]; then
+	echo "check-session-keys: found no keys at all - has the file been renamed?" >&2
+	exit 1
+fi
+
+fail=0
+
+for key in $written; do
+	if ! echo "$read_keys" | grep -qx "$key"; then
+		echo "  FAIL saved but never loaded: $key"
+		fail=1
+	fi
+done
+
+for key in $read_keys; do
+	if ! echo "$written" | grep -qx "$key"; then
+		echo "  FAIL loaded but never saved: $key"
+		fail=1
+	fi
+done
+
+count=$(echo "$written" | wc -w | tr -d ' ')
+
+if [ "$fail" -ne 0 ]; then
+	echo "check-session-keys: FAILED"
+	exit 1
+fi
+
+echo "  $count session settings, each one both saved and loaded          ok"
+echo "check-session-keys: all tests passed"

--- a/tests/test_arm_disasm.c
+++ b/tests/test_arm_disasm.c
@@ -533,6 +533,28 @@ test_rendering_options(void)
 	opts.hex_immediates = 1;
 	check_opts(&opts, 0xE92D409F, AT, "STMDB sp!, {a1-v1, v4, lr}");
 
+	/*
+	 * Lower case, and the two things it must NOT touch.
+	 *
+	 * A SWI's name and a symbol annotation are identifiers belonging to
+	 * somebody else: "os_writec" is not a lower-case rendering of "OS_WriteC",
+	 * it is the wrong name. That is the whole difficulty of this option and
+	 * the reason it was not done with the other three.
+	 */
+	memset(&opts, 0, sizeof(opts));
+	opts.lowercase = 1;
+	check_opts(&opts, 0xE3A00080, AT, "mov r0, #128");
+	check_opts(&opts, 0xE92D409F, AT, "stmdb r13!, {r0, r1, r2, r3, r4, r7, r14}");
+	check_opts(&opts, 0x0A00001C, AT, "beq 0x00008078");
+	check_opts(&opts, 0xEF000011, AT, "swi OS_Exit");
+	check_opts(&opts, 0xEF020011, AT, "swi XOS_Exit");
+	check_opts(&opts, 0xEF012345, AT, "swi 0x012345");
+
+	/* With hex as well, since the digits are ours to lower but the name is not. */
+	opts.hex_immediates = 1;
+	check_opts(&opts, 0xE3A000FF, AT, "mov r0, #&ff");
+	check_opts(&opts, 0xEF000011, AT, "swi OS_Exit");
+
 	/* And setting NULL restores every default. */
 	arm_disasm_set_options(&opts);
 	arm_disasm_set_options(NULL);
@@ -541,6 +563,74 @@ test_rendering_options(void)
 	check("NULL puts every option back to its default",
 	      opts.hex_immediates == 0 && opts.apcs_registers == 0 &&
 	      opts.collapse_reglists == 0 && opts.resolve_pc_relative == 0);
+}
+
+/*
+ * SWI names from a file.
+ *
+ * A debugger that says "SWI 0x042C40" where a module's own SWI should be is of
+ * limited use, and the built-in table only knows RISC OS's own. Asked for in
+ * discussion #223. A name from the file must beat the built-in table, so a
+ * chunk can be renamed as well as added, and a malformed line must be skipped
+ * rather than take the rest of the file with it.
+ */
+static void
+test_user_swi_names(void)
+{
+	const char *path = "test-swi-names.csv";
+	unsigned count = 0;
+	const char *err;
+	FILE *f;
+
+	printf("SWI names from a file\n");
+
+	check_text(0xEF042C40, "SWI 0x042C40");	/* a number, to begin with */
+
+	f = fopen(path, "w");
+	if (f == NULL) {
+		check("could not write the test file", 0);
+		return;
+	}
+	fputs("# a comment, and a blank line follow\n\n", f);
+	fputs("0x42c40,ADFFS_Info\n", f);
+	fputs("  273473 ,  ADFFS_Decimal  \n", f);   /* decimal, and the same number */
+	fputs("not a number,ignored\n", f);          /* skipped, not fatal */
+	fputs("0x11,MyOwnExit\n", f);                 /* beats the built-in table */
+	fputs("\t# an indented comment\n", f);
+	fputs("&42C42,ADFFS_Ampersand\n", f);        /* the way RISC OS writes hex */
+	fclose(f);
+
+	err = arm_disasm_load_swi_names(path, &count);
+	check("the file loads", err == NULL);
+	check("and reports how many names it took", count == 4);
+
+	check_text(0xEF042C40, "SWI ADFFS_Info");
+	check_text(0xEF042C41, "SWI ADFFS_Decimal");
+	check_text(0xEF000011, "SWI MyOwnExit");
+
+	/*
+	 * "&62C40" is what RISC OS documents, module headers and assembler
+	 * listings write, and strtoul() has never heard of it. The line was being
+	 * skipped in silence - the file loaded, said so, and the name was simply
+	 * not there.
+	 */
+	check_text(0xEF042C42, "SWI ADFFS_Ampersand");
+
+	/*
+	 * A file lists the chunk base, as a module header declares it; the code
+	 * being read calls the X form. Matching only on the number as written
+	 * meant the common case - reading a caller - found nothing.
+	 */
+	check_text(0xEF062C40, "SWI XADFFS_Info");
+	check_text(0xEF062C42, "SWI XADFFS_Ampersand");
+
+	arm_disasm_clear_swi_names();
+	check_text(0xEF000011, "SWI OS_Exit");
+
+	err = arm_disasm_load_swi_names("no-such-file-here.csv", &count);
+	check("a missing file is reported, not fatal", err != NULL);
+
+	remove(path);
 }
 
 int
@@ -559,6 +649,7 @@ main(void)
 	test_unknown();
 	test_symbol_annotation();
 	test_rendering_options();
+	test_user_swi_names();
 
 	printf("\n%s\n", failures ? "FAILED" : "All tests passed");
 

--- a/tests/test_debugger_gate.c
+++ b/tests/test_debugger_gate.c
@@ -30,6 +30,7 @@
 #include <string.h>
 
 #include "rpcemu.h"
+#include "arm.h"		/* arm.mode, and the mode numbers the filter tests */
 
 static int failures;
 
@@ -301,6 +302,158 @@ test_step_is_not_immediately_paused(void)
 	check("and the step is over", status.step_active == 0);
 }
 
+/*
+ * A step lands where the user said they did not want to look, and keeps going.
+ *
+ * WHY THIS EXISTS. Asked for in discussion #223: stepping through application
+ * code is useless when every few steps drops into the timer interrupt or into
+ * the middle of the ROM, and the way out - step, step, step until the PC comes
+ * back - is exactly the tedium the filter is meant to remove.
+ *
+ * The filter must apply to STEPS ONLY. A breakpoint set inside the ROM is an
+ * explicit request for that address; silently not stopping there would be the
+ * same silent failure the gate test above exists to prevent, and worse, because
+ * the person set the breakpoint deliberately. So the last two cases here matter
+ * as much as the first two.
+ */
+static void
+test_step_filters(void)
+{
+	DebuggerStatus status;
+	DebugTraceConfig cfg;
+
+	printf("Stepping past IRQs and the OS\n");
+
+	/* Interrupt mode, filter on. */
+	reset_debugger();
+	memset(&cfg, 0, sizeof(cfg));
+	cfg.step_skip_irq = 1;
+	debugger_set_trace_config(&cfg);
+
+	debugger_request_pause(DebugPauseReason_User);
+	debugger_instruction_hook(0x8000, 0xe1a00000);
+	arm.mode = IRQ;
+	debugger_single_step(1);
+	debugger_after_instruction(0x8000, 0xe1a00000);
+	debugger_instruction_hook(0x8004, 0xe1a00000);
+
+	debugger_get_status(&status);
+	check("a step into IRQ mode does not stop", status.paused == 0);
+	check("and another step is armed", status.step_active != 0);
+
+	/* Back in user code, and it stops. */
+	arm.mode = USER;
+	debugger_after_instruction(0x8004, 0xe1a00000);
+	debugger_instruction_hook(0x8008, 0xe1a00000);
+
+	debugger_get_status(&status);
+	check("it stops once the mode is back to the user's", status.paused != 0);
+	check("at the first instruction outside the interrupt",
+	    status.halt_pc == 0x8008);
+
+	/* The OS half of the same idea, on the address rather than the mode. */
+	reset_debugger();
+	memset(&cfg, 0, sizeof(cfg));
+	cfg.step_skip_os = 1;
+	debugger_set_trace_config(&cfg);
+	arm.mode = USER;
+
+	debugger_request_pause(DebugPauseReason_User);
+	debugger_instruction_hook(0x8000, 0xe1a00000);
+	debugger_single_step(1);
+	debugger_after_instruction(0x8000, 0xe1a00000);
+	debugger_instruction_hook(0xfc001000, 0xe1a00000);
+
+	debugger_get_status(&status);
+	check("a step into the ROM does not stop", status.paused == 0);
+
+	/* The vector page is the OS too, and is in low RAM rather than the ROM;
+	   filtering on the ROM address alone let every step land on a vector. */
+	debugger_after_instruction(0xfc001000, 0xe1a00000);
+	debugger_instruction_hook(0x00000008, 0xea000000);
+	debugger_get_status(&status);
+	check("nor does it stop on a hardware vector", status.paused == 0);
+
+	debugger_after_instruction(0x00000008, 0xea000000);
+	debugger_instruction_hook(0x8004, 0xe1a00000);
+	debugger_get_status(&status);
+	check("it stops on the way back out", status.paused != 0);
+	check("at the address returned to", status.halt_pc == 0x8004);
+
+	/* And now the half that must NOT be filtered. */
+	reset_debugger();
+	memset(&cfg, 0, sizeof(cfg));
+	cfg.step_skip_os = 1;
+	cfg.step_skip_irq = 1;
+	debugger_set_trace_config(&cfg);
+	arm.mode = IRQ;
+	debugger_add_breakpoint(0xfc002000);
+	debugger_instruction_hook(0xfc002000, 0xe1a00000);
+
+	debugger_get_status(&status);
+	check("a breakpoint in the ROM still fires", status.paused != 0);
+	check("and reports its own address", status.halt_pc == 0xfc002000);
+
+	reset_debugger();
+	arm.mode = USER;
+}
+
+/*
+ * A trapped exception reports the instruction that faulted, not the vector.
+ *
+ * WHY THIS EXISTS. The halt is deferred on purpose - exception() has to finish
+ * building the handler's state before the machine can usefully stop - so the
+ * instruction hook that actually performs the halt is looking at the handler's
+ * first instruction, several thousand instructions away from anything the
+ * person debugging wrote. Reporting THAT address is technically where the
+ * machine is and practically useless, which is what discussion #223 said: the
+ * useful answer is which instruction aborted.
+ */
+static void
+test_exception_reports_the_faulting_instruction(void)
+{
+	DebuggerStatus status;
+	DebugTraceConfig cfg;
+
+	printf("A trapped exception reports the faulting instruction\n");
+
+	reset_debugger();
+	memset(&cfg, 0, sizeof(cfg));
+	cfg.trap_data_abort = 1;
+	debugger_set_trace_config(&cfg);
+
+	/* The load that aborts, seen by the hook first. */
+	debugger_instruction_hook(0x9000, 0xe5901000);
+	debugger_exception_hook(ABORT, 0x14, 0x9000);
+
+	check_gate("exception pending", 1);
+
+	/* exception() has now vectored, and the hook next sees the handler. */
+	debugger_instruction_hook(0x00000014, 0xea000000);
+
+	debugger_get_status(&status);
+	check("stopped", status.paused != 0);
+	check("the reason is an exception",
+	    status.reason == DebugPauseReason_Exception);
+	check("the address is the load, not the vector", status.halt_pc == 0x9000);
+	check("and the opcode is the load's", status.halt_opcode == 0xe5901000);
+
+	/* A second, untrapped exception must not re-report the first one's
+	   address: the recorded PC is consumed by the halt it caused. */
+	reset_debugger();
+	memset(&cfg, 0, sizeof(cfg));
+	cfg.trap_undefined = 1;
+	debugger_set_trace_config(&cfg);
+	debugger_instruction_hook(0xa000, 0xe7f000f0);
+	debugger_exception_hook(UNDEFINED, 0x08, 0xa000);
+	debugger_instruction_hook(0x00000008, 0xea000000);
+	debugger_get_status(&status);
+	check("an undefined instruction reports its own address",
+	    status.halt_pc == 0xa000);
+
+	reset_debugger();
+}
+
 int
 main(void)
 {
@@ -313,6 +466,8 @@ main(void)
 	test_traps();
 	test_combinations();
 	test_step_is_not_immediately_paused();
+	test_step_filters();
+	test_exception_reports_the_faulting_instruction();
 
 	printf("\n%s\n", failures ? "FAILED" : "All tests passed");
 


### PR DESCRIPTION
Six items from discussion #223, completing that list.

### Lower-case disassembly
A post-pass over the finished line rather than doubled mnemonic tables, but not a blind one: the spans holding a SWI name or a symbol annotation are recorded as the line is built and left alone, because `os_writec` is not a lower-case style of `OS_WriteC`, it is wrong. The `X` of `XOS_Exit` belongs to the name for this purpose.

### SWI names from a file
The built-in table is the OS's, so a call into your own module reads `SWI &42C40`. One number and name per line, loaded from the **SWI names...** button beside the disassembly or `swi load <path>` on the debug socket.

Two bugs found by running it rather than reading it:

- **`&42C40` was skipped in silence.** That is how RISC OS writes hex in every document, module header and assembler listing, and `strtoul()` has never heard of it. The file loaded, reported how many names it took, and the name was simply absent.
- **A file listing the chunk base did not match the X form.** Which is the common case, because the code being read almost always calls `X`. Matching now ignores the X bit on both sides, and the `X` is still printed from the opcode.

### Halting at the faulting instruction
The halt has to be deferred - `exception()` needs to finish building the handler's state - so the machine really is sitting at the vector. But the vector address is the same for every data abort in the session, and the aborting instruction is the whole question. The pause now reports the faulting PC and its opcode.

### Passing through interrupts and the OS while stepping
Two settings, off unless asked for, and **steps only**: a breakpoint in the ROM is an explicit request for that address and still fires there.

The OS half covers the hardware vector page as well as the ROM, which came out of measuring it: with only the ROM filtered, a step out of the idle loop stopped at `&00000008`, which is no more use to somebody debugging their own code than the ROM was. Measured on a RISC OS 5.31 desktop, both settings on: one step from inside the ROM arrives at `&000086D4`, in application space.

If the machine never reaches unfiltered code the step never completes and the machine runs on; **Pause** still gets control back, and that is verified on a live machine.

### Auto-step at a chosen rate
1 to 200 steps a second, the rate a ceiling rather than a queue - a tick arriving while a step is in flight is dropped. It switches itself off if the machine is resumed from anywhere else rather than single-stepping it from under whoever resumed it.

It measured **0 instructions** the first time it ran: the tick read the mid-step transient as "somebody hit Run" and turned itself off after one step. That is the same transient `test_step_is_not_immediately_paused()` exists for. Now 25 steps in 173ms, about **6ms a step** - against the half a second the discussion reported before the inspector stopped polling on a timer.

### Saving and loading a session
Breakpoints, watchpoints, traps, filters, rendering options, the auto-step rate and the SWI name file, as plain text meant to be edited by hand and kept in a repository beside the code being debugged. Loading replaces rather than merges: a session file describes a whole setup.

The writer and the reader spell each key out as a string literal a hundred lines apart, which no compiler can pair up, and a reader that was never written would lose the setting in silence with the file still looking right - so `tests/check-session-keys.sh` compares the two lists.

## Testing

- `tests/test_debugger_gate.c` gains the step filters (including that a breakpoint in filtered code still fires) and the faulting-instruction report.
- `tests/test_arm_disasm.c` gains the ampersand form and X-form matching.
- `tests/check-session-keys.sh` is new; verified to fail when a loader is removed.
- Auto-step and the session file are window behaviour that no unit test can reach, so `RPCEMU_TEST_INSPECTOR_AFTER` drives them against a real machine and reports each setting separately - a round trip that fails says which one was lost.
- The `swi load` / `trace config step_skip_*` paths were exercised end to end against a booted RISC OS 5.31 machine over the debug socket.
- Full suite: 81/81. No new compiler warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)