### PR TITLE
Display: advertise what the monitor can show, not just the configured size (1.x)

### DIFF
--- a/src/edid.c
+++ b/src/edid.c
@@ -143,6 +143,8 @@ static const timing_bit_t established_timings3[] = {
    the second is free for the mode bitmap. */
 #define DESC_PREFERRED		0x36u
 #define DESC_SECOND		0x48u
+#define DESC_THIRD		0x5au
+#define DESC_FOURTH		0x6cu
 
 /**
  * Set the bits of a timing bitmap for every listed mode that fits.
@@ -247,13 +249,38 @@ set_standard_timing(uint8_t *p, unsigned x, unsigned aspect, unsigned hz)
 	p[1] = (uint8_t) (((aspect & 0x03) << 6) | ((hz - 60) & 0x3f));
 }
 
+/* Modes no timing bitmap can express, largest first.
+   DMT has no entry for any of them, and a standard timing cannot describe them
+   either: that field stores (width / 8) - 31 in a byte, so it stops at 2288
+   pixels wide. A detailed timing descriptor is the only way to declare one, and
+   there are exactly two spare descriptor slots, so at most the largest two that
+   fit are advertised. Without this the mode chooser offers 2560x1440 and RISC OS
+   refuses it, which is the 1440p half of the display reports. */
+static const struct { unsigned x, y; } detail_only_modes[] = {
+	{ 3840, 2160 },
+	{ 3440, 1440 },
+	{ 2560, 1440 },
+};
+
 void
 edid_build_from_base(uint8_t out[EDID_BLOCK_SIZE],
                      const uint8_t base[EDID_BLOCK_SIZE],
-                     unsigned x, unsigned y, unsigned hz)
+                     unsigned x, unsigned y,
+                     unsigned max_x, unsigned max_y, unsigned hz)
 {
 	unsigned sum = 0;
 	int i;
+
+	/* The ceiling can never be below the preferred mode: the monitor plainly
+	   shows the mode it says is native, and a caller that passes a smaller
+	   ceiling means "no ceiling worth applying" rather than "hide the native
+	   mode". */
+	if (max_x < x) {
+		max_x = x;
+	}
+	if (max_y < y) {
+		max_y = y;
+	}
 
 	memcpy(out, base, EDID_BLOCK_SIZE);
 
@@ -271,7 +298,7 @@ edid_build_from_base(uint8_t out[EDID_BLOCK_SIZE],
 	out[0x25] = 0;
 	set_timing_bits(&out[0x23], 3, established_timings,
 	                (unsigned) (sizeof(established_timings) /
-	                            sizeof(established_timings[0])), x, y);
+	                            sizeof(established_timings[0])), max_x, max_y);
 
 	/* Standard timings: a ladder of widescreen/legacy modes.
 	 *
@@ -310,7 +337,7 @@ edid_build_from_base(uint8_t out[EDID_BLOCK_SIZE],
 		unsigned slot = 0, e;
 
 		for (e = 0; e < sizeof(ladder) / sizeof(ladder[0]) && slot < slots; e++) {
-			if (ladder[e].x > x || ladder[e].y > y) {
+			if (ladder[e].x > max_x || ladder[e].y > max_y) {
 				continue;
 			}
 			set_standard_timing(&out[0x26 + slot * 2], ladder[e].x,
@@ -341,7 +368,34 @@ edid_build_from_base(uint8_t out[EDID_BLOCK_SIZE],
 		set_timing_bits(&d[ET3_BITMAP_OFFSET], ET3_BITMAP_BYTES,
 		                established_timings3,
 		                (unsigned) (sizeof(established_timings3) /
-		                            sizeof(established_timings3[0])), x, y);
+		                            sizeof(established_timings3[0])),
+		                max_x, max_y);
+	}
+
+	/* Descriptors 3 and 4 = the largest modes that fit the ceiling but which no
+	   bitmap can express. Both slots are dummies (tag 0x10, all zero) in every
+	   ROM block seen, so this displaces nothing, and a slot is left inherited
+	   when there is nothing to put in it rather than being blanked. The
+	   preferred mode is skipped: it already has descriptor 1. */
+	{
+		const unsigned slot_at[2] = { DESC_THIRD, DESC_FOURTH };
+		unsigned used = 0;
+		size_t m;
+
+		for (m = 0; m < sizeof(detail_only_modes) /
+		                sizeof(detail_only_modes[0]) && used < 2; m++) {
+			const unsigned dx = detail_only_modes[m].x;
+			const unsigned dy = detail_only_modes[m].y;
+
+			if (dx > max_x || dy > max_y) {
+				continue;
+			}
+			if (dx == x && dy == y) {
+				continue;	/* already the preferred timing */
+			}
+			build_detailed_timing(&out[slot_at[used]], dx, dy, hz);
+			used++;
+		}
 	}
 
 	/* Recompute the checksum so the whole block sums to a multiple of 256.
@@ -352,6 +406,105 @@ edid_build_from_base(uint8_t out[EDID_BLOCK_SIZE],
 		sum += out[i];
 	}
 	out[0x7f] = (uint8_t) ((256 - (sum & 0xff)) & 0xff);
+}
+
+/*
+ * Read a block back and say whether it declares one particular mode.
+ *
+ * Decoding rather than remembering: the question "will RISC OS accept this
+ * size?" has to be answered from the block the guest is actually reading, or a
+ * caller ends up re-implementing the builder's rules and the two drift. The
+ * established bitmap and the standard-timing ladder are read straight out of
+ * the base block's fixed offsets; the other two mechanisms live in descriptors,
+ * which have to be walked because their order is not fixed.
+ */
+static void
+detailed_timing_size(const uint8_t d[18], unsigned *x, unsigned *y)
+{
+	*x = (unsigned) d[2] | (((unsigned) d[4] & 0xf0u) << 4);
+	*y = (unsigned) d[5] | (((unsigned) d[7] & 0xf0u) << 4);
+}
+
+int
+edid_block_declares(const uint8_t block[EDID_BLOCK_SIZE],
+                    unsigned width, unsigned height)
+{
+	/* The seventeen established-bitmap modes, at their fixed bit positions. */
+	static const struct { unsigned w, h, byte, bit; } established[] = {
+		{  720, 400, 0x23, 7 }, {  640, 480, 0x23, 5 },
+		{  640, 480, 0x23, 3 }, {  640, 480, 0x23, 2 },
+		{  800, 600, 0x23, 1 }, {  800, 600, 0x23, 0 },
+		{  800, 600, 0x24, 7 }, {  800, 600, 0x24, 6 },
+		{  832, 624, 0x24, 5 }, { 1024, 768, 0x24, 3 },
+		{ 1024, 768, 0x24, 2 }, { 1024, 768, 0x24, 1 },
+		{ 1280, 1024, 0x24, 0 }, { 1152, 870, 0x25, 7 },
+	};
+	/* A standard timing stores the width and an aspect code; the height is
+	   derived, so it is never in the block. */
+	static const unsigned aspect_num[4] = { 16, 4, 5, 16 };
+	static const unsigned aspect_den[4] = { 10, 3, 4,  9 };
+	unsigned i;
+
+	if (block == NULL || width == 0 || height == 0) {
+		return 0;
+	}
+
+	for (i = 0; i < sizeof(established) / sizeof(established[0]); i++) {
+		if (established[i].w == width && established[i].h == height &&
+		    (block[established[i].byte] &
+		     (1u << established[i].bit)) != 0) {
+			return 1;
+		}
+	}
+
+	for (i = 0x26; i < 0x36; i += 2) {
+		unsigned w, h, aspect;
+
+		if (block[i] == 0x01 && block[i + 1] == 0x01) {
+			continue;	/* unused slot */
+		}
+		w = ((unsigned) block[i] + 31u) * 8u;
+		aspect = ((unsigned) block[i + 1] >> 6) & 0x03u;
+		h = w * aspect_den[aspect] / aspect_num[aspect];
+
+		if (w == width && h == height) {
+			return 1;
+		}
+	}
+
+	for (i = 0; i < 4; i++) {
+		const uint8_t *d = block + DESC_PREFERRED + i * 18;
+
+		/* A descriptor with a zero pixel clock is a display descriptor;
+		   byte 3 is then its tag. Anything else is a detailed timing. */
+		if (d[0] != 0 || d[1] != 0) {
+			unsigned dx = 0, dy = 0;
+
+			detailed_timing_size(d, &dx, &dy);
+			if (dx == width && dy == height) {
+				return 1;
+			}
+			continue;
+		}
+
+		if (d[3] == ET3_TAG && d[4] == 0) {
+			const uint8_t *bitmap = d + ET3_BITMAP_OFFSET;
+			unsigned e;
+
+			for (e = 0; e < sizeof(established_timings3) /
+			                sizeof(established_timings3[0]); e++) {
+				if (established_timings3[e].x == width &&
+				    established_timings3[e].y == height &&
+				    established_timings3[e].byte < ET3_BITMAP_BYTES &&
+				    (bitmap[established_timings3[e].byte] &
+				     (1u << established_timings3[e].bit)) != 0) {
+					return 1;
+				}
+			}
+		}
+	}
+
+	return 0;
 }
 
 /* The block in force, for anything that must answer for the same monitor. Kept

--- a/src/edid.h
+++ b/src/edid.h
@@ -31,15 +31,44 @@
  * (which adjusts byte 0x14 and the checksum at runtime) keeps the checksum
  * valid.
  *
+ * The preferred mode and the ceiling on what else is advertised are separate
+ * arguments, and have to be: the preferred mode is the one desktop the machine
+ * is configured for, while the ceiling is what this monitor could show if asked.
+ * Bounding the list by the preferred mode instead - which is what this did until
+ * the two were split - meant a machine configured for 1280x1024 advertised
+ * nothing larger, so every bigger size the mode chooser offered was refused by
+ * RISC OS as "unsuitable for displaying the desktop". The chooser is bounded by
+ * display memory, so the ceiling must be too, or the two disagree again.
+ *
  * @param out    Destination 128-byte block
  * @param base   Source 128-byte block to inherit non-timing fields from
  * @param x      Preferred mode width in pixels
  * @param y      Preferred mode height in pixels
+ * @param max_x  Widest mode to advertise; never less than @x
+ * @param max_y  Tallest mode to advertise; never less than @y
  * @param hz     Preferred mode vertical refresh in Hz
  */
 void edid_build_from_base(uint8_t out[EDID_BLOCK_SIZE],
                           const uint8_t base[EDID_BLOCK_SIZE],
-                          unsigned x, unsigned y, unsigned hz);
+                          unsigned x, unsigned y,
+                          unsigned max_x, unsigned max_y, unsigned hz);
+
+/**
+ * Does this block declare @width x @height, by any of the four mechanisms a
+ * block can use to say so - the established bitmap, a standard timing, the
+ * Established Timings III descriptor, or one of the detailed timings?
+ *
+ * Decoded from the block rather than recomputed from whatever was passed to
+ * edid_build_from_base(), so a caller asking "would RISC OS accept this size?"
+ * gets the same answer the guest will arrive at.
+ *
+ * @param block  128-byte block to read
+ * @param width  Mode width in pixels
+ * @param height Mode height in pixels
+ * @return non-zero if the block declares that mode
+ */
+int edid_block_declares(const uint8_t block[EDID_BLOCK_SIZE],
+                        unsigned width, unsigned height);
 
 /**
  * Validate that a 128-byte buffer is a structurally sound EDID 1.x block

--- a/src/gui/emulator_host.cpp
+++ b/src/gui/emulator_host.cpp
@@ -56,6 +56,7 @@ extern "C" {
 #include "network-nat.h"
 #include "podulerom.h"
 #include "romload.h"
+#include "rom_patch.h"
 #include "savestate.h"
 #include "sound.h"
 #include "vidc20.h"
@@ -899,6 +900,11 @@ void EmulatorHost::HandleCommand(const EmuCommand &command)
 		   the only place that can then check whether the guest adopted the mode.
 		   See MainFrame::RequestGuestMode(). */
 		config_save(&config);
