### PR TITLE
Inspector: translate the memory view's address, and stop displaying memory from firing watchpoints (1.x)

### DIFF
--- a/src/gui/emulator_host.cpp
+++ b/src/gui/emulator_host.cpp
@@ -1064,8 +1064,10 @@ void EmulatorHost::HandleCommand(const EmuCommand &command)
 		break;
 	}
 	case EmuCommandType::ReadMemory: {
+		/* Virtual, like every other address crossing this boundary. This path
+		   has no callers today; EmulatorHost::ReadMemory() is unreferenced. */
 		std::vector<uint8_t> data =
-		    emulator_read_memory(command.debug_address, command.debug_count);
+		    emulator_read_memory(command.debug_address, command.debug_count).data;
 		{
 			std::lock_guard<std::mutex> lock(memory_mutex_);
 			memory_result_ = std::move(data);

--- a/src/gui/emulator_snapshot.cpp
+++ b/src/gui/emulator_snapshot.cpp
@@ -106,8 +106,13 @@ emulator_fill_snapshot(MachineSnapshot *snapshot)
 
 	for (int i = 0; i < 8; i++) {
 		const uint32_t addr = (pc + static_cast<uint32_t>(i * 4)) & arm.r15_mask;
+		uint32_t word = 0;
+
+		/* Side-effect-free, for the reason given in emulator_disassemble_at():
+		   this runs on EVERY snapshot, so the live read fired watchpoints
+		   around the PC continuously for as long as the inspector was open. */
 		snapshot->pipeline_addr[i] = addr;
-		snapshot->pipeline_data[i] = mem_read32(addr);
+		snapshot->pipeline_data[i] = mem_debug_read(addr, 4, &word) ? word : 0;
 	}
 
 	snapshot->mmu_enabled = mmu;
@@ -204,21 +209,41 @@ emulator_take_snapshot()
 	return snapshot;
 }
 
-std::vector<uint8_t>
-emulator_read_memory(uint32_t address, uint32_t length)
+MemoryRead
+emulator_read_memory(uint32_t address, uint32_t length, bool physical)
 {
 	if (length > 4096) {
 		length = 4096;
 	}
 
-	std::vector<uint8_t> data;
-	data.reserve(length);
+	MemoryRead result;
+	result.data.reserve(length);
+	result.mapped.reserve(length);
 
+	/*
+	 * Translated unless a physical read was asked for, which is what dc_read8()
+	 * in debugcmd.c has always done. This read did not translate at all, so the
+	 * hex view answered with whatever sat at that PHYSICAL address while every
+	 * other address in the window - the PC, the registers, the disassembly,
+	 * breakpoints - meant a virtual one. Same number, two different places, and
+	 * that is issue #258.
+	 *
+	 * Byte at a time, and deliberately: a run of bytes can cross a page
+	 * boundary into an unmapped page, so mapped-ness is per byte and not a
+	 * property of the request.
+	 */
 	for (uint32_t i = 0; i < length; i++) {
-		data.push_back(mem_phys_read8_debug(address + i));
+		const uint32_t addr = address + i;
+		uint32_t phys = addr;
+		const int ok = physical ? 1 : mem_debug_translate(addr, &phys);
+
+		result.mapped.push_back(ok ? 1u : 0u);
+		result.data.push_back(ok
+		    ? static_cast<uint8_t>(mem_phys_read8_debug(phys))
+		    : static_cast<uint8_t>(0));
 	}
 
-	return data;
+	return result;
 }
 
 std::string
@@ -244,7 +269,24 @@ emulator_disassemble_at(uint32_t address, int count)
 
 	for (int i = 0; i < count; i++) {
 		const uint32_t addr = address + static_cast<uint32_t>(i * 4);
-		const uint32_t opcode = mem_read32(addr);
+		uint32_t opcode = 0;
+
+		/*
+		 * mem_debug_read(), not mem_read32(). The live read calls
+		 * debugger_memory_access(), so merely DISPLAYING code fired any
+		 * watchpoint covering it, and an address on an I/O page went through
+		 * readmemfl() with whatever side effect that carries. Looking at the
+		 * machine must not change it.
+		 */
+		if (!mem_debug_read(addr, 4, &opcode)) {
+			char line[256];
+
+			snprintf(line, sizeof(line), "%08X%c %s  %s\n",
+			         addr, addr == pc ? '<' : ':', "--------",
+			         "<unmapped>");
+			result += line;
+			continue;
+		}
 
 		arm_disasm(opcode, addr, disasm_buf, sizeof(disasm_buf));
 

--- a/src/gui/emulator_snapshot.h
+++ b/src/gui/emulator_snapshot.h
@@ -28,7 +28,36 @@
 #include "machine_snapshot.h"
 
 MachineSnapshot emulator_take_snapshot();
-std::vector<uint8_t> emulator_read_memory(uint32_t address, uint32_t length);
+
+/**
+ * The result of a debug read: the bytes, and which of them could be read at all.
+ *
+ * Unmapped bytes come back as zero, which is indistinguishable from a page of
+ * genuine zeros, so the caller is told which is which rather than being left to
+ * present one as the other. Issue #258: a hex dump of zeros for an address that
+ * is simply not mapped reads as "the debugger is wrong" and is how the
+ * untranslated read went unnoticed.
+ */
+struct MemoryRead {
+	std::vector<uint8_t> data;	/**< Byte values, zero where unmapped */
+	std::vector<uint8_t> mapped;	/**< 1 per readable byte, parallel to data */
+};
+
+/**
+ * Read guest memory for display, without disturbing the machine.
+ *
+ * Virtual by default, which is what every other address in the inspector means
+ * and what the debug socket's `mem` command does; pass @physical for a raw
+ * read of the same number. Never fires a watchpoint and never leaves an abort
+ * pending, so looking at memory cannot change what the machine then does.
+ *
+ * @param address  Virtual address, or physical when @physical is set
+ * @param length   Bytes to read, capped at 4096
+ * @param physical Treat @address as already physical
+ */
+MemoryRead emulator_read_memory(uint32_t address, uint32_t length,
+                                bool physical = false);
+
 std::string emulator_disassemble_at(uint32_t address, int count);
 
 #endif

--- a/src/gui/machine_inspector_window.cpp
+++ b/src/gui/machine_inspector_window.cpp
@@ -35,6 +35,7 @@
 extern "C" {
 #include "arm.h"
 #include "arm_common.h"	/* ARM_MODE_32: bit 4 of the mode says 26- or 32-bit */
+#include "mem.h"	/* mem_debug_read: the translated, side-effect-free read */
 }
 
 #include <cstring>
@@ -369,6 +370,11 @@ void MachineInspectorWindow::BuildUi()
 	                                    wxDefaultPosition, wxSize(80, -1),
 	                                    wxSP_ARROW_KEYS, 16, 4096, 256);
 	memory_bytes_spin_->SetToolTip("Number of bytes to display");
+	memory_physical_checkbox_ = new wxCheckBox(memory_panel, wxID_ANY, "Physical");
+	memory_physical_checkbox_->SetToolTip(
+	    "Read the address as a physical one. Off, it is a virtual address and "
+	    "goes through the MMU, which is what every other address in this window "
+	    "means. Matches the debug socket's 'mem <addr> <len> [phys]'.");
 	auto *memory_go_button = new wxButton(memory_panel, ID_MEMORY_GO, "Go");
 	auto *memory_refresh_button = new wxButton(memory_panel, ID_MEMORY_REFRESH, "Refresh");
 
@@ -377,6 +383,7 @@ void MachineInspectorWindow::BuildUi()
 	memory_controls->Add(memory_address_input_, 0, wxRIGHT, 6);
 	memory_controls->Add(new wxStaticText(memory_panel, wxID_ANY, "Bytes:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 6);
 	memory_controls->Add(memory_bytes_spin_, 0, wxRIGHT, 6);
+	memory_controls->Add(memory_physical_checkbox_, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 6);
 	memory_controls->Add(memory_go_button, 0, wxRIGHT, 6);
 	memory_controls->Add(memory_refresh_button, 0);
 
@@ -619,6 +626,10 @@ void MachineInspectorWindow::BuildUi()
 
 	disasm_address_input_->Bind(wxEVT_TEXT_ENTER, &MachineInspectorWindow::OnDisasmGo, this);
 	memory_address_input_->Bind(wxEVT_TEXT_ENTER, &MachineInspectorWindow::OnMemoryGo, this);
+	/* The same number in the other address space, so re-read it rather than
+	   leaving the previous space's bytes on screen under the new setting. */
+	memory_physical_checkbox_->Bind(wxEVT_CHECKBOX,
+	    [this](wxCommandEvent &) { RefreshMemoryView(memory_current_address_); });
 	breakpoint_list_->Bind(wxEVT_LISTBOX, &MachineInspectorWindow::OnBreakpointSelection, this);
 	watchpoint_list_->Bind(wxEVT_LISTBOX, &MachineInspectorWindow::OnWatchpointSelection, this);
 	/* Keys on the frame and on the two read-only views, which are where the
@@ -687,11 +698,8 @@ void MachineInspectorWindow::ApplySnapshot(const MachineSnapshot &snapshot)
 
 	/* Something useful in the memory pane on the first snapshot rather than an
 	   empty box: the stack is what a stopped machine is usually asked about. */
-	if (memory_current_address_ == 0 && snapshot.regs[13] != 0) {
-		memory_current_address_ = snapshot.regs[13] & ~0xfu;
-		memory_address_input_->SetValue(wxString::Format("%08X",
-		    memory_current_address_));
-		RefreshMemoryView(memory_current_address_);
+	if (!memory_address_chosen_ && snapshot.regs[13] != 0) {
+		RefreshMemoryView(snapshot.regs[13] & ~0xfu);
 	}
 
 	if (disasm_follow_pc_checkbox_->GetValue()) {
@@ -1094,6 +1102,68 @@ bool MachineInspectorWindow::LogTraceControlsAgainstMachine(const char *when)
 	return agree;
 }
 
+bool MachineInspectorWindow::LogMemoryViewAgainstMachine(const char *when)
+{
+	const MachineSnapshot snapshot = emulator_.TakeSnapshot();
+	bool agree = true;
+
+	/* Somewhere the MMU actually moves, so an untranslated read is visibly
+	   different rather than accidentally right. Virtual 0 is RISC OS's vector
+	   table and is mapped on any booted machine. */
+	const uint32_t probe[] = { 0x00000000u, 0x00008000u, snapshot.regs[13] & ~0xfu };
+
+	for (uint32_t addr : probe) {
+		const MemoryRead virt = emulator_read_memory(addr, 4, false);
+		const MemoryRead phys = emulator_read_memory(addr, 4, true);
+		uint32_t expect = 0;
+		const int expect_ok = mem_debug_read(addr, 4, &expect);
+		uint32_t got = 0;
+
+		for (int i = 0; i < 4; i++) {
+			got |= static_cast<uint32_t>(virt.data[i]) << (i * 8);
+		}
+
+		/* The view's virtual read must be the same thing the debugger's own
+		   translated read gives. If this disagrees the view is reading some
+		   other address space, which is the bug. */
+		const bool matches = expect_ok
+		    ? (virt.mapped[0] != 0 && got == expect)
+		    : (virt.mapped[0] == 0);
+
+		if (!matches) {
+			agree = false;
+		}
+		rpclog("TEST_INSPECTOR: %s: &%08X virtual=%08X(mapped=%d) "
+		       "physical=%02X%02X%02X%02X debugger=%08X(ok=%d)%s\n",
+		       when, addr, got, virt.mapped[0],
+		       phys.data[3], phys.data[2], phys.data[1], phys.data[0],
+		       expect, expect_ok, matches ? "" : "  DISAGREE");
+
+		/* And the two spaces must not be silently the same number, or the
+		   check above proves nothing on this machine. */
+		if (virt.data != phys.data) {
+			rpclog("TEST_INSPECTOR: %s: &%08X translation is visible "
+			       "(virtual and physical differ)\n", when, addr);
+		}
+	}
+
+	/* The zero sentinel: a deliberate 0 must survive the next snapshot rather
+	   than being replaced by R13. */
+	RefreshMemoryView(0);
+	ApplySnapshot(emulator_.TakeSnapshot());
+	if (memory_current_address_ != 0) {
+		agree = false;
+		rpclog("TEST_INSPECTOR: %s: address 0 was replaced by &%08X  DISAGREE\n",
+		       when, memory_current_address_);
+	} else {
+		rpclog("TEST_INSPECTOR: %s: address 0 stayed 0 across a snapshot\n", when);
+	}
+
+	rpclog("TEST_INSPECTOR: %s: memory view %s the machine\n", when,
+	       agree ? "agrees with" : "DISAGREES with");
+	return agree;
+}
+
 void MachineInspectorWindow::ApplyTraceConfig()
 {
 	DebugTraceConfig cfg{};
@@ -1232,6 +1302,7 @@ void MachineInspectorWindow::RefreshDisassembly(uint32_t address)
 void MachineInspectorWindow::RefreshMemoryView(uint32_t address)
 {
 	memory_current_address_ = address;
+	memory_address_chosen_ = true;
 	memory_address_input_->SetValue(wxString::Format("%08X", address));
 
 	int num_bytes = memory_bytes_spin_->GetValue();
@@ -1239,7 +1310,11 @@ void MachineInspectorWindow::RefreshMemoryView(uint32_t address)
 		num_bytes = 16;
 	}
 
-	const std::vector<uint8_t> data = emulator_read_memory(address, static_cast<uint32_t>(num_bytes));
+	const bool physical = memory_physical_checkbox_ != nullptr &&
+	                      memory_physical_checkbox_->GetValue();
+	const MemoryRead read = emulator_read_memory(address,
+	    static_cast<uint32_t>(num_bytes), physical);
+	const std::vector<uint8_t> &data = read.data;
 	if (data.empty()) {
 		memory_view_->SetValue("Failed to read memory");
 		return;
@@ -1252,9 +1327,19 @@ void MachineInspectorWindow::RefreshMemoryView(uint32_t address)
 		wxString ascii_part;
 		for (int i = 0; i < bytes_per_line; i++) {
 			if (offset + static_cast<size_t>(i) < data.size()) {
-				const uint8_t byte = data[offset + static_cast<size_t>(i)];
-				hex_part += wxString::Format("%02X ", byte);
-				ascii_part += (byte >= 32 && byte < 127) ? wxString(static_cast<char>(byte)) : ".";
+				const size_t at = offset + static_cast<size_t>(i);
+				const uint8_t byte = data[at];
+
+				/* An unmapped byte is not a zero. Printing it as 00 is what
+				   made a wrong address look like a page of zeros rather than
+				   like a question the machine cannot answer. */
+				if (at < read.mapped.size() && read.mapped[at] == 0) {
+					hex_part += "-- ";
+					ascii_part += " ";
+				} else {
+					hex_part += wxString::Format("%02X ", byte);
+					ascii_part += (byte >= 32 && byte < 127) ? wxString(static_cast<char>(byte)) : ".";
+				}
 			} else {
 				hex_part += "   ";
 				ascii_part += " ";

--- a/src/gui/machine_inspector_window.h
+++ b/src/gui/machine_inspector_window.h
@@ -52,6 +52,15 @@ public:
 	 */
 	bool LogTraceControlsAgainstMachine(const char *when);
 
+	/**
+	 * Check the memory view reads the address space it claims to (issue #258).
+	 *
+	 * Driven by RPCEMU_TEST_INSPECTOR_AFTER against a booted machine, because
+	 * none of this can be constructed in a unit test: it needs real page tables
+	 * and a real MMU. Returns true when every check agreed.
+	 */
+	bool LogMemoryViewAgainstMachine(const char *when);
+
 	/*
 	 * Driven by RPCEMU_TEST_INSPECTOR_AFTER. Auto-step and the session file are
 	 * both window behaviour - a timer and two file dialogs - so no unit test can
@@ -235,6 +244,7 @@ private:
 
 	wxTextCtrl *memory_address_input_ = nullptr;
 	wxSpinCtrl *memory_bytes_spin_ = nullptr;
+	wxCheckBox *memory_physical_checkbox_ = nullptr;
 
 	wxStaticText *debug_status_label_ = nullptr;
 	wxStaticText *debug_hit_label_ = nullptr;
@@ -280,6 +290,12 @@ private:
 
 	uint32_t disasm_current_address_ = 0;
 	uint32_t memory_current_address_ = 0;
+	/* Whether memory_current_address_ has been chosen, rather than using zero
+	   as the sentinel for "not yet". Zero is a perfectly good address to want
+	   to look at, and using it as the sentinel meant a deliberate 0 was
+	   replaced by R13 on the very next snapshot - the flicker reported in
+	   issue #258. */
+	bool memory_address_chosen_ = false;
 	MachineSnapshot last_snapshot_{};
 
 	wxDECLARE_EVENT_TABLE();

--- a/src/gui/main_frame.cpp
+++ b/src/gui/main_frame.cpp
@@ -1872,6 +1872,10 @@ void MainFrame::OnTestInspectorTimer(wxTimerEvent &event)
 	case 4:
 		if (machine_inspector_window_ != nullptr) {
 			machine_inspector_window_->LogTraceControlsAgainstMachine("reopened");
+			/* Issue #258: the memory view read physical addresses while every
+			   other address in the window meant a virtual one. Needs a booted
+			   machine, because it needs real page tables. */
+			machine_inspector_window_->LogMemoryViewAgainstMachine("reopened");
 		} else {
 			rpclog("TEST_INSPECTOR: no inspector window on reopen\n");
 		}


### PR DESCRIPTION
Backport of #259 to the 1.x line. #258 was reported against v1.1.19, so this is the line the reporter is actually running.

Cherry-picked cleanly and needed no changes. See #259 for the full write-up.

Verified the same way, on a booted RISC OS 5.31 machine through the `RPCEMU_TEST_INSPECTOR_AFTER` hook, with results identical to `main`:

```
&00000000 virtual=E59FF488(mapped=1) physical=E59FF038 debugger=E59FF488(ok=1)
&00000000 translation is visible (virtual and physical differ)
&00008000 virtual=00000000(mapped=0) physical=6D49534F debugger=00000000(ok=0)
address 0 stayed 0 across a snapshot
memory view agrees with the machine
```

57/57 tests pass, no new warnings.