+		/* The monitor the machine is being asked for has changed, so rebuild the
+		   block the graphics card serves over DDC. RISC OS reads the EDID when
+		   its display driver starts, so this reaches the guest on the next
+		   driver start or restart rather than at once. */
+		rom_patch_refresh_monitor_edid();
 		break;
 	case EmuCommandType::ClipboardEnabled:
 		config.clipboard_enabled ^= 1;

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -74,6 +74,7 @@
 extern "C" {
 #include "rpcemu.h"
 #include "display_mode.h"
+#include "edid.h"
 #include "hostclipboard.h"
 #include "machine_lock.h"
 }
@@ -1592,6 +1593,49 @@ void MainFrame::OnModeVerifyTimer(wxTimerEvent &event)
 	rpclog("Display: the guest refused %dx%d\n", requested.x, requested.y);
 
 	/*
+	 * Two quite different faults arrive here and they need opposite advice, so
+	 * ask the block the guest is actually reading which one this is.
+	 *
+	 * If our own EDID does not declare the size, the refusal is ours: the block
+	 * was built around the size configured at the time, and the one just picked
+	 * is now stored but will not be advertised until the monitor is rebuilt at
+	 * the next start. A restart is the cure and the size must stay in the menu,
+	 * because it is the size this machine is now configured for.
+	 *
+	 * If the block DOES declare it and RISC OS still said no, the monitor
+	 * definition in force is not ours - the guest's !Boot has loaded a
+	 * definition file over the top - and no restart will help. That is the case
+	 * this dialogue was originally written for.
+	 */
+	const uint8_t *in_force = edid_published();
+	const bool ours_declares_it =
+	    in_force != nullptr &&
+	    edid_block_declares(in_force, (unsigned) requested.x,
+	                        (unsigned) requested.y) != 0;
+
+	if (!ours_declares_it) {
+		rpclog("Display: %dx%d is not declared by the monitor EDID in force; "
+		       "stored, and offered again after a restart\n",
+		       requested.x, requested.y);
+
+		const wxString needs_restart = wxString::Format(
+		    "RISC OS would not switch to %d x %d yet, and is still using "
+		    "%d x %d.\n\n"
+		    "This machine's monitor was set up when it started, for the "
+		    "screen size in force then, and it does not offer this size. "
+		    "The setting has been saved.\n\n"
+		    "Restart the machine and it will start at %d x %d.",
+		    requested.x, requested.y,
+		    guest.x > 0 ? guest.x : requested.x,
+		    guest.y > 0 ? guest.y : requested.y,
+		    requested.x, requested.y);
+
+		wxMessageBox(needs_restart, "Screen Size Needs A Restart",
+		             wxOK | wxICON_INFORMATION, this);
+		return;
+	}
+
+	/*
 	 * Struck off the list.
 	 *
 	 * RISC OS accepts only the screen modes the monitor definition in force
@@ -1617,10 +1661,11 @@ void MainFrame::OnModeVerifyTimer(wxTimerEvent &event)
 	 * because its !Boot loads one over the top. Remove that and the emulator's
 	 * own monitor definition applies, which declares the whole list.
 	 *
-	 * Note what is NOT offered: a restart. Advertising the chosen size as the
-	 * monitor's native mode does not make RISC OS boot into it - the desktop mode
-	 * comes from CMOS and the monitor definition only vets it - so suggesting a
-	 * restart would be sending somebody round a loop that does not arrive.
+	 * Note what is NOT offered: a restart. This branch is reached only when our
+	 * own EDID DOES declare the size and RISC OS refused it anyway, so the
+	 * definition in force is the guest's own and restarting changes nothing -
+	 * it would send somebody round a loop that does not arrive. The case where a
+	 * restart IS the cure is handled above, before this point.
 	 */
 	wxMessageBox(
 	    wxString::Format(

--- a/src/rom_patch.c
+++ b/src/rom_patch.c
@@ -444,6 +444,59 @@ rom_patch_display_clock(size_t rom_bytes)
  *
  * @param rom_bytes Number of bytes actually loaded into the ROM image
  */
+/* Where the block was found and what it was built from, so the same block can
+   be rebuilt without re-scanning when the configured screen size changes. The
+   offset is into the loaded ROM image, which stays mapped for the life of the
+   machine. */
+static uint8_t edid_base_block[EDID_BLOCK_SIZE];
+static size_t edid_rom_offset;
+static int edid_base_known;
+
+/*
+ * The largest mode this monitor should claim it can show.
+ *
+ * Deliberately NOT the configured screen size. That is one desktop; this is the
+ * monitor's capability, and RISC OS will only accept a mode the monitor declares
+ * - so bounding the advertisement by the configured size makes every larger size
+ * in the emulator's own chooser unselectable. The chooser is bounded by display
+ * memory, so this is too, and the two then agree.
+ *
+ * The host display's FULL geometry is the ceiling, not its work area: full
+ * screen exists, and the work area is a fact about where a window may sit, not
+ * about what the screen can show. With no host display to ask - a headless run -
+ * there is nothing to bound by beyond the framestore.
+ */
+static void
+rom_patch_edid_ceiling(unsigned native_x, unsigned native_y,
+                       unsigned *max_x, unsigned *max_y)
+{
+	unsigned host_x = 0, host_y = 0;
+	unsigned fitted_x = 0, fitted_y = 0;
+
+	if (!rpcemu_get_host_display(&host_x, &host_y)) {
+		host_x = EDID_NATIVE_MAX_X;
+		host_y = EDID_NATIVE_MAX_Y;
+	}
+	if (host_x > EDID_NATIVE_MAX_X) {
+		host_x = EDID_NATIVE_MAX_X;
+	}
+	if (host_y > EDID_NATIVE_MAX_Y) {
+		host_y = EDID_NATIVE_MAX_Y;
+	}
+
+	/* Budgeted at the shallowest depth, exactly as the chooser is: a mode that
+	   fits at 8bpp is one the user may legitimately pick, and the depth at that
+	   size is the guest's business afterwards. */
+	if (!display_mode_fit(host_x, host_y, DISPLAY_BPP_SHALLOWEST,
+	                      rpcemu_display_memory(), &fitted_x, &fitted_y)) {
+		fitted_x = native_x;
+		fitted_y = native_y;
+	}
+
+	*max_x = fitted_x > native_x ? fitted_x : native_x;
+	*max_y = fitted_y > native_y ? fitted_y : native_y;
+}
+
 static void
 rom_patch_monitor_edid(size_t rom_bytes)
 {
@@ -452,10 +505,13 @@ rom_patch_monitor_edid(size_t rom_bytes)
 	size_t found = (size_t) -1;
 	size_t hits = 0;
 	unsigned native_x, native_y;
+	unsigned max_x = 0, max_y = 0;
 	unsigned bound_x = 0, bound_y = 0;
 	uint8_t base[EDID_BLOCK_SIZE];
 	uint8_t block[EDID_BLOCK_SIZE];
 	size_t byte;
+
+	edid_base_known = 0;
 
 	/* Word-aligned scan (the table is word-aligned in the driver). */
 	for (byte = 0; byte + EDID_BLOCK_SIZE <= words * 4; byte += 4) {
@@ -512,16 +568,25 @@ rom_patch_monitor_edid(size_t rom_bytes)
 	}
 
 	memcpy(base, &rb[found], EDID_BLOCK_SIZE);
-	edid_build_from_base(block, base, native_x, native_y, EDID_NATIVE_HZ);
+	rom_patch_edid_ceiling(native_x, native_y, &max_x, &max_y);
+	edid_build_from_base(block, base, native_x, native_y,
+	                     max_x, max_y, EDID_NATIVE_HZ);
 	memcpy(&rb[found], block, EDID_BLOCK_SIZE);
+
+	/* Kept so a later screen-size change can rebuild without re-scanning. */
+	memcpy(edid_base_block, base, EDID_BLOCK_SIZE);
+	edid_rom_offset = found;
+	edid_base_known = 1;
 
 	/* Publish it: the graphics card serves this same block over DDC, because
 	   RISC OS re-reads the EDID from the display driver when the driver
 	   changes and would otherwise end up with a different monitor. */
 	edid_publish(block);
 
-	rpclog("rom_patch: applied: monitor EDID replaced, native %ux%u@%u (block at 0x%06x)\n",
-	       native_x, native_y, EDID_NATIVE_HZ, (unsigned) found);
+	rpclog("rom_patch: applied: monitor EDID replaced, native %ux%u@%u, "
+	       "advertising up to %ux%u (block at 0x%06x)\n",
+	       native_x, native_y, EDID_NATIVE_HZ, max_x, max_y,
+	       (unsigned) found);
 }
 
 /* -------------------------------------------------------------------------
@@ -617,6 +682,61 @@ rom_patch_ncos_post(void)
 		rom[0x26f0 >> 2] = 0xe3b00000; /* MOVS r0, #0 */
 		rom[0x2750 >> 2] = 0xe3b00000; /* MOVS r0, #0 */
 	}
+}
+
+/*
+ * Rebuild the monitor EDID for the screen size now configured, and republish it.
+ *
+ * Called when the configured size changes while the machine is running, so the
+ * block the graphics card serves over DDC describes the monitor the machine is
+ * being asked for rather than the one it booted with.
+ *
+ * What this does NOT do is make RISC OS re-read it. The kernel builds its mode
+ * table from the EDID when the display driver starts and does not poll, so the
+ * new block is picked up on the next driver change or the next boot. That is why
+ * the size chooser still tells the user to restart when the size it wants is one
+ * the block in force does not declare: this keeps the two copies honest, it does
+ * not make the change live.
+ */
+void
+rom_patch_refresh_monitor_edid(void)
+{
+	uint8_t *rb = (uint8_t *) rom;
+	unsigned native_x, native_y;
+	unsigned max_x = 0, max_y = 0;
+	unsigned bound_x = 0, bound_y = 0;
+	uint8_t block[EDID_BLOCK_SIZE];
+
+	if (!edid_base_known) {
+		return;		/* No EDID in this ROM (RISC OS 3/4), nothing to do. */
+	}
+
+	if (!rpcemu_edid_bound(&bound_x, &bound_y)) {
+		bound_x = EDID_NATIVE_DEFAULT_X;
+		bound_y = EDID_NATIVE_DEFAULT_Y;
+	}
+	if (bound_x > EDID_NATIVE_MAX_X) {
+		bound_x = EDID_NATIVE_MAX_X;
+	}
+	if (bound_y > EDID_NATIVE_MAX_Y) {
+		bound_y = EDID_NATIVE_MAX_Y;
+	}
+
+	if (!display_mode_fit(bound_x, bound_y, DISPLAY_BPP_SHALLOWEST,
+	                      rpcemu_display_memory(), &native_x, &native_y)) {
+		return;
+	}
+
+	rom_patch_edid_ceiling(native_x, native_y, &max_x, &max_y);
+	edid_build_from_base(block, edid_base_block, native_x, native_y,
+	                     max_x, max_y, EDID_NATIVE_HZ);
+	memcpy(&rb[edid_rom_offset], block, EDID_BLOCK_SIZE);
+	edid_publish(block);
+
+	rpclog("rom_patch: monitor EDID rebuilt, native %ux%u@%u, "
+	       "advertising up to %ux%u (takes effect on the next display driver "
+	       "start or restart)\n",
+	       native_x, native_y, EDID_NATIVE_HZ, max_x, max_y);
 }
 
 /* -------------------------------------------------------------------------

--- a/src/rom_patch.h
+++ b/src/rom_patch.h
@@ -42,6 +42,16 @@ extern "C" {
  */
 void rom_patch_apply(size_t rom_bytes);
 
+/**
+ * Rebuild and republish the monitor EDID for the screen size now configured.
+ *
+ * For a size changed while the machine runs. The rebuilt block is what the
+ * graphics card serves over DDC from now on; RISC OS reads the EDID when its
+ * display driver starts, so the change reaches the guest on the next driver
+ * start or the next boot, not immediately.
+ */
+void rom_patch_refresh_monitor_edid(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/test_gfxcard.c
+++ b/tests/test_gfxcard.c
@@ -301,7 +301,7 @@ main(void)
 		memset(base, 0, sizeof(base));
 		memcpy(base, "\x00\xff\xff\xff\xff\xff\xff\x00", 8);
 		base[18] = 1;			/* EDID version 1 */
-		edid_build_from_base(block, base, 2560, 1440, 60);
+		edid_build_from_base(block, base, 2560, 1440, 2560, 1440, 60);
 		check(edid_block_is_valid(block), "the block built for the test is sound");
 		edid_publish(block);
 

--- a/tests/test_mode_fit.c
+++ b/tests/test_mode_fit.c
@@ -245,7 +245,7 @@ check_edid_est3_scales_with_the_preferred_mode(void)
 	uint8_t block[EDID_BLOCK_SIZE];
 	size_t i;
 
-	printf("\nthe mode bitmap scales with the preferred mode\n");
+	printf("\nthe mode bitmap scales with the advertising ceiling\n");
 
 	for (i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
 		char label[80];
@@ -254,7 +254,8 @@ check_edid_est3_scales_with_the_preferred_mode(void)
 		memset(base, 0, sizeof(base));
 		memset(base + 1, 0xff, 6);
 		base[18] = 1;
-		edid_build_from_base(block, base, cases[i].pref_w, cases[i].pref_h, 60);
+		edid_build_from_base(block, base, cases[i].pref_w, cases[i].pref_h,
+		                     cases[i].pref_w, cases[i].pref_h, 60);
 
 		if (edid_est3_bitmap(block) == NULL) {
 			printf("  native %ux%u: FAIL (no 0xF7 descriptor in the block)\n",
@@ -341,7 +342,7 @@ check_edid_advertises_every_mode(void)
 	   larger than the preferred one in either direction is deliberately left
 	   out. Asking at 2560x1440 is therefore asking "of everything the chooser
 	   can pick, is anything missing that would fit?". */
-	edid_build_from_base(block, base, 2560, 1440, 60);
+	edid_build_from_base(block, base, 2560, 1440, 2560, 1440, 60);
 
 	printf("\nevery mode the chooser can pick is one the EDID advertises\n");
 
@@ -396,6 +397,158 @@ check_edid_advertises_every_mode(void)
 		}
 		printf("  %-44s ok\n", label);
 	}
+}
+
+/*
+ * The bug this pair exists for.
+ *
+ * check_edid_advertises_every_mode() builds its block at 2560x1440, the largest
+ * mode there is, where nothing can be above the ceiling and the invariant it
+ * checks cannot fail. Every real machine has a preferred mode well below that,
+ * and until the ceiling became its own argument the list was bounded by the
+ * preferred mode - so a machine configured for 1280x1024 advertised nothing
+ * larger, the chooser went on offering the bigger sizes, and RISC OS refused
+ * every one of them as "unsuitable for displaying the desktop".
+ *
+ * So: build at a SMALL preferred mode with a LARGE ceiling, and check the list
+ * follows the ceiling. With the ceiling argument removed these all fail.
+ */
+static void
+check_small_preferred_mode_still_advertises_the_ceiling(void)
+{
+	static const struct { unsigned w, h; } want[] = {
+		{ 1920, 1080 },		/* Derek's case: standard-timing ladder */
+		{ 1920, 1200 },		/* Established Timings III */
+		{ 1680, 1050 },
+		{ 1280, 1024 },		/* the preferred mode itself */
+		{ 1024,  768 },		/* established bitmap */
+	};
+	uint8_t base[EDID_BLOCK_SIZE];
+	uint8_t block[EDID_BLOCK_SIZE];
+	size_t i;
+
+	memset(base, 0, sizeof(base));
+	memset(base + 1, 0xff, 6);
+	base[18] = 1;
+
+	/* A 1920x1200 monitor, a machine configured for 1280x1024. */
+	edid_build_from_base(block, base, 1280, 1024, 1920, 1200, 60);
+
+	printf("\na small preferred mode still advertises up to the ceiling\n");
+
+	if (!edid_block_is_valid(block)) {
+		printf("  FAIL (block checksum/header invalid)\n");
+		failures++;
+		return;
+	}
+
+	for (i = 0; i < sizeof(want) / sizeof(want[0]); i++) {
+		char label[80];
+
+		snprintf(label, sizeof(label), "%ux%u offered below a 1920x1200 ceiling",
+		         want[i].w, want[i].h);
+		if (!edid_advertises(block, want[i].w, want[i].h)) {
+			printf("  %-52s FAIL\n", label);
+			failures++;
+			continue;
+		}
+		printf("  %-52s ok\n", label);
+	}
+
+	/* And the ceiling still means something: above it, nothing is offered. */
+	if (edid_advertises(block, 1920, 1440)) {
+		printf("  %-52s FAIL\n", "1920x1440 withheld above the ceiling");
+		failures++;
+	} else {
+		printf("  %-52s ok\n", "1920x1440 withheld above the ceiling");
+	}
+}
+
+/*
+ * 2560x1440 and its neighbours cannot be said by any bitmap - DMT has no such
+ * mode and a standard timing stops at 2288 pixels wide - so they are carried in
+ * the two spare detailed-timing descriptors. Without that, picking 1440p from
+ * the chooser is refused by RISC OS however large the ceiling is, which is the
+ * 1440p half of the display reports.
+ */
+static void
+check_detail_only_modes_are_declared(void)
+{
+	uint8_t base[EDID_BLOCK_SIZE];
+	uint8_t block[EDID_BLOCK_SIZE];
+
+	memset(base, 0, sizeof(base));
+	memset(base + 1, 0xff, 6);
+	base[18] = 1;
+
+	printf("\nmodes no bitmap can express are carried as detailed timings\n");
+
+	/* A 1440p monitor, machine configured for 1920x1080. */
+	edid_build_from_base(block, base, 1920, 1080, 2560, 1440, 60);
+
+	if (!edid_block_is_valid(block)) {
+		printf("  FAIL (block checksum/header invalid)\n");
+		failures++;
+		return;
+	}
+	if (!edid_block_declares(block, 2560, 1440)) {
+		printf("  %-52s FAIL\n", "2560x1440 declared below a 1440p ceiling");
+		failures++;
+	} else {
+		printf("  %-52s ok\n", "2560x1440 declared below a 1440p ceiling");
+	}
+	/* The preferred mode keeps its own descriptor either way. */
+	if (!edid_block_declares(block, 1920, 1080)) {
+		printf("  %-52s FAIL\n", "1920x1080 still declared as preferred");
+		failures++;
+	} else {
+		printf("  %-52s ok\n", "1920x1080 still declared as preferred");
+	}
+	/* Above the ceiling it stays out. */
+	if (edid_block_declares(block, 3840, 2160)) {
+		printf("  %-52s FAIL\n", "3840x2160 withheld above the ceiling");
+		failures++;
+	} else {
+		printf("  %-52s ok\n", "3840x2160 withheld above the ceiling");
+	}
+}
+
+/*
+ * edid_block_declares() is what the size chooser asks before deciding whether a
+ * refusal was the emulator's fault or the guest's, so it has to agree with the
+ * decoder this file already had. Two independent readers of the same block: if
+ * they disagree, one of them is wrong and the dialogue gives the wrong advice.
+ */
+static void
+check_declares_agrees_with_the_test_decoder(void)
+{
+	uint8_t base[EDID_BLOCK_SIZE];
+	uint8_t block[EDID_BLOCK_SIZE];
+	size_t i;
+
+	memset(base, 0, sizeof(base));
+	memset(base + 1, 0xff, 6);
+	base[18] = 1;
+	edid_build_from_base(block, base, 1280, 1024, 1920, 1200, 60);
+
+	printf("\nedid_block_declares() agrees with the test's own decoder\n");
+
+	for (i = 0; i < display_mode_count(); i++) {
+		unsigned w = 0, h = 0;
+		int mine, theirs;
+
+		if (!display_mode_get(i, &w, &h)) {
+			continue;
+		}
+		mine = edid_block_declares(block, w, h) ? 1 : 0;
+		theirs = edid_advertises(block, w, h) ? 1 : 0;
+		if (mine != theirs) {
+			printf("  %ux%u: FAIL (edid_block_declares says %d, decoder says %d)\n",
+			       w, h, mine, theirs);
+			failures++;
+		}
+	}
+	printf("  every mode in the table agrees\n");
 }
 
 int
@@ -474,6 +627,9 @@ main(void)
 	expect_nothing("host smaller than any mode", 320, 200, 4, 8);
 
 	check_edid_advertises_every_mode();
+	check_small_preferred_mode_still_advertises_the_ceiling();
+	check_detail_only_modes_are_declared();
+	check_declares_agrees_with_the_test_decoder();
 	check_edid_est3_scales_with_the_preferred_mode();
 
 	printf("\n%s (%d failure%s)\n", failures ? "FAILED" : "PASSED",


### PR DESCRIPTION
Backport of #255 to the 1.x line, which is what the users who reported this are running.

Same change: the synthesised monitor EDID was bounded by the configured screen size rather than by what the monitor can show, so a machine configured for 1280x1024 advertised nothing larger and every bigger size the chooser offered was refused by RISC OS. See #255 for the full write-up.

One difference from the main branch version. The new dialogue on `main` routes through the Manager when the machine is managed; this line has no Manager, so it uses a plain message box like the dialogue beside it. The cherry-pick compiled on `main` and failed to build here on `managed_mode_`, which is the only thing that differs between the two branches.

## Measured on this line

RISC OS 5.31, RPCSA, graphics card driving the display, booted to the desktop off a real disc, configured for 1280x1024, mode read back over VNC:

| Build | Asked at run time | Result |
| --- | --- | --- |
| 1.1.19 | `WimpMode X1920 Y1080 C256` | refused, stayed 1280x1024 |
| this | `WimpMode X1920 Y1080 C256` | 1920x1080 |
| 1.1.19 | `WimpMode X2560 Y1440 C16M F60` | refused, stayed 1280x1024 |
| this | `WimpMode X2560 Y1440 C16M F60` | 2560x1440 |

57/57 tests pass. No new warnings.

The republish path is only reached from the front end, so a headless run cannot exercise it. It compiles and is wired, but has not been watched firing on a live machine.